### PR TITLE
Fix issue where Instance name isn't shown for custom check history

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/CustomChecksHistory_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/CustomChecksHistory_Get.sql
@@ -15,6 +15,7 @@ DECLARE @SQL NVARCHAR(MAX)
 SET @SQL =
 'SELECT CCH.InstanceID,
 	   I.ConnectionID,
+	   I.InstanceDisplayName,
        CCH.Test,
        CCH.Context,
        CCH.Status,


### PR DESCRIPTION
Add InstanceDisplayName column to CustomChecksHistory_Get SP.  The instance name is shown in the grid with this change. #154