### PR TITLE
Add dependabot.yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly


### PR DESCRIPTION
This helps keep the GitHub Actions versions up-to-date. (a few of them in this repo are currently on older versions).

REF: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot