### PR TITLE
Fix intermittent PRIMARY KEY constraint error on Drive collection

### DIFF
--- a/DBADash/SQL/SQLDrives.sql
+++ b/DBADash/SQL/SQLDrives.sql
@@ -4,19 +4,23 @@ BEGIN
 END
 ELSE IF  SERVERPROPERTY('EngineEdition') = 8
 BEGIN
-	SELECT DISTINCT dovs.volume_mount_point AS Name,
-		dovs.total_bytes + dovs.available_bytes as Capacity, /* Total Bytes = Used for Azure MI */
-		dovs.available_bytes as FreeSpace,
-		dovs.logical_volume_name as Label
+	SELECT  dovs.volume_mount_point AS Name,
+			AVG(dovs.total_bytes + dovs.available_bytes) as Capacity, /* Total Bytes = Used for Azure MI */
+			AVG(dovs.available_bytes) as FreeSpace,
+			dovs.logical_volume_name as Label
 	FROM sys.master_files mf
-	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.FILE_ID) dovs
+	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+	GROUP BY dovs.volume_mount_point,
+			 dovs.logical_volume_name;
 END
 ELSE
 BEGIN
-	SELECT DISTINCT dovs.volume_mount_point AS Name,
-		dovs.total_bytes as Capacity,
-		dovs.available_bytes as FreeSpace,
-		dovs.logical_volume_name as Label
+	SELECT  dovs.volume_mount_point AS Name,
+			AVG(dovs.total_bytes) as Capacity,
+			AVG(dovs.available_bytes) as FreeSpace,
+			dovs.logical_volume_name as Label
 	FROM sys.master_files mf
-	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.FILE_ID) dovs
+	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
+	GROUP BY dovs.volume_mount_point,
+			 dovs.logical_volume_name;
 END


### PR DESCRIPTION
Use GROUP BY instead of DISTINCT to remove the possibility of duplicates.  Affects collection where WMI is disabled. #140