### PR TITLE
JobHistory - Exclude In progress

### DIFF
--- a/DBADash/SQL/SQLJobHistory.sql
+++ b/DBADash/SQL/SQLJobHistory.sql
@@ -15,5 +15,6 @@
 		retries_attempted,
 		server
 FROM msdb.dbo.sysjobhistory
-WHERE instance_id> @instance_id
+WHERE instance_id> @instance_id -- Get history since last run
 AND run_date > @run_date
+AND run_status <> 4 -- Exclude 4 In Progress


### PR DESCRIPTION
Exclude run_status 4 (in progress) from job history collection.  These rows can be produced by CDC.  It's incorrect to sum the durations for in progress rows and doing so can result in an overflow exception. Removing these from the collection will fix the issue and reduce the amount of data to collect/store for job history.  #147