### PR TITLE
Fix summary page drill downs for instances with aliases

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/CollectionErrorLog_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/CollectionErrorLog_Get.sql
@@ -1,7 +1,7 @@
 ﻿CREATE PROC dbo.CollectionErrorLog_Get(
 	@InstanceID INT=NULL,
 	@Days INT=7,
-	@Instance NVARCHAR(128)=NULL
+	@InstanceGroupName NVARCHAR(128)=NULL
 )
 AS
 SELECT I.Instance,
@@ -14,6 +14,6 @@ SELECT I.Instance,
 FROM dbo.CollectionErrorLog E
 LEFT JOIN dbo.Instances I ON I.InstanceID = E.InstanceID
 WHERE (I.InstanceID = @InstanceID OR @InstanceID IS NULL)
-AND (I.Instance = @Instance OR @Instance IS NULL)
+AND (I.InstanceGroupName = @InstanceGroupName OR @InstanceGroupName IS NULL)
 AND E.ErrorDate>=DATEADD(d,-@Days,GETUTCDATE())
 ORDER BY E.ErrorDate DESC

--- a/DBADashDB/dbo/Stored Procedures/Summary_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/Summary_Get.sql
@@ -172,7 +172,7 @@ QS AS (
 )
 SELECT I.InstanceID,
 	I.Instance,
-	I.InstanceDisplayName,
+	I.InstanceGroupName,
 	ISNULL(LS.LogShippingStatus,3) AS LogShippingStatus,
 	ISNULL(B.FullBackupStatus,3) AS FullBackupStatus,
 	ISNULL(B.LogBackupStatus,3) AS LogBackupStatus,
@@ -266,7 +266,7 @@ AND I.EngineEdition<> 5 -- not azure
 UNION ALL
 SELECT NULL AS InstanceID,
 	I.Instance,
-	I.Instance AS InstanceDisplayName,
+	I.InstanceGroupName,
 	3 AS LogShippingStatus,
 	3 AS FullBackupStatus,
 	3 AS LogBackupStatus,
@@ -326,4 +326,4 @@ LEFT JOIN QS ON QS.InstanceID = I.InstanceID
 WHERE I.EngineEdition=5 -- azure
 AND EXISTS(SELECT 1 FROM #Instances t WHERE I.InstanceID = t.InstanceID)
 AND I.IsActive=1
-GROUP BY I.Instance
+GROUP BY I.Instance,I.InstanceGroupName

--- a/DBADashGUI/Checks/Summary.Designer.cs
+++ b/DBADashGUI/Checks/Summary.Designer.cs
@@ -416,7 +416,7 @@
             // 
             // Instance
             // 
-            this.Instance.DataPropertyName = "InstanceDisplayName";
+            this.Instance.DataPropertyName = "InstanceGroupName";
             this.Instance.HeaderText = "Instance";
             this.Instance.MinimumWidth = 6;
             this.Instance.Name = "Instance";

--- a/DBADashGUI/Checks/Summary.cs
+++ b/DBADashGUI/Checks/Summary.cs
@@ -431,11 +431,11 @@ namespace DBADashGUI
                 }
                 else if (e.ColumnIndex == FileFreeSpaceStatus.Index || e.ColumnIndex == PctMaxSizeStatus.Index || e.ColumnIndex == LogFreeSpaceStatus.Index)
                 {
-                     Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["Instance"], Tab = "tabFiles" });
+                     Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = "tabFiles" });
                 }
                 else if (e.ColumnIndex == CustomCheckStatus.Index)
                 {
-                       Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["Instance"], Tab = "tabCustomChecks" });
+                       Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = "tabCustomChecks" });
                 }
                 else if (e.ColumnIndex ==  CollectionErrorStatus.Index)
                 {
@@ -445,12 +445,12 @@ namespace DBADashGUI
                     }
                     else
                     {
-                        Instance_Selected(this, new InstanceSelectedEventArgs() { InstanceID=-1, Instance = (string)row["Instance"], Tab = "tabDBADashErrorLog" });
+                        Instance_Selected(this, new InstanceSelectedEventArgs() { InstanceID=-1, Instance = (string)row["InstanceGroupName"], Tab = "tabDBADashErrorLog" });
                     }
                 }
                 else if (e.ColumnIndex == SnapshotAgeStatus.Index)
                 {
-                    Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["Instance"], Tab = "tabCollectionDates" });                   
+                    Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = "tabCollectionDates" });                   
                 }
                 else if (e.ColumnIndex == AlertStatus.Index)
                 {
@@ -461,15 +461,15 @@ namespace DBADashGUI
                 }
                 else if(e.ColumnIndex == ElasticPoolStorageStatus.Index)
                 {
-                    Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["Instance"], Tab = "tabAzureSummary" });
+                    Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = "tabAzureSummary" });
                 }
                 else if(e.ColumnIndex== AGStatus.Index)
                 {
-                    Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["Instance"], Tab = "tabAG" });
+                    Instance_Selected(this, new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = "tabAG" });
                 }
                 else if ( e.ColumnIndex == QueryStoreStatus.Index)
                 {
-                    Instance_Selected(this,new InstanceSelectedEventArgs() { Instance = (string)row["Instance"], Tab = "tabQS" });
+                    Instance_Selected(this,new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = "tabQS" });
                 }
                 else if (e.ColumnIndex== UptimeStatus.Index)
                 {

--- a/DBADashGUI/CollectionDates/CollectionErrors.cs
+++ b/DBADashGUI/CollectionDates/CollectionErrors.cs
@@ -19,7 +19,7 @@ namespace DBADashGUI.CollectionDates
         }
 
         public Int32 InstanceID { get; set; }
-        public string InstanceName { get; set; }
+        public string InstanceGroupName { get; set; }
         private int _days;
         public Int32 Days
         {
@@ -52,28 +52,26 @@ namespace DBADashGUI.CollectionDates
         public void RefreshData()
         {
             using (var cn = new SqlConnection(Common.ConnectionString))
+            using (var cmd = new SqlCommand("dbo.CollectionErrorLog_Get", cn) { CommandType = CommandType.StoredProcedure })
+            using (var da = new SqlDataAdapter(cmd))
             {
-                using (SqlCommand cmd = new SqlCommand("dbo.CollectionErrorLog_Get", cn) { CommandType = CommandType.StoredProcedure })
-                {
                     if (InstanceID > 0)
                     {
                         cmd.Parameters.AddWithValue("InstanceID", InstanceID);
                     }
-                    if (InstanceName != "")
+                    if (!String.IsNullOrEmpty(InstanceGroupName))
                     {
-                        cmd.Parameters.AddWithValue("Instance", InstanceName);
+                        cmd.Parameters.AddWithValue("InstanceGroupName", InstanceGroupName);
                     }
                     cmd.Parameters.AddWithValue("Days", Days);
-                    SqlDataAdapter da = new SqlDataAdapter(cmd);
                     DataTable dt = new DataTable();
                     da.Fill(dt);
                     Common.ConvertUTCToLocal(ref dt);
                     dgvDBADashErrors.AutoGenerateColumns = false;
                     dgvDBADashErrors.DataSource = dt;
                     dgvDBADashErrors.AutoResizeColumns(DataGridViewAutoSizeColumnsMode.DisplayedCells);
-                }
+                
             }
-
         }
 
         private void tsErrorDays_Click(object sender, EventArgs e)

--- a/DBADashGUI/Main.Designer.cs
+++ b/DBADashGUI/Main.Designer.cs
@@ -1157,7 +1157,7 @@
             this.collectionErrors1.Days = 0;
             this.collectionErrors1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.collectionErrors1.InstanceID = 0;
-            this.collectionErrors1.InstanceName = null;
+            this.collectionErrors1.InstanceGroupName = null;
             this.collectionErrors1.Location = new System.Drawing.Point(3, 3);
             this.collectionErrors1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.collectionErrors1.Name = "collectionErrors1";

--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -318,7 +318,7 @@ namespace DBADashGUI
             else if(tabs.SelectedTab== tabDBADashErrorLog)
             {
                 collectionErrors1.InstanceID = n.InstanceID;
-                collectionErrors1.InstanceName = n.InstanceName;
+                collectionErrors1.InstanceGroupName = n.InstanceName;
                 collectionErrors1.Days = 1;
                 collectionErrors1.AckErrors =  SelectedTags().Count == 0 && parent.Type == SQLTreeItem.TreeType.DBADashRoot;
                 collectionErrors1.RefreshData();


### PR DESCRIPTION
Some drill downs that rely on the instance name are broken if you configure a display name for the instance.  #152