### PR TITLE
Fix for string or binary data would be truncated

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
@@ -26,7 +26,7 @@ CREATE TABLE #results(
     DatabaseName NVARCHAR(128),
     DatabaseID INT,
 	ObjectID BIGINT,
-    object_name NVARCHAR(128),
+    object_name NVARCHAR(257),
     TotalCPU DECIMAL(29, 9),
     AvgCPU DECIMAL(29, 9),
 	cpu_ms_per_sec DECIMAL(29, 9),


### PR DESCRIPTION
Max length of object_name in temp table increased to 257 as it combines schema and object name. #282