### PR TITLE
Include mount points in drive collection via WMI

### DIFF
--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -1385,7 +1385,10 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
                     ManagementScope scope = new ManagementScope(path);
                     //string condition = "DriveLetter = 'C:'";
                     string[] selectedProperties = new string[] { "FreeSpace", "Name", "Capacity", "Caption", "Label" };
-                    SelectQuery query = new SelectQuery("Win32_Volume", "DriveType=3 AND DriveLetter IS NOT NULL", selectedProperties);
+                    // Using @ to avoid doubling up the backslashes for C#.  The doubling up is for WQL which also uses backslashes as an escape character.
+                    // Drive Type 3 = Local Disk.  Not like \\?\ excludes system voume and recovery partition
+                    string condition = @"DriveType=3 AND NOT Name LIKE '\\\\?\\%'"; 
+                    SelectQuery query = new SelectQuery("Win32_Volume", condition, selectedProperties);
 
                     using (ManagementObjectSearcher searcher = new ManagementObjectSearcher(scope, query))
                     using (ManagementObjectCollection results = searcher.Get())


### PR DESCRIPTION
Drive collection via WMI didn't include mount points as there was a filter included in the query to include volumes with a drive letter only.  Removed the DriveLetter IS NOT NULL filter and replaced with a filter on Name to exclude system and recovery partitions. #142