### PR TITLE
Fix NullReferenceException on performance tab

### DIFF
--- a/DBADashGUI/Performance/Performance.Designer.cs
+++ b/DBADashGUI/Performance/Performance.Designer.cs
@@ -29,6 +29,12 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            DBADashGUI.CPUMetric cpuMetric1 = new DBADashGUI.CPUMetric();
+            DBADashGUI.ObjectExecutionMetric objectExecutionMetric1 = new DBADashGUI.ObjectExecutionMetric();
+            DBADashGUI.IOMetric ioMetric1 = new DBADashGUI.IOMetric();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Performance));
+            DBADashGUI.BlockingMetric blockingMetric1 = new DBADashGUI.BlockingMetric();
+            DBADashGUI.WaitMetric waitMetric1 = new DBADashGUI.WaitMetric();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
             this.smoothLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -75,7 +81,7 @@
             this.smoothLinesToolStripMenuItem.CheckOnClick = true;
             this.smoothLinesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.smoothLinesToolStripMenuItem.Name = "smoothLinesToolStripMenuItem";
-            this.smoothLinesToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.smoothLinesToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.smoothLinesToolStripMenuItem.Text = "Smooth Lines";
             this.smoothLinesToolStripMenuItem.Click += new System.EventHandler(this.SmoothLinesToolStripMenuItem_Click);
             // 
@@ -85,7 +91,7 @@
             this.dataPointsToolStripMenuItem.CheckOnClick = true;
             this.dataPointsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.dataPointsToolStripMenuItem.Name = "dataPointsToolStripMenuItem";
-            this.dataPointsToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.dataPointsToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.dataPointsToolStripMenuItem.Text = "Data Points";
             this.dataPointsToolStripMenuItem.Click += new System.EventHandler(this.DataPointsToolStripMenuItem_Click);
             // 
@@ -115,6 +121,7 @@
             this.tableLayoutPanel1.Controls.Add(this.waits1, 0, 2);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 27);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 5;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
@@ -122,63 +129,91 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1757, 1865);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1757, 2338);
             this.tableLayoutPanel1.TabIndex = 8;
             // 
             // cpu1
             // 
+            this.cpu1.CloseVisible = false;
             this.cpu1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.cpu1.Location = new System.Drawing.Point(3, 3);
+            this.cpu1.InstanceID = 0;
+            this.cpu1.Location = new System.Drawing.Point(3, 5);
+            this.cpu1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            cpuMetric1.AggregateType = DBADashGUI.Performance.IMetric.AggregateTypes.Avg;
+            this.cpu1.Metric = cpuMetric1;
+            this.cpu1.MoveUpVisible = false;
             this.cpu1.Name = "cpu1";
-            this.cpu1.Size = new System.Drawing.Size(1751, 367);
+            this.cpu1.Size = new System.Drawing.Size(1751, 457);
             this.cpu1.SmoothLines = true;
             this.cpu1.TabIndex = 4;
             // 
             // objectExecution1
             // 
+            this.objectExecution1.CloseVisible = false;
             this.objectExecution1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.objectExecution1.Location = new System.Drawing.Point(3, 1495);
+            this.objectExecution1.Location = new System.Drawing.Point(3, 1873);
+            this.objectExecution1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            objectExecutionMetric1.Measure = "TotalDuration";
+            this.objectExecution1.Metric = objectExecutionMetric1;
+            this.objectExecution1.MoveUpVisible = false;
             this.objectExecution1.Name = "objectExecution1";
-            this.objectExecution1.Size = new System.Drawing.Size(1751, 367);
+            this.objectExecution1.Size = new System.Drawing.Size(1751, 460);
             this.objectExecution1.TabIndex = 7;
             // 
             // ioPerformance1
             // 
+            this.ioPerformance1.CloseVisible = false;
             this.ioPerformance1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ioPerformance1.Drive = "";
             this.ioPerformance1.FileGroup = "";
-            this.ioPerformance1.Location = new System.Drawing.Point(3, 376);
+            this.ioPerformance1.Location = new System.Drawing.Point(3, 472);
+            this.ioPerformance1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            ioMetric1.Drive = "";
+            ioMetric1.VisibleMetrics = ((System.Collections.Generic.List<string>)(resources.GetObject("ioMetric1.VisibleMetrics")));
+            this.ioPerformance1.Metric = ioMetric1;
+            this.ioPerformance1.MoveUpVisible = false;
             this.ioPerformance1.Name = "ioPerformance1";
-            this.ioPerformance1.Size = new System.Drawing.Size(1751, 367);
+            this.ioPerformance1.Size = new System.Drawing.Size(1751, 457);
             this.ioPerformance1.SmoothLines = true;
             this.ioPerformance1.TabIndex = 3;
             // 
             // blocking1
             // 
+            this.blocking1.CloseVisible = false;
             this.blocking1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.blocking1.Location = new System.Drawing.Point(3, 1122);
+            this.blocking1.Location = new System.Drawing.Point(3, 1406);
+            this.blocking1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            this.blocking1.Metric = blockingMetric1;
+            this.blocking1.MoveUpVisible = false;
             this.blocking1.Name = "blocking1";
-            this.blocking1.Size = new System.Drawing.Size(1751, 367);
+            this.blocking1.Size = new System.Drawing.Size(1751, 457);
             this.blocking1.TabIndex = 6;
             // 
             // waits1
             // 
+            this.waits1.CloseVisible = false;
             this.waits1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.waits1.Location = new System.Drawing.Point(3, 749);
+            this.waits1.Location = new System.Drawing.Point(3, 939);
+            this.waits1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            waitMetric1.CriticalWaitsOnly = false;
+            waitMetric1.WaitType = null;
+            this.waits1.Metric = waitMetric1;
+            this.waits1.MoveUpVisible = false;
             this.waits1.Name = "waits1";
-            this.waits1.Size = new System.Drawing.Size(1751, 367);
+            this.waits1.Size = new System.Drawing.Size(1751, 457);
             this.waits1.TabIndex = 5;
             this.waits1.WaitType = null;
             // 
             // Performance
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.toolStrip1);
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "Performance";
-            this.Size = new System.Drawing.Size(1757, 1892);
+            this.Size = new System.Drawing.Size(1757, 2365);
             this.Load += new System.EventHandler(this.Performance_Load);
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();

--- a/DBADashGUI/Performance/Performance.resx
+++ b/DBADashGUI/Performance/Performance.resx
@@ -1,64 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
+﻿<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -123,4 +63,12 @@
   <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>141, 17</value>
   </metadata>
+  <data name="ioMetric1.VisibleMetrics" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAEAQAAAH9TeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5MaXN0YDFbW1N5
+        c3RlbS5TdHJpbmcsIG1zY29ybGliLCBWZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVi
+        bGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OV1dAwAAAAZfaXRlbXMFX3NpemUIX3ZlcnNpb24GAAAI
+        CAkCAAAAAwAAAAMAAAARAgAAAAQAAAAGAwAAAAVNQnNlYwYEAAAABElPUHMGBQAAAAdMYXRlbmN5Cgs=
+</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix NullReferenceException on performance tab when you click the move up button.  The move up button should only be visible when the control is used on the Metrics tab. #313