### PR TITLE
Improve error handling around scripting jobs

### DIFF
--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -902,6 +902,10 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
                     {
                         Log.Warning("SnapshotJobs not supported: {0}. From {1}", ex.Message, Source.SourceConnection.ConnectionForPrint);
                     }
+                    catch(AggregateException ex) // thrown if any issues scripting jobs
+                    {
+                        LogDBError(collectionTypeString,ex.ToString());
+                    }
                 }
                 else
                 {

--- a/DBADashDB/dbo/Stored Procedures/Jobs_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/Jobs_Upd.sql
@@ -1,4 +1,4 @@
-﻿CREATE   PROC dbo.Jobs_Upd(
+﻿CREATE PROC dbo.Jobs_Upd(
 	@InstanceID INT,
 	@Jobs dbo.Jobs READONLY,
 	@SnapshotDate DATETIME2(2)
@@ -13,7 +13,8 @@ BEGIN
 		DDLHash,
 		DDL
 	)
-	SELECT DDLHash,DDL
+	SELECT DISTINCT DDLHash,
+			DDL
 	FROM @Jobs T
 	WHERE NOT EXISTS(SELECT 1 FROM dbo.DDL WHERE DDL.DDLHash = T.DDLHash)
 


### PR DESCRIPTION
If an agent job can't be scripted for some reason, log an error and continue instead of failing the Job collection.  #373