### PR TITLE
Improve copy data

### DIFF
--- a/DBADashGUI/Common.cs
+++ b/DBADashGUI/Common.cs
@@ -177,6 +177,8 @@ namespace DBADashGUI
             obj.SetData(DataFormats.Html, new MemoryStream(
               enc.GetBytes(html_total)));
 
+            obj.SetData(DataFormats.Text, html);
+            
             Clipboard.SetDataObject(obj, true);
         }
 


### PR DESCRIPTION
Copy data as text in addition to HTML to allow pasting into programs like notepad.  Otherwise it can appear that the copy button doesn't work if the app you are pasting into doesn't support pasting HTML content. #94