### PR TITLE
Object Execution Stats Fix

### DIFF
--- a/DBADash/SQL/SQLObjectExecutionStats.sql
+++ b/DBADash/SQL/SQLObjectExecutionStats.sql
@@ -6,7 +6,7 @@ BEGIN
 	SET @SQL = N'
 			SELECT object_id,
 				   database_id,
-				   ISNULL(OBJECT_NAME(object_id, database_id),'''') object_name,
+				   ISNULL(OBJECT_NAME(object_id, database_id),''{object_id:'' + CAST(object_id AS SYSNAME) + ''}'') object_name,
 				   total_worker_time,
 				   total_elapsed_time,
 				   total_logical_reads,
@@ -26,7 +26,7 @@ BEGIN
 	SET @SQL = @SQL + 'UNION ALL
 		SELECT object_id,
 		   database_id,
-		   ISNULL(OBJECT_NAME(object_id, database_id),'''') object_name,
+		   ISNULL(OBJECT_NAME(object_id, database_id),''{object_id:'' + CAST(object_id AS SYSNAME) + ''}'') object_name,
 		   total_worker_time,
 		   total_elapsed_time,
 		   total_logical_reads,
@@ -46,7 +46,7 @@ BEGIN
 	SET @SQL = @SQL + 'UNION ALL
 		SELECT object_id,
 		   database_id,
-		   ISNULL(OBJECT_NAME(object_id, database_id),'''') object_name,
+		   ISNULL(OBJECT_NAME(object_id, database_id),''{object_id:'' + CAST(object_id AS SYSNAME) + ''}'') object_name,
 		   total_worker_time,
 		   total_elapsed_time,
 		   total_logical_reads,
@@ -61,5 +61,5 @@ BEGIN
 	WHERE database_id ' + CASE WHEN @IsAzure=1 THEN '= DB_ID()' ELSE '<> 32767' END + '
 	'
 END
-PRINT @SQL
+
 EXEC sp_executesql @SQL

--- a/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
@@ -70,7 +70,7 @@ WITH agg AS (
 SELECT T.*
 FROM T
 WHERE ProcRank <=20
-ORDER BY TotalMeasure DESC,ObjectID'
+ORDER BY DatabaseName,object_name,SnapshotDate'
 PRINT @SQL
 IF @SQL IS NOT NULL
 BEGIN

--- a/DBADashGUI/Performance/ObjectExecution.cs
+++ b/DBADashGUI/Performance/ObjectExecution.cs
@@ -97,17 +97,17 @@ namespace DBADashGUI.Performance
             ChartValues<DateTimePoint> values = new ChartValues<DateTimePoint>();
             foreach (DataRow r in dt.Rows)
             {
-                var waitType = (string)r["DatabaseName"] + " | " + (string)r["object_name"];
+                var objectName = (string)r["DatabaseName"] + " | " + (string)r["object_name"];
                 var time = (DateTime)r["SnapshotDate"];
                 if (time > chartMaxDate)
                 {
                     chartMaxDate = time;
                 }
-                if (current != waitType)
+                if (current != objectName)
                 {
                     if (values.Count > 0) { dPoints.Add(current, values); }
                     values = new ChartValues<DateTimePoint>();
-                    current = waitType;
+                    current = objectName;
                 }
                 values.Add(new DateTimePoint(((DateTime)r["SnapshotDate"]), Convert.ToDouble(r["Measure"])));
             }


### PR DESCRIPTION
Fix 'An item with the same key has already been added' error in the object execution chart.  This occurs when the service account doesn't have permission to collect the object name - resulting in objects with the same blank string as the name.
Replaced blank string with the object_id.
Changed sort order to further reduce the change of the error occurring.
Refactoring variable name. #158