### PR TITLE
Fix 'Invalid group by' bug on Slow Queries tab

### DIFF
--- a/DBADashGUI/Performance/SlowQueries.cs
+++ b/DBADashGUI/Performance/SlowQueries.cs
@@ -240,12 +240,12 @@ namespace DBADashGUI
                     }
                     else
                     {
-                        throw new Exception("Invalid group by");
+                        throw new Exception($"Invalid group by: {groupBy}");
                     }
 
                     if (txtInstance.Text.Length == 0 && _db.Length==0)
                     {
-                        groupBy = "ConnectionID";
+                        groupBy = "InstanceDisplayName";
                     }
                     else if (txtDatabase.Text.Length == 0 && _db.Length==0)
                     {
@@ -461,7 +461,7 @@ namespace DBADashGUI
                 }
                 else
                 {
-                    throw new Exception("Invalid group by");
+                    throw new Exception($"Invalid group by: {groupBy}");
                 }
 
                 if (client.Length > 0)

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.16.1")]
+[assembly: AssemblyVersion("2.16.2")]


### PR DESCRIPTION
Fix 'Invalid group by' bug. Group by should be InstanceDisplayName instead of ConnectionID. #211