### PR TITLE
Fix schema snapshots for SQL 2005

### DIFF
--- a/DBADash/SchemaSnapshotDB.cs
+++ b/DBADash/SchemaSnapshotDB.cs
@@ -462,7 +462,7 @@ namespace DBADash
                             op.Complete();
                         }
                     }
-                    if (options.ObjectTypes.Contains(SchemaSnapshotDBObjectTypes.UserDefinedTableType))
+                    if (options.ObjectTypes.Contains(SchemaSnapshotDBObjectTypes.UserDefinedTableType) && instance.VersionMajor>=10) // Support for User Defined Table Types added in SQL 2008
                     {
                         using (var op = Operation.Begin("Schema snapshot {DBame}: {Object}", DBName, "UserDefinedTableTypes"))
                         {
@@ -649,20 +649,23 @@ namespace DBADash
                 r["ObjectDateModified"] = "1900-01-01";
                 dtSchema.Rows.Add(r);
             }
-            foreach (BrokerPriority p in db.ServiceBroker.Priorities)
+            if (db.Parent.VersionMajor >= 10) // Broker priorities supported on SQL 2008 
             {
-                var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(p.Script(ScriptingOptions));
-                var bDDL = Zip(sDDL);
-                r["ObjectName"] = p.Name;
-                r["SchemaName"] = "";
-                r["ObjectType"] = "SBP";
-                r["object_id"] = p.ID;
-                r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
-                r["ObjectDateCreated"] = "1900-01-01";
-                r["ObjectDateModified"] = "1900-01-01";
-                dtSchema.Rows.Add(r);
+                foreach (BrokerPriority p in db.ServiceBroker.Priorities)
+                {
+                    var r = dtSchema.NewRow();
+                    var sDDL = stringCollectionToString(p.Script(ScriptingOptions));
+                    var bDDL = Zip(sDDL);
+                    r["ObjectName"] = p.Name;
+                    r["SchemaName"] = "";
+                    r["ObjectType"] = "SBP";
+                    r["object_id"] = p.ID;
+                    r["DDL"] = bDDL;
+                    r["DDLHash"] = computeHash(bDDL);
+                    r["ObjectDateCreated"] = "1900-01-01";
+                    r["ObjectDateModified"] = "1900-01-01";
+                    dtSchema.Rows.Add(r);
+                }
             }
         }
 


### PR DESCRIPTION
Disable collection of broker priorities and user defined table types on SQL 2005.  These features were added in 2008 and an error will be thrown if trying to collect on 2005.  #108