### PR TITLE
Fix language issue with date format

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/AzureDBResourceStats_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/AzureDBResourceStats_Upd.sql
@@ -191,7 +191,7 @@ BEGIN
 	WHERE RS.InstanceID=@InstanceID
 	AND RS.end_time>=@60MINFrom
 	GROUP BY RS.InstanceID,DG.DateGroup
-	OPTION(OPTIMIZE FOR(@60MINFrom='9999-12-31'))
+	OPTION(OPTIMIZE FOR(@60MINFrom='99991231'))
 END;
 
 WITH t AS (
@@ -210,7 +210,7 @@ SELECT t.InstanceID,
        t.dtu_limit_previous
 FROM T 
 WHERE t.dtu_limit<> t.dtu_limit_previous
-OPTION(OPTIMIZE FOR(@MaxDate='9999-12-31'))
+OPTION(OPTIMIZE FOR(@MaxDate='99991231'))
 
 COMMIT
 

--- a/DBADashDB/dbo/Stored Procedures/Waits_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/Waits_Upd.sql
@@ -92,7 +92,7 @@ AND SnapshotDate >= @MaxDate
 GROUP BY InstanceID,
 	CONVERT(DATETIME,SUBSTRING(CONVERT(VARCHAR,SnapshotDate,120),0,14) + ':00',120),
 	WaitTypeID
- OPTION(OPTIMIZE FOR(@MaxDate='9999-12-31'))
+ OPTION(OPTIMIZE FOR(@MaxDate='99991231'))
 COMMIT
 /* **************** */
 


### PR DESCRIPTION
Switch from yyyy-MM-dd to yyyyMMdd which is safe to use across languages. #104