### PR TITLE
Add option to configure max_memory for target

### DIFF
--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -358,18 +358,10 @@ namespace DBADash
                 while (rdr.Read())
                 {
                     builder.InitialCatalog = rdr.GetString(0);
-                    DBADashSource dbCn = new DBADashSource(builder.ConnectionString)
-                    {
-                        CollectionSchedules = masterConnection.CollectionSchedules,
-                        SlowQueryThresholdMs = masterConnection.SlowQueryThresholdMs,
-                        SlowQuerySessionMaxMemoryKB = masterConnection.SlowQuerySessionMaxMemoryKB,
-                        UseDualEventSession = masterConnection.UseDualEventSession,
-                        RunningQueryPlanThreshold = masterConnection.RunningQueryPlanThreshold
-                    };
-                    if (masterConnection.SchemaSnapshotDBs == "*")
-                    {
-                        dbCn.SchemaSnapshotDBs = masterConnection.SchemaSnapshotDBs;
-                    }
+                    DBADashSource dbCn = masterConnection.DeepCopy();
+                    dbCn.SourceConnection.ConnectionString = builder.ConnectionString;
+                    dbCn.ConnectionID = string.Empty;
+
                     if (!SourceExists(dbCn.SourceConnection.ConnectionString,true))
                     {
                         newConnections.Add(dbCn);

--- a/DBADash/DBADashSource.cs
+++ b/DBADash/DBADashSource.cs
@@ -15,6 +15,7 @@ namespace DBADash
         private string schemaSnapshotDBs;
         private bool noWMI;
         private Int32 slowQuerySessionMaxMemoryKB = 4096;
+        private Int32 slowQueryTargetMaxMemoryKB = -1;
         private bool persistXESessions = false;
         private bool useDualXESesion = true;
 
@@ -272,6 +273,25 @@ namespace DBADash
             set {            
                     slowQuerySessionMaxMemoryKB = value;
             } 
+        }
+
+        public Int32 SlowQueryTargetMaxMemoryKB
+        {
+            get
+            {
+                if (SourceConnection != null && SourceConnection.Type == ConnectionType.SQL)
+                {
+                    return slowQueryTargetMaxMemoryKB;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            set
+            {
+                slowQueryTargetMaxMemoryKB = value;
+            }
         }
 
         [DefaultValue(true)]

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -990,6 +990,7 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
                         cmd.Parameters.AddWithValue("SlowQueryThreshold", Source.SlowQueryThresholdMs * 1000);
                         cmd.Parameters.AddWithValue("MaxMemory",Source.SlowQuerySessionMaxMemoryKB);
                         cmd.Parameters.AddWithValue("UseDualSession", Source.UseDualEventSession);
+                        cmd.Parameters.AddWithValue("MaxTargetMemory", Source.SlowQueryTargetMaxMemoryKB);
                         var result = cmd.ExecuteScalar();
                         if (result == DBNull.Value)
                         {

--- a/DBADash/ExtensionMethods.cs
+++ b/DBADash/ExtensionMethods.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -22,6 +23,12 @@ namespace DBADash
         public static bool Like(this string toSearch, string toFind)
         {
             return new Regex(@"\A" + new Regex(@"\.|\$|\^|\{|\[|\(|\||\)|\*|\+|\?|\\").Replace(toFind, ch => @"\" + ch).Replace('_', '.').Replace("%", ".*") + @"\z", RegexOptions.Singleline).IsMatch(toSearch);
+        }
+
+        public static T DeepCopy<T>(this T self)
+        {
+            var serialized = JsonConvert.SerializeObject(self);
+            return JsonConvert.DeserializeObject<T>(serialized);
         }
     }
 }

--- a/DBADash/SQL/SQLSlowQueries.sql
+++ b/DBADash/SQL/SQLSlowQueries.sql
@@ -7,11 +7,11 @@ DECLARE @EventSessionTemplate NVARCHAR(MAX) = N'CREATE EVENT SESSION [{EventSess
 	ADD EVENT sqlserver.sql_batch_completed(
 		ACTION(sqlserver.client_app_name,sqlserver.client_hostname,sqlserver.database_id,sqlserver.username,sqlserver.session_id)
 		WHERE ([duration]>(' + CAST(@SlowQueryThreshold AS NVARCHAR(MAX)) + ') AND ([sqlserver].[client_app_name]<>N''DBADashXE'')))
-	ADD TARGET package0.ring_buffer
+	ADD TARGET package0.ring_buffer' + CASE WHEN @MaxTargetMemory > 0 THEN N' (SET max_memory=' + CAST(@MaxTargetMemory AS NVARCHAR(MAX)) + N')' ELSE N'' END + '
 	WITH (MAX_MEMORY=' + CAST(@MaxMemory AS NVARCHAR(MAX)) + ' KB,EVENT_RETENTION_MODE=ALLOW_MULTIPLE_EVENT_LOSS,MAX_DISPATCH_LATENCY=2 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF)'
 
 
--- create the fisr event session if it doesn't alrreeady exist
+-- create the fisrt event session if it doesn't already exist
 IF NOT EXISTS(SELECT 1 
 			FROM sys.server_event_sessions
 			WHERE name = 'DBADash_1'

--- a/DBADash/SQL/SQLSlowQueriesAzure.sql
+++ b/DBADash/SQL/SQLSlowQueriesAzure.sql
@@ -7,11 +7,11 @@ DECLARE @EventSessionTemplate NVARCHAR(MAX) = N'CREATE EVENT SESSION [{EventSess
 	ADD EVENT sqlserver.sql_batch_completed(
 		ACTION(sqlserver.client_app_name,sqlserver.client_hostname,sqlserver.database_id,sqlserver.username,sqlserver.session_id)
 		WHERE ([duration]>(' + CAST(@SlowQueryThreshold AS NVARCHAR(MAX)) + ') AND ([sqlserver].[client_app_name]<>N''DBADashXE'')))
-	ADD TARGET package0.ring_buffer
+	ADD TARGET package0.ring_buffer' + CASE WHEN @MaxTargetMemory > 0 THEN N' (SET max_memory=' + CAST(@MaxTargetMemory AS NVARCHAR(MAX)) + N')' ELSE N'' END + '
 	WITH (MAX_MEMORY=' + CAST(@MaxMemory AS NVARCHAR(MAX)) + ' KB,EVENT_RETENTION_MODE=ALLOW_MULTIPLE_EVENT_LOSS,MAX_DISPATCH_LATENCY=2 SECONDS,MAX_EVENT_SIZE=0 KB,MEMORY_PARTITION_MODE=NONE,TRACK_CAUSALITY=OFF,STARTUP_STATE=OFF)'
 
 
--- create the fisr event session if it doesn't alrreeady exist
+-- create the fisrt event session if it doesn't already exist
 IF NOT EXISTS(SELECT 1 
 			FROM sys.database_event_sessions
 			WHERE name = 'DBADash_1'

--- a/DBADashConfig/Options.cs
+++ b/DBADashConfig/Options.cs
@@ -54,6 +54,9 @@ namespace DBADashConfig
         [Option("SlowQuerySessionMaxMemoryKB", Default = 4096, Required = false, HelpText = "Max memory for extended events session")]
         public int SlowQuerySessionMaxMemoryKB { get; set; }
 
+        [Option("SlowQueryTargetMaxMemoryKB", Default = -1, Required = false, HelpText = "Max memory target parameter for ring_buffer")]
+        public int SlowQueryTargetMaxMemoryKB { get; set; }
+
         [Option("ConnectionID", Default = "", Required = false, HelpText = "The ConnectionID is used to uniquely identify the SQL Instance in the repository database.  The ConnectionID is automatically assigned to @@SERVERNAME but you can override this with a custom value.  If you change the ConnectionID for an existing server it will appear as a new instance in the repository database.")]
         public string ConnectionID { get; set; } = "";
 

--- a/DBADashConfig/Program.cs
+++ b/DBADashConfig/Program.cs
@@ -98,6 +98,7 @@ try
                   }
                   source.SlowQueryThresholdMs = o.SlowQueryThresholdMs;
                   source.SlowQuerySessionMaxMemoryKB = o.SlowQuerySessionMaxMemoryKB;
+                  source.SlowQueryTargetMaxMemoryKB = o.SlowQueryTargetMaxMemoryKB;
                   if (!o.SkipValidation)
                   {
                       Log.Information("Validating connection...");

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -301,7 +301,8 @@ namespace DBADashServiceConfig
             dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "UseDualEventSession", HeaderText = "Use Dual Event Session" });
             dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "PersistXESessions", HeaderText = "Persist XE Sessions" });
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "SchemaSnapshotDBs", HeaderText = "Schema Snapshot DBs" });
-            dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "SlowQuerySessionMaxMemoryKB", HeaderText = "Slow Query Session Max Memory (KB)" });
+            dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "SlowQuerySessionMaxMemoryKB", HeaderText = "Slow Query Session Max Memory (KB)", ToolTipText= "Max amount of memory to allocate for event buffering." });
+            dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "SlowQueryTargetMaxMemoryKB", HeaderText = "Slow Query Target Max Memory (KB)", ToolTipText="Max memory target parameter for ring_buffer" });
             dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "CollectSessionWaits", HeaderText = "Collect Session Waits", ToolTipText = "Collect Session Waits for Running Queries" });
             dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "PlanCollectionEnabled", HeaderText = "Running Query Plan Collection" });
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "PlanCollectionCPUThreshold", HeaderText = "Plan Collection CPU Threshold" });


### PR DESCRIPTION
Add option to configure max_memory target parameter for ring_buffer.
Improve method of cloning Azure master connection to ensure SlowQueryTargetMaxMemoryKB is included along with any other future properties.
#240