### PR TITLE
Fix issue with 6.0.2 SDK update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 6.0.101
           include-prerelease: true
 
       - name: Build

--- a/.github/workflows/tag-create-release.yml
+++ b/.github/workflows/tag-create-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 6.0.101
           include-prerelease: true
 
       - name: Build

--- a/Global.json
+++ b/Global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.101",
+    "rollForward": "disable"
+  }
+}


### PR DESCRIPTION
Use Global.json to prevent upgrade to 6.0.2 until a better solution is found.  Edit workflows to specify version.
https://github.com/dotnet/winforms/issues/6663

#42 