### PR TITLE
Remove execute as owner

### DIFF
--- a/DBADashDB/Report/Stored Procedures/ProcStats.sql
+++ b/DBADashDB/Report/Stored Procedures/ProcStats.sql
@@ -1,4 +1,4 @@
-﻿CREATE  PROC [Report].[ProcStats](
+﻿CREATE  PROC Report.ProcStats(
 	@Instance SYSNAME=NULL,
 	@DatabaseID INT=NULL,
 	@Proc SYSNAME=NULL,
@@ -10,7 +10,6 @@
 	@UTCOffset INT=0,
 	@InstanceID INT=NULL
 )
-WITH EXECUTE AS OWNER
 AS
 SELECT @FromDate= DATEADD(mi, -@UTCOffset, @FromDate),
 	@ToDate = DATEADD(mi, -@UTCOffset, @ToDate) 
@@ -74,11 +73,11 @@ ORDER BY DatabaseName, object_name'
 PRINT @SQL
 IF @SQL IS NOT NULL
 BEGIN
-EXEC sp_executesql @SQL,N'@Instance SYSNAME,@DatabaseID INT,@FromDate DATETIME,@ToDate DATETIME,@Proc SYSNAME,@UTCOffset INT,@InstanceID INT',
-	@Instance,@DatabaseID,@FromDate,@ToDate,@Proc,@UTCOffset,@InstanceID
+	EXEC sp_executesql @SQL,N'@Instance SYSNAME,@DatabaseID INT,@FromDate DATETIME,@ToDate DATETIME,@Proc SYSNAME,@UTCOffset INT,@InstanceID INT',
+		@Instance,@DatabaseID,@FromDate,@ToDate,@Proc,@UTCOffset,@InstanceID
 END 
 ELSE
 BEGIN
-DECLARE  @results TABLE( [SnapshotDate] DATETIME, [DatabaseName] NVARCHAR(128),[DatabaseID] INT, [object_name] NVARCHAR(128), [TotalCPU] DECIMAL(29,9), [AvgCPU] DECIMAL(29,9), [ExecutionCount] BIGINT, [ExecutionsPerMin] DECIMAL(38,9), [TotalDuration] DECIMAL(29,9), [AvgDuration] DECIMAL(29,9), [TotalLogicalReads] BIGINT, [AvgLogicalReads] BIGINT, [TotalPhysicalReads] BIGINT, [AvgPhysicalReads] BIGINT, [TotalWrites] BIGINT, [AvgWrites] BIGINT, [Measure] DECIMAL(29,9), [ProcRank] BIGINT )
-SELECT * FROM @results
+	DECLARE  @results TABLE( [SnapshotDate] DATETIME, [DatabaseName] NVARCHAR(128),[DatabaseID] INT, [object_name] NVARCHAR(128), [TotalCPU] DECIMAL(29,9), [AvgCPU] DECIMAL(29,9), [ExecutionCount] BIGINT, [ExecutionsPerMin] DECIMAL(38,9), [TotalDuration] DECIMAL(29,9), [AvgDuration] DECIMAL(29,9), [TotalLogicalReads] BIGINT, [AvgLogicalReads] BIGINT, [TotalPhysicalReads] BIGINT, [AvgPhysicalReads] BIGINT, [TotalWrites] BIGINT, [AvgWrites] BIGINT, [Measure] DECIMAL(29,9), [ProcRank] BIGINT )
+	SELECT * FROM @results
 END

--- a/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
@@ -1,4 +1,4 @@
-﻿CREATE  PROC [dbo].[ObjectExecutionStats_Get](
+﻿CREATE  PROC dbo.ObjectExecutionStats_Get(
 	@Instance SYSNAME=NULL,
 	@DatabaseID INT=NULL,
 	@ObjectName SYSNAME=NULL,
@@ -11,7 +11,6 @@
 	@ObjectID BIGINT=NULL,
 	@DateGroupingMin INT=NULL
 )
-WITH EXECUTE AS OWNER
 AS
 IF @FromDateUTC IS NULL
 	SET @FromDateUTC = CONVERT(DATETIME,STUFF(CONVERT(VARCHAR,DATEADD(mi,-120,GETUTCDATE()),120),16,4,'0:00'),120) 
@@ -75,11 +74,11 @@ ORDER BY TotalMeasure DESC,ObjectID'
 PRINT @SQL
 IF @SQL IS NOT NULL
 BEGIN
-EXEC sp_executesql @SQL,N'@Instance SYSNAME,@DatabaseID INT,@FromDate DATETIME,@ToDate DATETIME,@ObjectName SYSNAME,@SchemaName SYSNAME,@UTCOffset INT,@InstanceID INT,@ObjectID BIGINT,@DateGroupingMin INT',
-	@Instance,@DatabaseID,@FromDateUTC,@ToDateUTC,@ObjectName,@SchemaName,@UTCOffset,@InstanceID,@ObjectID,@DateGroupingMin
+	EXEC sp_executesql @SQL,N'@Instance SYSNAME,@DatabaseID INT,@FromDate DATETIME,@ToDate DATETIME,@ObjectName SYSNAME,@SchemaName SYSNAME,@UTCOffset INT,@InstanceID INT,@ObjectID BIGINT,@DateGroupingMin INT',
+		@Instance,@DatabaseID,@FromDateUTC,@ToDateUTC,@ObjectName,@SchemaName,@UTCOffset,@InstanceID,@ObjectID,@DateGroupingMin
 END 
 ELSE
 BEGIN
-DECLARE  @results TABLE( [SnapshotDate] DATETIME, [DatabaseName] NVARCHAR(128),[DatabaseID] INT, [object_name] NVARCHAR(128), [TotalCPU] DECIMAL(29,9), [AvgCPU] DECIMAL(29,9), [ExecutionCount] BIGINT, [ExecutionsPerMin] DECIMAL(38,9), [TotalDuration] DECIMAL(29,9), [AvgDuration] DECIMAL(29,9), [TotalLogicalReads] BIGINT, [AvgLogicalReads] BIGINT, [TotalPhysicalReads] BIGINT, [AvgPhysicalReads] BIGINT, [TotalWrites] BIGINT, [AvgWrites] BIGINT, [Measure] DECIMAL(29,9), [ProcRank] BIGINT )
-SELECT * FROM @results
+	DECLARE  @results TABLE( [SnapshotDate] DATETIME, [DatabaseName] NVARCHAR(128),[DatabaseID] INT, [object_name] NVARCHAR(128), [TotalCPU] DECIMAL(29,9), [AvgCPU] DECIMAL(29,9), [ExecutionCount] BIGINT, [ExecutionsPerMin] DECIMAL(38,9), [TotalDuration] DECIMAL(29,9), [AvgDuration] DECIMAL(29,9), [TotalLogicalReads] BIGINT, [AvgLogicalReads] BIGINT, [TotalPhysicalReads] BIGINT, [AvgPhysicalReads] BIGINT, [TotalWrites] BIGINT, [AvgWrites] BIGINT, [Measure] DECIMAL(29,9), [ProcRank] BIGINT )
+	SELECT * FROM @results
 END


### PR DESCRIPTION
Remove WITH EXECUTE AS OWNER.  This isn't required and it might cause issues if the DB owner account is deleted. #78