### PR TITLE
Fix arithmetic overflow error for Identity Columns collection

### DIFF
--- a/DBADash/SQL/SQLIdentityColumns.sql
+++ b/DBADash/SQL/SQLIdentityColumns.sql
@@ -36,6 +36,7 @@ WHERE (
 	*/
 	OR RC.row_count  / calc.max_rows * 100 > @IdentityCollectionThreshold 
 	)
+AND IC.max_length < 9 /* Exclude decimal types that would be larger than BIGINT and break calculations */
 ORDER BY object_name;'
 
 CREATE TABLE #ident(


### PR DESCRIPTION
Fix arithmetic overflow error that can occur if tables have identity columns with decimal/numeric data types.  Exclude collection if max_length is >8.  These identity columns are unlikely to run out of values or hit the threshold for collection.  #312