### PR TITLE
Set app name

### DIFF
--- a/DBADash/DBADash.csproj
+++ b/DBADash/DBADash.csproj
@@ -98,7 +98,7 @@
     <PackageReference Include="Microsoft.SqlServer.Assessment" Version="1.1.0" />
     <PackageReference Include="Microsoft.SqlServer.Assessment.Authoring" Version="1.1.0" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5400.1" />
-    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.21292.55" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.22504.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46521.71" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/DBADash/DBADashConnection.cs
+++ b/DBADash/DBADashConnection.cs
@@ -56,6 +56,13 @@ namespace DBADash
 
         private void setConnectionString(string value)
         {
+            if (getConnectionType(value) == ConnectionType.SQL){
+                var builder = new SqlConnectionStringBuilder(value)
+                {
+                    ApplicationName = "DBADash"
+                };
+                value = builder.ToString();
+            }
             encryptedConnectionString = getConnectionStringWithEncryptedPassword(value);
             connectionString = getDecryptedConnectionString(value);
             connectionType = getConnectionType(value);

--- a/DBADashService/DBADashService.csproj
+++ b/DBADashService/DBADashService.csproj
@@ -65,7 +65,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.1" />
     <PackageReference Include="Microsoft.SqlServer.Assessment" Version="1.1.0" />
     <PackageReference Include="Microsoft.SqlServer.Assessment.Authoring" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.21292.55" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.22504.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46521.71" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />

--- a/DBADashServiceConfig/ServiceConfigTool.csproj
+++ b/DBADashServiceConfig/ServiceConfigTool.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.1" />
     <PackageReference Include="Microsoft.SqlServer.Assessment" Version="1.1.0" />
     <PackageReference Include="Microsoft.SqlServer.Assessment.Authoring" Version="1.1.0" />
-    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.21292.55" />
+    <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="160.22504.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="161.46521.71" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Quartz" Version="3.3.3" />


### PR DESCRIPTION
App should identify itself properly instead of 'Core Microsoft SqlClient Data Provider'. The GUI is setting the app name but not the service.
nuget update for SqlParser
#39 