### PR TITLE
Express edition fix

### DIFF
--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -435,6 +435,11 @@ namespace DBADash
                 // Don't need to collect these types for Azure MI
                 return false;
             }
+            else if((new CollectionType[] { CollectionType.JobHistory, CollectionType.AgentJobs, CollectionType.Jobs }).Contains(collectionType)  && engineEdition == DatabaseEngineEdition.Express)
+            {
+                // SQL Agent not supported on express
+                return false;
+            }
             else
             {
                 return true;

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -816,8 +816,15 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
                 if (currentJobModified > JobLastModified)
                 {
                     var ss = new SchemaSnapshotDB(_connectionString, new SchemaSnapshotDBOptions());
-                    ss.SnapshotJobs(ref Data);
-                    JobLastModified = currentJobModified;
+                    try
+                    {
+                        ss.SnapshotJobs(ref Data);
+                        JobLastModified = currentJobModified;
+                    }
+                    catch (Microsoft.SqlServer.Management.Smo.UnsupportedFeatureException ex)
+                    {
+                        Log.Warning("SnapshotJobs not supported: {0}. From {1}", ex.Message, Source.SourceConnection.ConnectionForPrint);
+                    }
                 }
             }
             else if (collectionType == CollectionType.ResourceGovernorConfiguration)

--- a/DBADash/SQL/SQLServerExtraProperties.sql
+++ b/DBADash/SQL/SQLServerExtraProperties.sql
@@ -48,9 +48,12 @@ END
 
 IF COL_LENGTH('sys.dm_server_services','instant_file_initialization_enabled') IS NOT NULL
 BEGIN
-	SELECT @InstantFileInitializationEnabled=CASE WHEN instant_file_initialization_enabled='Y' THEN 1 ELSE 0 END
+	DECLARE @SQL NVARCHAR(MAX)
+	SET @SQL = N'
+	SELECT @InstantFileInitializationEnabled=CASE WHEN instant_file_initialization_enabled=''Y'' THEN 1 ELSE 0 END
 	FROM   sys.dm_server_services dss
-	WHERE  dss.[servicename] LIKE N'SQL Server (%';
+	WHERE  dss.[servicename] LIKE N''SQL Server (%'';';
+	EXEC sp_executesql @SQL,N'@InstantFileInitializationEnabled BIT OUT',@InstantFileInitializationEnabled OUT
 END
 
 SELECT @IsAgentRunning = CASE WHEN EXISTS(SELECT * 

--- a/DBADashDB/dbo/Stored Procedures/Summary_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/Summary_Get.sql
@@ -228,7 +228,7 @@ SELECT I.InstanceID,
 		WHEN DATEDIFF(hh,a.LastAlert,GETUTCDATE())<72 THEN 2
 		ELSE 4 END AS AlertStatus,
 	AlertCD.SnapshotDate AS AlertSnapshotDate,
-	I.IsAgentRunning,
+	CASE WHEN I.EngineEdition = 4 THEN NULL ELSE I.IsAgentRunning END AS IsAgentRunning,
 	ISNULL(cus.Status,3) AS CustomCheckStatus,
 	ISNULL(dbm.MirroringStatus,3) AS MirroringStatus,
 	3 AS ElasticPoolStorageStatus,

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.13.1")]
+[assembly: AssemblyVersion("2.13.2")]


### PR DESCRIPTION
Remove SQL Agent from the collection for Express edition
Better error handling if SQL Agent isn't supported (Just warn and continue instead of error/retry).  
Improve reporting for Agent not running as this doesn't apply to Express
Fix issue identified for ServerExtraProperties collection
#74