### PR TITLE
Fix Instance name column on Running Queries

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/RunningQueriesForSession_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/RunningQueriesForSession_Get.sql
@@ -6,6 +6,7 @@
 )
 AS
 SELECT InstanceID,
+       InstanceDisplayName,
        Duration,
        batch_text,
        text,


### PR DESCRIPTION
Fix instance name column when filtering for running queries for a specific session. #329