### PR TITLE
Fix 'Cannot insert the value NULL' error on AG Replicas/Groups import

### DIFF
--- a/DBADashDB/dbo/Tables/AvailabilityGroups.sql
+++ b/DBADashDB/dbo/Tables/AvailabilityGroups.sql
@@ -2,7 +2,7 @@
 	   InstanceID INT NOT NULL,
 	   group_id UNIQUEIDENTIFIER NOT NULL,
        name NVARCHAR(128) NOT NULL,
-       resource_id NVARCHAR(40) NOT NULL,
+       resource_id NVARCHAR(40) NULL,
        resource_group_id NVARCHAR(40) NOT NULL,
        failure_condition_level INT NOT NULL,
        health_check_timeout INT NOT NULL,

--- a/DBADashDB/dbo/Tables/AvailabilityReplicas.sql
+++ b/DBADashDB/dbo/Tables/AvailabilityReplicas.sql
@@ -4,7 +4,7 @@
        group_id UNIQUEIDENTIFIER NOT NULL,
        replica_metadata_id INT NULL,
        replica_server_name NVARCHAR(256) NOT NULL,
-       endpoint_url NVARCHAR(128) NOT NULL,
+       endpoint_url NVARCHAR(128) NULL,
        availability_mode TINYINT NOT NULL,
        failover_mode TINYINT NOT NULL,
        session_timeout INT NOT NULL,

--- a/DBADashDB/dbo/User Defined Types/AvailabilityGroups.sql
+++ b/DBADashDB/dbo/User Defined Types/AvailabilityGroups.sql
@@ -1,7 +1,7 @@
 ﻿CREATE TYPE dbo.AvailabilityGroups as TABLE(
 	   group_id UNIQUEIDENTIFIER NOT NULL PRIMARY KEY,
        name NVARCHAR(128) NOT NULL,
-       resource_id NVARCHAR(40) NOT NULL,
+       resource_id NVARCHAR(40) NULL,
        resource_group_id NVARCHAR(40) NOT NULL,
        failure_condition_level INT NOT NULL,
        health_check_timeout INT NOT NULL,

--- a/DBADashDB/dbo/User Defined Types/AvailabilityReplicas.sql
+++ b/DBADashDB/dbo/User Defined Types/AvailabilityReplicas.sql
@@ -3,7 +3,7 @@
        group_id UNIQUEIDENTIFIER NOT NULL,
        replica_metadata_id INT NULL,
        replica_server_name NVARCHAR(256) NOT NULL,
-       endpoint_url NVARCHAR(128) NOT NULL,
+       endpoint_url NVARCHAR(128) NULL,
        availability_mode TINYINT NOT NULL,
        failover_mode TINYINT NOT NULL,
        session_timeout INT NOT NULL,


### PR DESCRIPTION
Fix Cannot insert the value NULL into column 'endpoint_url' error
Fix Cannot insert the value NULL into column 'resource_id' error
#274