### PR TITLE
Fix maximum recursion bug on running queries

### DIFF
--- a/DBADashDB/dbo/Functions/RunningQueriesBlockingHierarchy.sql
+++ b/DBADashDB/dbo/Functions/RunningQueriesBlockingHierarchy.sql
@@ -12,19 +12,26 @@ RETURN
 	We pass in 64 as the current blocking session and get: 96 \ 72 \ 64.  
 */
 WITH  H AS(
-	SELECT @BlockingSessionID as blocking_session_id,
-			0 as Sort
+	SELECT	@BlockingSessionID as blocking_session_id,
+			0 as Sort,
+			' \ ' + CAST(@BlockingSessionID AS VARCHAR(MAX)) AS BlockingHierarchy,
+			0 AS IsDeadlock
 	WHERE @BlockingSessionID<>0
 	UNION ALL
-	SELECT Q.blocking_session_id,H.Sort+1
+	SELECT	Q.blocking_session_id,
+			H.Sort+1,
+			CASE WHEN calc.IsDeadlock =1 THEN ' \ {!Deadlock!}' ELSE '' END + ' \ ' + CAST(Q.blocking_session_id AS VARCHAR(MAX)) + H.BlockingHierarchy,
+			calc.IsDeadlock
 	FROM H 
 	JOIN dbo.RunningQueries Q ON H.blocking_session_id = Q.session_id
+	-- Check for a loop (deadlock).  Break execution on the next iteration when a deadlock is detected
+	OUTER APPLY(SELECT CASE WHEN Q.blocking_session_id = @BlockingSessionID OR H.BlockingHierarchy LIKE '%\ ' + CAST(Q.blocking_session_id AS VARCHAR(MAX)) + ' \%' THEN 1 ELSE 0 END AS IsDeadlock) calc
 	WHERE Q.InstanceID = @InstanceID
 	AND Q.SnapshotDateUTC = @SnapshotDateUTC
 	AND Q.blocking_session_id <> 0
-	AND Q.blocking_session_id <> @BlockingSessionID -- Avoid an infinite loop in a deadlock scenario
+	AND H.IsDeadlock=0 -- Stop if a deadlock was detected on the previous loop
+	AND H.Sort < 100 -- Stop before we break max recursion
 	)
-SELECT ISNULL(STUFF((SELECT ' \ '  + CAST(blocking_session_id AS VARCHAR(MAX))
-				FROM H
-				ORDER BY Sort DESC
-				FOR XML PATH(''),TYPE).value('.','VARCHAR(MAX)'),1,3,''),'')  as BlockingHierarchy
+SELECT TOP(1) ISNULL(STUFF(BlockingHierarchy,1,3,''),'')  as BlockingHierarchy
+FROM H
+ORDER BY Sort DESC

--- a/DBADashGUI/Performance/RunningQueries.cs
+++ b/DBADashGUI/Performance/RunningQueries.cs
@@ -337,7 +337,7 @@ namespace DBADashGUI.Performance
         {
             runningJobCount = snapshotDT.AsEnumerable().Where(r => r["job_id"] != DBNull.Value).Count();
             blockedCount = snapshotDT.AsEnumerable().Where(r => Convert.ToInt16(r["blocking_session_id"]) != 0).Count();
-            blockedWait = snapshotDT.AsEnumerable().Where(r => Convert.ToInt16(r["blocking_session_id"]) != 0).Sum(r => Convert.ToInt64(r["wait_time"]));
+            blockedWait = snapshotDT.AsEnumerable().Where(r => Convert.ToInt16(r["blocking_session_id"]) != 0 && r["wait_time"]!=DBNull.Value).Sum(r => Convert.ToInt64(r["wait_time"]));
             planCount = snapshotDT.AsEnumerable().Where(r => r["query_plan"] != DBNull.Value).Count();
             hasWaitResource = snapshotDT.AsEnumerable().Where(r => r["wait_resource"] != DBNull.Value && !string.IsNullOrEmpty((string)r["wait_resource"])).Any();
 


### PR DESCRIPTION
It's possible to create a loop in the blocking chain that results in a maximum recursion error.  Fixed issue and added highlighting of deadlock situations in the blocking hierarchy. Fixed additional potential bug if wait_time is null for a blocked query. #320