### PR TITLE
Exclude read only from last good DBCC

### DIFF
--- a/DBADashDB/dbo/Views/LastGoodCheckDB.sql
+++ b/DBADashDB/dbo/Views/LastGoodCheckDB.sql
@@ -32,7 +32,7 @@ OUTER APPLY(SELECT TOP(1) T.*
 				ORDER BY T.DatabaseID DESC, T.InstanceID DESC
 			) cfg
 OUTER APPLY(SELECT STUFF(CONCAT(CASE WHEN D.state<>0 THEN ', ' + state_desc ELSE NULL END,
-					CASE WHEN D.is_in_standby=1 THEN ', STANDBY' ELSE NULL END,
+					CASE WHEN D.is_in_standby=1 THEN ', STANDBY' WHEN D.is_read_only=1 THEN ', READ ONLY'  ELSE NULL END,
 					CASE WHEN EXISTS(SELECT * FROM STRING_SPLIT(cfg.ExcludedDatabases,',') SS WHERE d.name LIKE RTRIM(LTRIM(SS.value))) THEN ', name' ELSE NULL END,
 					CASE WHEN D.LastGoodCheckDbTime IS NULL THEN ', Not captured' ELSE NULL END,
 					CASE WHEN DATEADD(mi,I.UTCOffset,D.create_date) > DATEADD(mi,-cfg.MinimumAge,GETUTCDATE())  THEN ', create_date' ELSE NULL END,


### PR DESCRIPTION
Last good DBCC date doesn't get updated for read only databases so these should be excluded from checks. #325