### PR TITLE
Improve Jobs collection

### DIFF
--- a/DBADash/AgentJobs.cs
+++ b/DBADash/AgentJobs.cs
@@ -1,0 +1,254 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.SqlServer.Management.Smo;
+using Microsoft.SqlServer.Management.Smo.Agent;
+using Serilog;
+using SerilogTimings;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DBADash
+{
+    internal class AgentJobs: SMOBaseClass
+    {
+        public AgentJobs(DBADashConnection source, SchemaSnapshotDBOptions options) : base(source, options)
+        {
+        }
+        public AgentJobs(DBADashConnection source) : base(source)
+        {
+        }
+
+        private static DataTable JobDataTableSchema()
+        {
+            DataTable dtSchema = new("Jobs");
+            dtSchema.Columns.Add("job_id", typeof(Guid));
+            dtSchema.Columns.Add("originating_server");
+            dtSchema.Columns.Add("name");
+            dtSchema.Columns.Add("enabled", typeof(bool));
+            dtSchema.Columns.Add("description");
+            dtSchema.Columns.Add("start_step_id", typeof(int));
+            dtSchema.Columns.Add("category_id", typeof(int));
+            dtSchema.Columns.Add("category");
+            dtSchema.Columns.Add("owner");
+            dtSchema.Columns.Add("notify_level_eventlog", typeof(int));
+            dtSchema.Columns.Add("notify_level_email", typeof(int));
+            dtSchema.Columns.Add("notify_level_netsend", typeof(int));
+            dtSchema.Columns.Add("notify_level_page", typeof(int));
+            dtSchema.Columns.Add("notify_email_operator");
+            dtSchema.Columns.Add("notify_netsend_operator");
+            dtSchema.Columns.Add("notify_page_operator");
+            dtSchema.Columns.Add("delete_level", typeof(int));
+            dtSchema.Columns.Add("date_created", typeof(DateTime));
+            dtSchema.Columns.Add("date_modified", typeof(DateTime));
+            dtSchema.Columns.Add("version_number", typeof(int));
+            dtSchema.Columns.Add("has_schedule", typeof(bool));
+            dtSchema.Columns.Add("has_server", typeof(bool));
+            dtSchema.Columns.Add("has_step", typeof(bool));
+            dtSchema.Columns.Add("DDLHash", typeof(byte[]));
+            dtSchema.Columns.Add("DDL", typeof(byte[]));
+            return dtSchema;
+        }
+
+        private static DataTable JobStepTableSchema()
+        {
+            DataTable jobStepDT = new("JobSteps");
+            jobStepDT.Columns.Add("job_id", typeof(Guid));
+            jobStepDT.Columns.Add("step_id", typeof(int));
+            jobStepDT.Columns.Add("step_name");
+            jobStepDT.Columns.Add("subsystem");
+            jobStepDT.Columns.Add("command");
+            jobStepDT.Columns.Add("cmdexec_success_code", typeof(int));
+            jobStepDT.Columns.Add("on_success_action", typeof(short));
+            jobStepDT.Columns.Add("on_success_step_id", typeof(int));
+            jobStepDT.Columns.Add("on_fail_action", typeof(short));
+            jobStepDT.Columns.Add("on_fail_step_id", typeof(int));
+            jobStepDT.Columns.Add("database_name");
+            jobStepDT.Columns.Add("database_user_name");
+            jobStepDT.Columns.Add("retry_attempts", typeof(int));
+            jobStepDT.Columns.Add("retry_interval", typeof(int));
+            jobStepDT.Columns.Add("output_file_name");
+            jobStepDT.Columns.Add("proxy_name");
+            return jobStepDT;
+        }
+
+        public void CollectJobs(ref DataSet ds,bool scriptJobs)
+        {
+            DataTable jobsDT;
+            DataTable jobStepsDT;
+            using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Collect Jobs from instance {instance}", SourceConnection.ConnectionForPrint))
+            {
+                jobsDT = GetJobsDT();
+                op.Complete();
+            }
+            using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Collect JobsSteps from instance {instance}", SourceConnection.ConnectionForPrint))
+            {
+                jobStepsDT = GetJobStepsDT();
+                op.Complete();
+            }
+           
+            if (scriptJobs)
+            {
+                using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Script Jobs from instance {instance}", SourceConnection.ConnectionForPrint))
+                {
+                    ScriptJobs(ref jobsDT);
+                    op.Complete();
+                }
+            }
+            ds.Tables.Add(jobsDT);
+            ds.Tables.Add(jobStepsDT);
+        }
+
+        private void ScriptJobs(ref DataTable jobsDT)
+        {
+            List<Exception> errors = new();
+            using (var cn = new SqlConnection(ConnectionString))
+            {
+                var instance = new Microsoft.SqlServer.Management.Smo.Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn));
+                int totalJobs = jobsDT.Rows.Count;
+                int cnt=0;
+                foreach (DataRow row in jobsDT.Rows)
+                {
+                    cnt++;
+                    string sDDL;
+                    string jobName = (string)row["name"];
+                    using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Script Job {number}/{totaljobs} ({pct}) {job} from {instance}",cnt,totalJobs,(cnt*1.0/totalJobs).ToString("P1"), jobName, SourceConnection.ConnectionForPrint))
+                    {
+                        try
+                        {
+                            var job = instance.JobServer.Jobs[jobName];
+                            sDDL = SchemaSnapshotDB.StringCollectionToString(job.Script(ScriptingOptions));
+                        }
+                        catch (Exception ex)
+                        {
+                            string message = String.Format("Error scripting agent job `{0}` on {1}", jobName, instance.Name);
+                            sDDL = "/*\n Error scripting job: \n" + ex.Message + "\n*/";
+                            errors.Add(new Exception(message, ex));
+                            Log.Error(ex, message);
+                        }
+                        var bDDL = Zip(sDDL);
+                        row["DDL"] = bDDL;
+                        row["DDLHash"] = ComputeHash(bDDL);
+                        op.Complete();
+                    }
+                }
+                
+            }
+        }
+
+        private DataTable GetJobsDT()
+        {
+            using (var cn = new SqlConnection(ConnectionString))
+            using (var da = new SqlDataAdapter(SqlStrings.Jobs, cn))
+            {
+                cn.Open();
+                da.SelectCommand.CommandTimeout = CollectionType.Jobs.GetCommandTimeout();
+                var jobDT = JobDataTableSchema();
+                da.Fill(jobDT);
+                return jobDT;
+            }
+        }
+
+        private DataTable GetJobStepsDT()
+        {
+            using (var cn = new SqlConnection(ConnectionString))
+            using (var da = new SqlDataAdapter(SqlStrings.JobSteps, cn))
+            {
+                cn.Open();
+                da.SelectCommand.CommandTimeout = CollectionType.Jobs.GetCommandTimeout();
+                var jobStepDT = JobStepTableSchema();
+                da.Fill(jobStepDT);
+                return jobStepDT;
+            }
+        }
+
+        public void SnapshotJobs(ref DataSet ds)
+        {
+            var jobDT = JobDataTableSchema();
+            var jobStepDT = JobStepTableSchema();
+            List<Exception> errors = new();
+            using (var cn = new SqlConnection(ConnectionString))
+            {
+                var instance = new Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn));
+                foreach (Job job in instance.JobServer.Jobs)
+                {
+                    DataRow r = jobDT.NewRow();
+                    string sDDL;
+                    try
+                    {
+                        sDDL = SchemaSnapshotDB.StringCollectionToString(job.Script(ScriptingOptions));
+                    }
+                    catch (Exception ex)
+                    {
+                        string message = String.Format("Error scripting agent job `{0}` on {1}", job.Name, instance.Name);
+                        sDDL = "/*\n Error scripting job: \n" + ex.Message + "\n*/";
+                        errors.Add(new Exception(message, ex));
+                        Log.Error(ex, message);
+                    }
+
+                    var bDDL = Zip(sDDL);
+                    r["name"] = job.Name;
+                    r["job_id"] = job.JobID;
+                    r["enabled"] = job.IsEnabled;
+                    r["DDL"] = bDDL;
+                    r["DDLHash"] = ComputeHash(bDDL);
+                    r["date_created"] = job.DateCreated;
+                    r["date_modified"] = job.DateLastModified;
+                    r["category"] = job.Category;
+                    r["category_id"] = job.CategoryID;
+                    r["description"] = job.Description;
+                    r["version_number"] = job.VersionNumber;
+                    r["delete_level"] = job.DeleteLevel;
+                    r["notify_level_page"] = job.DeleteLevel;
+                    r["notify_level_netsend"] = job.NetSendLevel;
+                    r["notify_level_email"] = job.EmailLevel;
+                    r["notify_level_eventlog"] = job.EventLogLevel;
+                    r["notify_email_operator"] = job.OperatorToEmail;
+                    r["notify_netsend_operator"] = job.OperatorToNetSend;
+                    r["notify_page_operator"] = job.OperatorToPage;
+                    r["owner"] = job.OwnerLoginName;
+                    r["start_step_id"] = job.StartStepID;
+                    r["has_schedule"] = job.HasSchedule;
+                    r["has_server"] = job.HasServer;
+                    r["has_step"] = job.HasStep;
+                    jobDT.Rows.Add(r);
+
+                    foreach (Microsoft.SqlServer.Management.Smo.Agent.JobStep step in job.JobSteps)
+                    {
+                        var stepR = jobStepDT.NewRow();
+                        stepR["job_id"] = job.JobID;
+                        stepR["step_name"] = step.Name;
+                        stepR["database_name"] = step.DatabaseName;
+                        stepR["step_id"] = step.ID;
+                        stepR["subsystem"] = step.SubSystem;
+                        stepR["command"] = step.Command;
+                        stepR["cmdexec_success_code"] = step.CommandExecutionSuccessCode;
+                        stepR["on_success_action"] = step.OnSuccessAction;
+                        stepR["on_success_step_id"] = step.OnSuccessStep;
+                        stepR["on_fail_action"] = step.OnFailAction;
+                        stepR["on_fail_step_id"] = step.OnFailStep;
+                        stepR["database_user_name"] = step.DatabaseUserName;
+                        stepR["retry_attempts"] = step.RetryAttempts;
+                        stepR["retry_interval"] = step.RetryInterval;
+                        stepR["output_file_name"] = step.OutputFileName;
+                        stepR["proxy_name"] = step.ProxyName;
+
+                        jobStepDT.Rows.Add(stepR);
+
+                    }
+                }
+            }
+            ds.Tables.Add(jobDT);
+            ds.Tables.Add(jobStepDT);
+            if (errors.Count > 0)
+            {
+                throw new AggregateException(errors);
+            }
+        }
+
+
+    }
+}

--- a/DBADash/AgentJobs.cs
+++ b/DBADash/AgentJobs.cs
@@ -79,12 +79,12 @@ namespace DBADash
         {
             DataTable jobsDT;
             DataTable jobStepsDT;
-            using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Collect Jobs from instance {instance}", SourceConnection.ConnectionForPrint))
+            using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Run Jobs query on instance {instance}", SourceConnection.ConnectionForPrint))
             {
                 jobsDT = GetJobsDT();
                 op.Complete();
             }
-            using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Collect JobsSteps from instance {instance}", SourceConnection.ConnectionForPrint))
+            using (var op = Operation.At(Serilog.Events.LogEventLevel.Debug).Begin("Run JobsSteps query instance {instance}", SourceConnection.ConnectionForPrint))
             {
                 jobStepsDT = GetJobStepsDT();
                 op.Complete();

--- a/DBADash/DBADash.csproj
+++ b/DBADash/DBADash.csproj
@@ -19,6 +19,8 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="SQL\SQLIdentityColumns.sql" />
+    <None Remove="SQL\SQLJobs.sql" />
+    <None Remove="SQL\SQLJobSteps.sql" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs" Link="Properties\GlobalAssemblyInfo.cs" />
@@ -55,6 +57,8 @@
 	<EmbeddedResource Include="SQL\SQLInstance.sql" />
 	<EmbeddedResource Include="SQL\SQLIOStats.sql" />
 	<EmbeddedResource Include="SQL\SQLJobHistory.sql" />
+	<EmbeddedResource Include="SQL\SQLJobs.sql" />
+	<EmbeddedResource Include="SQL\SQLJobSteps.sql" />
 	<EmbeddedResource Include="SQL\SQLLastGoodCheckDB.sql" />
 	<EmbeddedResource Include="SQL\SQLLogRestores.sql" />
 	<EmbeddedResource Include="SQL\SQLMemoryUsage.sql" />

--- a/DBADash/DBADashSource.cs
+++ b/DBADash/DBADashSource.cs
@@ -20,6 +20,7 @@ namespace DBADash
         private bool useDualXESesion = true;
 
         public string ConnectionID { get; set; }
+        public bool ScriptAgentJobs { get; set; } = true;
 
         public  CollectionSchedules CollectionSchedules {
             get

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -843,6 +843,7 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
             if (collectionType == CollectionType.JobHistory)
             {
                 param = new SqlParameter[] { new SqlParameter { DbType = DbType.Int32, Value = Job_instance_id, ParameterName = "instance_id" }, new SqlParameter { DbType = DbType.Int32, ParameterName = "run_date", Value = Convert.ToInt32(DateTime.Now.AddDays(-7).ToString("yyyyMMdd")) } };
+                Log.Debug("JobHistory From {JobInstanceID} on {Instance}", Job_instance_id,Source.SourceConnection.ConnectionForPrint);
             }
             else if (collectionType == CollectionType.AzureDBResourceStats || collectionType == CollectionType.AzureDBElasticPoolResourceStats)
             {

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -892,10 +892,11 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
                 var currentJobModified = GetJobLastModified();
                 if (currentJobModified > JobLastModified)
                 {
-                    var ss = new SchemaSnapshotDB(ConnectionString, new SchemaSnapshotDBOptions());
+                    var ss = new AgentJobs(Source.SourceConnection, new SchemaSnapshotDBOptions());
                     try
                     {
-                        ss.SnapshotJobs(ref Data);
+                        //ss.SnapshotJobs(ref Data);
+                        ss.CollectJobs(ref Data, Source.ScriptAgentJobs);
                         JobLastModified = currentJobModified;
                     }
                     catch (Microsoft.SqlServer.Management.Smo.UnsupportedFeatureException ex)
@@ -953,7 +954,7 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
 
         private void CollectResourceGovernor()
         {
-            var ss = new SchemaSnapshotDB(ConnectionString);
+            var ss = new SchemaSnapshotDB(Source.SourceConnection);
             var dtRG = ss.ResourceGovernorConfiguration();
             Data.Tables.Add(dtRG);
         }

--- a/DBADash/GlobalSuppressions.cs
+++ b/DBADash/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+[assembly: SuppressMessage("Style", "IDE0063:Use simple 'using' statement")]

--- a/DBADash/SMOBaseClass.cs
+++ b/DBADash/SMOBaseClass.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.SqlServer.Management.Smo;
+using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Specialized;
+using System.Security.Cryptography;
+
+namespace DBADash
+{
+    public class SMOBaseClass
+    {
+        protected readonly SchemaSnapshotDBOptions options;
+        protected readonly ScriptingOptions ScriptingOptions;
+        protected string ConnectionString { get => SourceConnection.ConnectionString; }
+        protected readonly DBADashConnection SourceConnection;
+
+        public SMOBaseClass(DBADashConnection source, SchemaSnapshotDBOptions options)
+        {
+            SourceConnection =  source;
+            options = options == null ? new SchemaSnapshotDBOptions() : options;
+            this.options = options;
+            this.ScriptingOptions = options.ScriptOptions();
+        }
+
+        public SMOBaseClass(DBADashConnection source)
+        {
+            SourceConnection = source;
+            this.options = new SchemaSnapshotDBOptions();
+            this.ScriptingOptions = options.ScriptOptions();
+        }
+
+        
+
+        protected string MasterConnectionString
+        {
+            get
+            {
+                var builder = new SqlConnectionStringBuilder(ConnectionString)
+                {
+                    InitialCatalog = "master"
+                };
+                return builder.ConnectionString;
+            }
+        }
+
+        public static byte[] ComputeHash(byte[] obj)
+        {
+            using (var crypt = SHA256.Create())
+            {
+                return crypt.ComputeHash(obj);
+            }
+        }
+
+
+        public static string StringCollectionToString(StringCollection sc)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var s in sc)
+            {
+                sb.AppendLine(s);
+                sb.AppendLine("GO");
+            }
+            return sb.ToString();
+        }
+
+        public static void CopyTo(Stream src, Stream dest)
+        {
+            byte[] bytes = new byte[4096];
+
+            int cnt;
+
+            while ((cnt = src.Read(bytes, 0, bytes.Length)) != 0)
+            {
+                dest.Write(bytes, 0, cnt);
+            }
+        }
+
+        public static byte[] Zip(string str)
+        {
+            var bytes = Encoding.Unicode.GetBytes(str);
+
+            using (var msi = new MemoryStream(bytes))
+            using (var mso = new MemoryStream())
+            {
+                using (var gs = new GZipStream(mso, CompressionMode.Compress))
+                {
+                    //msi.CopyTo(gs);
+                    CopyTo(msi, gs);
+                }
+
+                return mso.ToArray();
+            }
+        }
+
+        public static string Unzip(byte[] bytes)
+        {
+            using (var msi = new MemoryStream(bytes))
+            using (var mso = new MemoryStream())
+            {
+                using (var gs = new GZipStream(msi, CompressionMode.Decompress))
+                {
+                    //gs.CopyTo(mso);
+                    CopyTo(gs, mso);
+                }
+
+                return Encoding.Unicode.GetString(mso.ToArray());
+            }
+        }
+
+    }
+}

--- a/DBADash/SQL/SQLJobSteps.sql
+++ b/DBADash/SQL/SQLJobSteps.sql
@@ -1,0 +1,18 @@
+﻿SELECT	JS.job_id,
+		JS.step_name,
+		JS.database_name,
+		JS.step_id,
+		JS.subsystem,
+		JS.command,
+		JS.cmdexec_success_code,
+		JS.on_success_action,
+		JS.on_success_step_id,
+		JS.on_fail_action,
+		JS.on_fail_step_id,
+		ISNULL(JS.database_user_name,'') AS database_user_name,
+		JS.retry_attempts,
+		JS.retry_interval,
+		ISNULL(JS.output_file_name,'') AS output_file_name,
+		ISNULL(P.name,'') AS proxy_name
+FROM msdb.dbo.sysjobsteps JS
+LEFT JOIN msdb.dbo.sysproxies P ON JS.proxy_id = P.proxy_id

--- a/DBADash/SQL/SQLJobs.sql
+++ b/DBADash/SQL/SQLJobs.sql
@@ -1,0 +1,31 @@
+﻿SELECT	J.job_id,
+		S.name AS originating_server,
+		J.name,
+		J.enabled,
+		J.description,
+		J.start_step_id,
+		J.category_id,
+		C.name AS category,
+		SUSER_SNAME(J.owner_sid) AS owner,
+		J.notify_level_eventlog,
+		J.notify_level_email,
+		J.notify_level_netsend,
+		J.notify_level_page,
+		ISNULL(EmailOp.name,'') AS notify_email_operator,
+		ISNULL(NetOp.name,'') AS notify_netsend_operator,
+		ISNULL(PageOp.name,'') AS notify_page_operator,
+		J.delete_level,
+		J.date_created,
+		J.date_modified,
+		J.version_number,
+		CASE WHEN EXISTS(SELECT * FROM msdb.dbo.sysjobschedules JS WHERE JS.job_id = J.job_id) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS has_schedule,
+		CASE WHEN EXISTS(SELECT * FROM msdb.dbo.sysjobservers JS WHERE JS.job_id = J.job_id) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS has_server,
+		CASE WHEN EXISTS(SELECT 1 FROM msdb.dbo.sysjobsteps JS WHERE JS.job_id = J.job_id) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END has_step,
+		CAST(NULL AS BINARY(32)) AS DDLHash, /* Populated using SMO */
+		CAST(NULL AS VARBINARY(MAX)) AS DDL /* Populated using SMO */
+FROM msdb.dbo.sysjobs J 
+LEFT JOIN [msdb].[sys].[servers] AS S ON J.originating_server_id = S.server_id AND J.originating_server_id<>0 /* Return NULL for this server like SMO */
+LEFT JOIN msdb.dbo.syscategories C ON C.category_id = J.category_id
+LEFT JOIN msdb.dbo.sysoperators EmailOp ON J.notify_email_operator_id = EmailOp.id
+LEFT JOIN msdb.dbo.sysoperators NetOp ON J.notify_netsend_operator_id = NetOp.id
+LEFT JOIN msdb.dbo.sysoperators PageOp ON J.notify_page_operator_id = PageOp.id

--- a/DBADash/SchemaSnapshotDB.cs
+++ b/DBADash/SchemaSnapshotDB.cs
@@ -83,195 +83,15 @@ namespace DBADash
 
     }
 
-    public class SchemaSnapshotDB
+    public class SchemaSnapshotDB : SMOBaseClass
     {
-
-        private readonly string _connectionString;
-        private readonly SchemaSnapshotDBOptions options;
-        private readonly ScriptingOptions ScriptingOptions;
-        private string masterConnectionString
+        public SchemaSnapshotDB(DBADashConnection source, SchemaSnapshotDBOptions options) : base(source, options)
         {
-            get
-            {
-                var builder = new SqlConnectionStringBuilder(_connectionString)
-                {
-                    InitialCatalog = "master"
-                };
-                return builder.ConnectionString;
-            }
+
         }
-
-        private byte[] computeHash(byte[] obj)
+        public SchemaSnapshotDB(DBADashConnection source) : base(source)
         {
-            using(var crypt = SHA256.Create())
-            {
-                return crypt.ComputeHash(obj); 
-            }
-        }
-       
-        public SchemaSnapshotDB(string connectionString,SchemaSnapshotDBOptions options)
-        {
-            _connectionString = connectionString;
-            options = options == null ? new SchemaSnapshotDBOptions() : options;
-            this.options = options;
-            this.ScriptingOptions = options.ScriptOptions();
-        }
-
-        public SchemaSnapshotDB(string connectionString)
-        {
-            _connectionString = connectionString;
-            this.options = new SchemaSnapshotDBOptions();
-            this.ScriptingOptions = options.ScriptOptions();
-        }
-
-
-        private static string stringCollectionToString(StringCollection sc)
-        {
-            StringBuilder sb = new StringBuilder();
-            foreach (var s in sc)
-            {
-                sb.AppendLine(s);
-                sb.AppendLine("GO");
-            }
-            return sb.ToString();
-        }
-
-
-        private DataTable JobDataTableSchema()
-        {
-            DataTable dtSchema = new DataTable("Jobs");
-            dtSchema.Columns.Add("job_id", typeof(Guid));
-            dtSchema.Columns.Add("originating_server");
-            dtSchema.Columns.Add("name");
-            dtSchema.Columns.Add("enabled", typeof(bool));
-            dtSchema.Columns.Add("description");
-            dtSchema.Columns.Add("start_step_id", typeof(int));
-            dtSchema.Columns.Add("category_id", typeof(int));
-            dtSchema.Columns.Add("category");
-            dtSchema.Columns.Add("owner");
-            dtSchema.Columns.Add("notify_level_eventlog", typeof(int));
-            dtSchema.Columns.Add("notify_level_email", typeof(int));
-            dtSchema.Columns.Add("notify_level_netsend", typeof(int));
-            dtSchema.Columns.Add("notify_level_page", typeof(int));
-            dtSchema.Columns.Add("notify_email_operator");
-            dtSchema.Columns.Add("notify_netsend_operator");
-            dtSchema.Columns.Add("notify_page_operator");
-            dtSchema.Columns.Add("delete_level", typeof(int));
-            dtSchema.Columns.Add("date_created", typeof(DateTime));
-            dtSchema.Columns.Add("date_modified", typeof(DateTime));
-            dtSchema.Columns.Add("version_number", typeof(int));
-            dtSchema.Columns.Add("has_schedule", typeof(bool));
-            dtSchema.Columns.Add("has_server", typeof(bool));
-            dtSchema.Columns.Add("has_step", typeof(bool));
-            dtSchema.Columns.Add("DDLHash", typeof(byte[]));
-            dtSchema.Columns.Add("DDL", typeof(byte[]));
-            return dtSchema;
-        }
-
-        private DataTable JobStepTableSchema()
-        {
-            var jobStepDT = new DataTable("JobSteps");
-            jobStepDT.Columns.Add("job_id", typeof(Guid));
-            jobStepDT.Columns.Add("step_id", typeof(int));
-            jobStepDT.Columns.Add("step_name");
-            jobStepDT.Columns.Add("subsystem");
-            jobStepDT.Columns.Add("command");
-            jobStepDT.Columns.Add("cmdexec_success_code", typeof(int));
-            jobStepDT.Columns.Add("on_success_action", typeof(short));
-            jobStepDT.Columns.Add("on_success_step_id", typeof(int));
-            jobStepDT.Columns.Add("on_fail_action", typeof(short));
-            jobStepDT.Columns.Add("on_fail_step_id", typeof(int));
-            jobStepDT.Columns.Add("database_name");
-            jobStepDT.Columns.Add("database_user_name");
-            jobStepDT.Columns.Add("retry_attempts", typeof(int));
-            jobStepDT.Columns.Add("retry_interval", typeof(int));
-            jobStepDT.Columns.Add("output_file_name");
-            jobStepDT.Columns.Add("proxy_name");
-            return jobStepDT;
-        }
-
-        public void SnapshotJobs(ref DataSet ds)
-        {
-            var jobDT = JobDataTableSchema();
-            var jobStepDT = JobStepTableSchema();
-            List<Exception> errors = new();
-            using (var cn = new Microsoft.Data.SqlClient.SqlConnection(_connectionString))
-            {
-                var instance = new Microsoft.SqlServer.Management.Smo.Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn));
-                foreach(Microsoft.SqlServer.Management.Smo.Agent.Job job in instance.JobServer.Jobs)
-                {
-                    DataRow r = jobDT.NewRow();
-                    string sDDL;
-                    try
-                    {
-                        sDDL = stringCollectionToString(job.Script(ScriptingOptions));
-                    }
-                    catch(Exception ex)
-                    {
-                        string message = String.Format("Error scripting agent job `{0}` on {1}", job.Name, instance.Name);
-                        sDDL = "/*\n Error scripting job: \n" + ex.Message + "\n*/";
-                        errors.Add(new Exception(message, ex));
-                        Log.Error(ex, message);
-                    }
-                   
-                    var bDDL = Zip(sDDL);
-                    r["name"] = job.Name;
-                    r["job_id"] = job.JobID;
-                    r["enabled"] = job.IsEnabled;
-                    r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
-                    r["date_created"] = job.DateCreated;
-                    r["date_modified"] = job.DateLastModified;
-                    r["category"] = job.Category;
-                    r["category_id"] = job.CategoryID;
-                    r["description"] = job.Description;
-                    r["version_number"] = job.VersionNumber;
-                    r["delete_level"] = job.DeleteLevel;
-                    r["notify_level_page"] = job.DeleteLevel;
-                    r["notify_level_netsend"] = job.NetSendLevel;
-                    r["notify_level_email"] = job.EmailLevel;
-                    r["notify_level_eventlog"] = job.EventLogLevel;
-                    r["notify_email_operator"] = job.OperatorToEmail;
-                    r["notify_netsend_operator"] = job.OperatorToNetSend;
-                    r["notify_page_operator"] = job.OperatorToPage;
-                    r["owner"] = job.OwnerLoginName;
-                    r["start_step_id"] = job.StartStepID;
-                    r["has_schedule"] = job.HasSchedule;
-                    r["has_server"] = job.HasServer;
-                    r["has_step"] = job.HasStep;
-                    jobDT.Rows.Add(r);
-
-                    foreach(Microsoft.SqlServer.Management.Smo.Agent.JobStep step in job.JobSteps)
-                    {
-                        var stepR = jobStepDT.NewRow();
-                        stepR["job_id"] = job.JobID;
-                        stepR["step_name"] = step.Name;
-                        stepR["database_name"] = step.DatabaseName;
-                        stepR["step_id"] = step.ID;
-                        stepR["subsystem"] = step.SubSystem;
-                        stepR["command"] = step.Command;
-                        stepR["cmdexec_success_code"] = step.CommandExecutionSuccessCode;
-                        stepR["on_success_action"] = step.OnSuccessAction;
-                        stepR["on_success_step_id"] = step.OnSuccessStep;
-                        stepR["on_fail_action"] = step.OnFailAction;
-                        stepR["on_fail_step_id"] = step.OnFailStep;
-                        stepR["database_user_name"] = step.DatabaseUserName;
-                        stepR["retry_attempts"] = step.RetryAttempts;
-                        stepR["retry_interval"] = step.RetryInterval;
-                        stepR["output_file_name"] = step.OutputFileName;
-                        stepR["proxy_name"] = step.ProxyName;
-
-                        jobStepDT.Rows.Add(stepR);
-
-                    }
-                }
-            }
-            ds.Tables.Add(jobDT);
-            ds.Tables.Add(jobStepDT);
-            if (errors.Count > 0)
-            {
-                throw new AggregateException(errors);
-            }
+            
         }
 
         private DataTable rgDTSchema()
@@ -293,7 +113,7 @@ namespace DBADash
         {
             DataTable dtRG = rgDTSchema();
             bool reconfigError = false;
-            using (var cn = new Microsoft.Data.SqlClient.SqlConnection(masterConnectionString))
+            using (var cn = new Microsoft.Data.SqlClient.SqlConnection(MasterConnectionString))
             {
                 var instance = new Microsoft.SqlServer.Management.Smo.Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn));
                 if (instance.EngineEdition == Edition.EnterpriseOrDeveloper) //  RG is an enterprise only edition feature
@@ -302,7 +122,7 @@ namespace DBADash
                     // Script RG configuration
                     var sc = rg.Script();
                     // Add classifier function script
-                    sc.Insert(0,ObjectDDL(masterConnectionString, rg.ClassifierFunction));
+                    sc.Insert(0,ObjectDDL(MasterConnectionString, rg.ClassifierFunction));
 
                     // Script out resource pool configuration and workload groups
                     foreach (ResourcePool pool in rg.ResourcePools)
@@ -347,7 +167,7 @@ namespace DBADash
                     row["reconfiguration_error"] = reconfigError;
                     row["reconfiguration_pending"] = rg.ReconfigurePending;
                     row["max_outstanding_io_per_volume"] =rg.ServerVersion.Major >=12 ? rg.MaxOutstandingIOPerVolume : 0; // Supported 2014 and later
-                    row["script"] = stringCollectionToString(sc);
+                    row["script"] = StringCollectionToString(sc);
                     dtRG.Rows.Add(row);
                     
                 }
@@ -370,7 +190,7 @@ namespace DBADash
         public DataTable SnapshotDB(string DBName)
         {
 
-            using (var cn = new Microsoft.Data.SqlClient.SqlConnection(_connectionString))
+            using (var cn = new Microsoft.Data.SqlClient.SqlConnection(ConnectionString))
             using (var opSS = Operation.Begin("Schema snapshot {DBame}", DBName))
             {
                 DataTable dtSchema = new DataTable("Schema_" + DBName);
@@ -393,7 +213,7 @@ namespace DBADash
                 {
                     if (options.ObjectTypes.Contains(SchemaSnapshotDBObjectTypes.Database))
                     {
-                        sDDL = stringCollectionToString(db.Script(ScriptingOptions));
+                        sDDL = StringCollectionToString(db.Script(ScriptingOptions));
                         bDDL = Zip(sDDL);
                         r = dtSchema.NewRow();
                         r["ObjectName"] = "Database";
@@ -401,7 +221,7 @@ namespace DBADash
                         r["ObjectType"] = "DB";
                         r["object_id"] = 0;
                         r["DDL"] = bDDL;
-                        r["DDLHash"] = computeHash(bDDL);
+                        r["DDLHash"] = ComputeHash(bDDL);
                         r["ObjectDateCreated"] = db.CreateDate;
                         r["ObjectDateModified"] = DBNull.Value;
                         dtSchema.Rows.Add(r);
@@ -568,14 +388,14 @@ namespace DBADash
                 if (!q.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(q.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(q.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = q.Name;
                     r["SchemaName"] = q.Schema;
                     r["ObjectType"] = "SQ";
                     r["object_id"] = q.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = q.CreateDate;
                     r["ObjectDateModified"] = q.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -584,14 +404,14 @@ namespace DBADash
             foreach (ServiceRoute rt in db.ServiceBroker.Routes)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(rt.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(rt.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = rt.Name;
                 r["SchemaName"] = "";
                 r["ObjectType"] = "SBR";
                 r["object_id"] = rt.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = "1900-01-01";
                 r["ObjectDateModified"] = "1900-01-01";
                 dtSchema.Rows.Add(r);
@@ -601,14 +421,14 @@ namespace DBADash
                 if (!m.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(m.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(m.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = m.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "SBM";
                     r["object_id"] = m.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = "1900-01-01";
                     r["ObjectDateModified"] = "1900-01-01";
                     dtSchema.Rows.Add(r);
@@ -619,14 +439,14 @@ namespace DBADash
                 if (!s.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(s.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(s.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = s.Name;
                     r["SchemaName"] = s.QueueSchema;
                     r["ObjectType"] = "SBS";
                     r["object_id"] = s.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = "1900-01-01";
                     r["ObjectDateModified"] = "1900-01-01";
                     dtSchema.Rows.Add(r);
@@ -637,14 +457,14 @@ namespace DBADash
                 if (!c.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(c.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(c.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = c.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "SBC";
                     r["object_id"] = c.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = "1900-01-01";
                     r["ObjectDateModified"] = "1900-01-01";
                     dtSchema.Rows.Add(r);
@@ -653,14 +473,14 @@ namespace DBADash
             foreach (RemoteServiceBinding b in db.ServiceBroker.RemoteServiceBindings)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(b.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(b.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = b.Name;
                 r["SchemaName"] = "";
                 r["ObjectType"] = "SBB";
                 r["object_id"] = b.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = "1900-01-01";
                 r["ObjectDateModified"] = "1900-01-01";
                 dtSchema.Rows.Add(r);
@@ -670,14 +490,14 @@ namespace DBADash
                 foreach (BrokerPriority p in db.ServiceBroker.Priorities)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(p.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(p.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = p.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "SBP";
                     r["object_id"] = p.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = "1900-01-01";
                     r["ObjectDateModified"] = "1900-01-01";
                     dtSchema.Rows.Add(r);
@@ -692,14 +512,14 @@ namespace DBADash
                 foreach (Sequence s in db.Sequences)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(s.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(s.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = s.Name;
                     r["SchemaName"] = s.Schema;
                     r["ObjectType"] = "SO";
                     r["object_id"] = s.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = s.CreateDate;
                     r["ObjectDateModified"] = s.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -713,14 +533,14 @@ namespace DBADash
             foreach (ApplicationRole ar in db.ApplicationRoles)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(ar.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(ar.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = ar.Name;
                 r["SchemaName"] = "";
                 r["ObjectType"] = "ARO";
                 r["object_id"] = ar.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = ar.CreateDate;
                 r["ObjectDateModified"] = ar.DateLastModified;
                 dtSchema.Rows.Add(r);
@@ -734,14 +554,14 @@ namespace DBADash
                 if (!u.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(u.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(u.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = u.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "USR";
                     r["object_id"] = u.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = u.CreateDate;
                     r["ObjectDateModified"] = u.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -756,14 +576,14 @@ namespace DBADash
                 if (!dbr.IsFixedRole)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(dbr.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(dbr.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = dbr.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "ROL";
                     r["object_id"] = dbr.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = dbr.CreateDate;
                     r["ObjectDateModified"] = dbr.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -776,14 +596,14 @@ namespace DBADash
             foreach (UserDefinedAggregate a in db.UserDefinedAggregates)
             {  
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(a.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(a.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = a.Name;
                 r["SchemaName"] = a.Schema;
                 r["ObjectType"] = "AF";
                 r["object_id"] = a.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = a.CreateDate;
                 r["ObjectDateModified"] = a.DateLastModified;
                 dtSchema.Rows.Add(r);
@@ -797,14 +617,14 @@ namespace DBADash
                 if (!a.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(a.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(a.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = a.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "CLR";
                     r["object_id"] = a.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = a.CreateDate;
                     r["ObjectDateModified"] = DBNull.Value;
                     dtSchema.Rows.Add(r);
@@ -817,14 +637,14 @@ namespace DBADash
             foreach (XmlSchemaCollection x in db.XmlSchemaCollections)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(x.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(x.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = x.Name;
                 r["SchemaName"] = x.Schema;
                 r["ObjectType"] = "XSC";
                 r["object_id"] = x.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = x.CreateDate;
                 r["ObjectDateModified"] = x.DateLastModified;
                 dtSchema.Rows.Add(r);
@@ -838,14 +658,14 @@ namespace DBADash
                 if (!s.IsSystemObject)
                 {
                     var r = dtSchema.NewRow();
-                    var sDDL = stringCollectionToString(s.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(s.Script(ScriptingOptions));
                     var bDDL = Zip(sDDL);
                     r["ObjectName"] = s.Name;
                     r["SchemaName"] = "";
                     r["ObjectType"] = "SCH";
                     r["object_id"] = s.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = DBNull.Value;
                     r["ObjectDateModified"] = DBNull.Value;
                     dtSchema.Rows.Add(r);
@@ -859,14 +679,14 @@ namespace DBADash
             foreach (Synonym s in db.Synonyms)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(s.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(s.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = s.Name;
                 r["SchemaName"] = s.Schema;
                 r["ObjectType"] = "SN";
                 r["object_id"] = s.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = s.CreateDate;
                 r["ObjectDateModified"] = s.DateLastModified;
                 dtSchema.Rows.Add(r);
@@ -885,7 +705,7 @@ namespace DBADash
                 }
                 else
                 {
-                    sDDL = stringCollectionToString(t.Script(ScriptingOptions));
+                    sDDL = StringCollectionToString(t.Script(ScriptingOptions));
                 }
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = t.Name;
@@ -893,7 +713,7 @@ namespace DBADash
                 r["ObjectType"] = "DTR";
                 r["object_id"] = t.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = t.CreateDate;
                 r["ObjectDateModified"] = t.DateLastModified;
                 dtSchema.Rows.Add(r);
@@ -907,14 +727,14 @@ namespace DBADash
             foreach (UserDefinedTableType t in db.UserDefinedTableTypes)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(t.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(t.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = t.Name;
                 r["SchemaName"] = t.Schema;
                 r["ObjectType"] = "TT";
                 r["object_id"] = t.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = t.CreateDate;
                 r["ObjectDateModified"] = t.DateLastModified;
                 dtSchema.Rows.Add(r);
@@ -926,14 +746,14 @@ namespace DBADash
             foreach (UserDefinedType t in db.UserDefinedTypes)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(t.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(t.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = t.Name;
                 r["SchemaName"] = t.Schema;
                 r["ObjectType"] = "UTY";
                 r["object_id"] = t.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = DBNull.Value;
                 r["ObjectDateModified"] = DBNull.Value;
                 dtSchema.Rows.Add(r);
@@ -946,14 +766,14 @@ namespace DBADash
             foreach (UserDefinedDataType t in db.UserDefinedDataTypes)
             {
                 var r = dtSchema.NewRow();
-                var sDDL = stringCollectionToString(t.Script(ScriptingOptions));
+                var sDDL = StringCollectionToString(t.Script(ScriptingOptions));
                 var bDDL = Zip(sDDL);
                 r["ObjectName"] = t.Name;
                 r["SchemaName"] = t.Schema;
                 r["ObjectType"] = "TYP";
                 r["object_id"] = t.ID;
                 r["DDL"] = bDDL;
-                r["DDLHash"] = computeHash(bDDL);
+                r["DDLHash"] = ComputeHash(bDDL);
                 r["ObjectDateCreated"] = DBNull.Value;
                 r["ObjectDateModified"] = DBNull.Value;
                 dtSchema.Rows.Add(r);
@@ -1013,7 +833,7 @@ namespace DBADash
 
                     r["object_id"] = f.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = f.CreateDate;
                     r["ObjectDateModified"] = f.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -1036,7 +856,7 @@ namespace DBADash
                     }
                     else
                     {
-                        sDDL = stringCollectionToString(v.Script(ScriptingOptions));
+                        sDDL = StringCollectionToString(v.Script(ScriptingOptions));
                     }
                  
                     var bDDL = Zip(sDDL);
@@ -1045,7 +865,7 @@ namespace DBADash
                     r["ObjectType"] = "V";
                     r["object_id"] = v.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = v.CreateDate;
                     r["ObjectDateModified"] = v.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -1086,7 +906,7 @@ namespace DBADash
                     r["SchemaName"] = sp.Schema;
                     r["object_id"] = sp.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = sp.CreateDate;
                     r["ObjectDateModified"] = sp.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -1117,7 +937,7 @@ namespace DBADash
                             }                      
                         }                       
                     }
-                    var sDDL = stringCollectionToString(t.Script(ScriptingOptions));
+                    var sDDL = StringCollectionToString(t.Script(ScriptingOptions));
                     if (hasEncryptedTriggers)
                     {
                         sDDL += Environment.NewLine +  "/* Encrypted Triggers */";
@@ -1128,7 +948,7 @@ namespace DBADash
                     r["ObjectType"] = "U";
                     r["object_id"] = t.ID;
                     r["DDL"] = bDDL;
-                    r["DDLHash"] = computeHash(bDDL);
+                    r["DDLHash"] = ComputeHash(bDDL);
                     r["ObjectDateCreated"] = t.CreateDate;
                     r["ObjectDateModified"] = t.DateLastModified;
                     dtSchema.Rows.Add(r);
@@ -1155,7 +975,7 @@ namespace DBADash
                         }
                         else
                         {
-                            sDDL = stringCollectionToString(t.Script(ScriptingOptions));
+                            sDDL = StringCollectionToString(t.Script(ScriptingOptions));
                         }
                         var bDDL = Zip(sDDL);
                         r["ObjectName"] = t.Name;
@@ -1163,7 +983,7 @@ namespace DBADash
                         r["ObjectType"] = t.ImplementationType == ImplementationType.SqlClr ? "TA" : "TR";
                         r["object_id"] = t.ID;
                         r["DDL"] = bDDL;
-                        r["DDLHash"] = computeHash(bDDL);
+                        r["DDLHash"] = ComputeHash(bDDL);
                         r["ObjectDateCreated"] = t.CreateDate;
                         r["ObjectDateModified"] = t.DateLastModified;
                         dtSchema.Rows.Add(r);
@@ -1173,49 +993,7 @@ namespace DBADash
         }
 
  
-        public static void CopyTo(Stream src, Stream dest)
-        {
-            byte[] bytes = new byte[4096];
 
-            int cnt;
-
-            while ((cnt = src.Read(bytes, 0, bytes.Length)) != 0)
-            {
-                dest.Write(bytes, 0, cnt);
-            }
-        }
-
-        public static byte[] Zip(string str)
-        {
-            var bytes = Encoding.Unicode.GetBytes(str);
-
-            using (var msi = new MemoryStream(bytes))
-            using (var mso = new MemoryStream())
-            {
-                using (var gs = new GZipStream(mso, CompressionMode.Compress))
-                {
-                    //msi.CopyTo(gs);
-                    CopyTo(msi, gs);
-                }
-
-                return mso.ToArray();
-            }
-        }
-
-        public static string Unzip(byte[] bytes)
-        {
-            using (var msi = new MemoryStream(bytes))
-            using (var mso = new MemoryStream())
-            {
-                using (var gs = new GZipStream(msi, CompressionMode.Decompress))
-                {
-                    //gs.CopyTo(mso);
-                    CopyTo(gs, mso);
-                }
-
-                return Encoding.Unicode.GetString(mso.ToArray());
-            }
-        }
 
     }
 }

--- a/DBADash/SqlStrings.cs
+++ b/DBADash/SqlStrings.cs
@@ -80,7 +80,7 @@ namespace DBADash
         public static string TraceFlags { get { return GetSqlString("TraceFlags"); } }
         public static string VLF { get { return GetSqlString("VLF"); } }
         public static string Waits { get { return GetSqlString("Waits"); } }
-
-
+        public static string Jobs { get { return GetSqlString("Jobs"); } }
+        public static string JobSteps { get { return GetSqlString("JobSteps"); } }
     }
 }

--- a/DBADashDB/dbo/Stored Procedures/Jobs_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/Jobs_Upd.sql
@@ -17,6 +17,7 @@ BEGIN
 			DDL
 	FROM @Jobs T
 	WHERE NOT EXISTS(SELECT 1 FROM dbo.DDL WHERE DDL.DDLHash = T.DDLHash)
+	AND DDL IS NOT NULL
 
 	BEGIN TRAN
 
@@ -92,7 +93,7 @@ BEGIN
 		@SnapshotDate,
 		@SnapshotDate
 	FROM @Jobs T
-	JOIN dbo.DDL ON T.DDLHash = DDL.DDLHash
+	LEFT JOIN dbo.DDL ON T.DDLHash = DDL.DDLHash
 	WHERE NOT EXISTS(SELECT 1 FROM dbo.Jobs J WHERE T.job_id = J.job_id AND J.InstanceID = @InstanceID)
 
 	UPDATE J 
@@ -131,7 +132,7 @@ BEGIN
 		SnapshotUpdatedDate = @SnapshotDate
 	FROM dbo.Jobs J
 	JOIN @Jobs T ON T.job_id = J.job_id
-	JOIN dbo.DDL ON T.DDLHash = DDL.DDLHash
+	LEFT JOIN dbo.DDL ON T.DDLHash = DDL.DDLHash
 	WHERE J.InstanceID = @InstanceID
 	AND NOT EXISTS(SELECT J.job_id,
 							J.originating_server,

--- a/DBADashService/SchemaSnapshotJob.cs
+++ b/DBADashService/SchemaSnapshotJob.cs
@@ -25,14 +25,15 @@ namespace DBADashService
             var dsSnapshot = collector.Data;
             var dbs = schemaSnapshotDBs.Split(',');
 
-            var cn = new Microsoft.Data.SqlClient.SqlConnection(connectionString);
-            var ss = new SchemaSnapshotDB(connectionString, SchedulerServiceConfig.Config.SchemaSnapshotOptions);
+            using var cn = new SqlConnection(connectionString);
+            var ss = new SchemaSnapshotDB(cfg.SourceConnection, SchedulerServiceConfig.Config.SchemaSnapshotOptions);
             var instance = new Microsoft.SqlServer.Management.Smo.Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn));
+
             if (instance.ServerType ==  Microsoft.SqlServer.Management.Common.DatabaseEngineType.SqlAzureDatabase && (builder.InitialCatalog == null || builder.InitialCatalog == "master" || builder.InitialCatalog==""))
             {
                 return Task.CompletedTask;
             }
-            Log.Information("DB Snapshots from instance {source}", builder.DataSource);
+            Log.Information("DB Snapshots from instance {source}",cfg.SourceConnection.ConnectionForPrint);
             foreach (Database db in instance.Databases)
             {
                 bool include = false;

--- a/DBADashServiceConfig/ServiceConfig.Designer.cs
+++ b/DBADashServiceConfig/ServiceConfig.Designer.cs
@@ -123,6 +123,7 @@
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.button1 = new System.Windows.Forms.Button();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.chkScriptJobs = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
             this.tab1.SuspendLayout();
             this.tabDest.SuspendLayout();
@@ -772,6 +773,7 @@
             // 
             // tabAddConnectionOther
             // 
+            this.tabAddConnectionOther.Controls.Add(this.chkScriptJobs);
             this.tabAddConnectionOther.Controls.Add(this.chkCollectSessionWaits);
             this.tabAddConnectionOther.Controls.Add(this.pictureBox3);
             this.tabAddConnectionOther.Controls.Add(this.lnkExample);
@@ -1297,6 +1299,19 @@
             this.panel1.Size = new System.Drawing.Size(1137, 64);
             this.panel1.TabIndex = 23;
             // 
+            // chkScriptJobs
+            // 
+            this.chkScriptJobs.AutoSize = true;
+            this.chkScriptJobs.Checked = true;
+            this.chkScriptJobs.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkScriptJobs.Location = new System.Drawing.Point(302, 23);
+            this.chkScriptJobs.Name = "chkScriptJobs";
+            this.chkScriptJobs.Size = new System.Drawing.Size(96, 20);
+            this.chkScriptJobs.TabIndex = 28;
+            this.chkScriptJobs.Text = "Script Jobs";
+            this.toolTip1.SetToolTip(this.chkScriptJobs, "If Jobs collection is enabled, the job definition will be scripted via SMO");
+            this.chkScriptJobs.UseVisualStyleBackColor = true;
+            // 
             // ServiceConfig
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
@@ -1447,6 +1462,7 @@
         private System.Windows.Forms.NumericUpDown numIdentityCollectionThreshold;
         private System.Windows.Forms.CheckBox chkDefaultIdentityCollection;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.CheckBox chkScriptJobs;
     }
 }
 

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -76,7 +76,8 @@ namespace DBADashServiceConfig
                     SlowQueryThresholdMs = chkSlowQueryThreshold.Checked ? (Int32)numSlowQueryThreshold.Value : -1,
                     RunningQueryPlanThreshold = chkCollectPlans.Checked ? new PlanCollectionThreshold() { CountThreshold = int.Parse(txtCountThreshold.Text), CPUThreshold = int.Parse(txtCPUThreshold.Text), DurationThreshold = int.Parse(txtDurationThreshold.Text), MemoryGrantThreshold = int.Parse(txtGrantThreshold.Text) } : null,
                     SchemaSnapshotDBs = schemaSnapshotDBs,
-                    CollectSessionWaits = chkCollectSessionWaits.Checked
+                    CollectSessionWaits = chkCollectSessionWaits.Checked,
+                    ScriptAgentJobs=chkScriptJobs.Checked
                 };
                 bool validated = validateSource(sourceString);
 
@@ -309,6 +310,7 @@ namespace DBADashServiceConfig
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "PlanCollectionDurationThreshold", HeaderText = "Plan Collection Duration Threshold" });
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "PlanCollectionCountThreshold", HeaderText = "Plan Collection Count Threshold" });
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { DataPropertyName = "PlanCollectionMemoryGrantThreshold", HeaderText = "Plan Collection Memory Grant Threshold" });
+            dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "ScriptAgentJobs", HeaderText = "Script Agent Jobs" });
             dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "HasCustomSchedule", HeaderText = "Custom Schedule" });
             dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "Schedule", HeaderText = "Schedule", Text = "Schedule", UseColumnTextForLinkValue = true, LinkColor = DashColors.LinkColor });
             dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "Edit", HeaderText = "Edit", Text = "Edit", UseColumnTextForLinkValue = true, LinkColor = DashColors.LinkColor });
@@ -693,6 +695,7 @@ namespace DBADashServiceConfig
                 chkNoWMI.Checked = src.NoWMI;
                 chkPersistXESession.Checked = src.PersistXESessions;
                 chkSlowQueryThreshold.Checked = (src.SlowQueryThresholdMs != -1);
+                chkScriptJobs.Checked = src.ScriptAgentJobs;
                 if (chkSlowQueryThreshold.Checked)
                 {
                     numSlowQueryThreshold.Value = src.SlowQueryThresholdMs;
@@ -980,6 +983,7 @@ namespace DBADashServiceConfig
             chkCollectPlans.Enabled = isSql;
             grpRunningQueryThreshold.Enabled = isSql && chkCollectPlans.Checked;
             chkNoWMI.Enabled = isSql;
+            chkScriptJobs.Enabled = isSql;
         }
 
 

--- a/DBADashServiceConfig/ServiceConfig.resx
+++ b/DBADashServiceConfig/ServiceConfig.resx
@@ -60,6 +60,30 @@
   <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>172, 17</value>
+  </metadata>
+  <data name="pictureBox2.ToolTip" xml:space="preserve">
+    <value>Click the Connect icon to the right and enter the details of the SQL instance you want to monitor
+Or:
+* Enter the connection string manually.
+* Enter multiple connection strings,  1 per line
+* Enter server name(s), 1 per line
+
+Source can also be a folder or a S3 bucket to import data from remote DBA Dash agents</value>
+  </data>
+  <data name="label10.Text" xml:space="preserve">
+    <value>Connections are required to each AzureDB to capture data for monitoring.  Alternativley, add a connection to the master database and check the option to scan for AzureDBs on service start and/or check the option to scan for new Azure DBs every 'X' seconds.
+
+You can also click "Scan Now" to persist any new connections to the config file. </value>
+  </data>
+  <data name="label12.Text" xml:space="preserve">
+    <value>For normal deployments this section isn't required
+
+Setting the destination connection to a S3 bucket allows you to send data to a repository database that you don't have direct connectivity to.
+Setting the source connection to a S3 bucket allows you to pull data from those remote sources.
+By default the instance profile credentials are used to connect to S3 buckets - if this isn't available you will need to specify a profile to use or the access/secret keys.</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -112,32 +136,5 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD///39yf/9/cH//f0Af/39AH8yMgB/
         Mv0AE/39AAP9/cAALlbAAPX9/gD9/f4A/f3+ADYy/4MyVv+D/f3///39
 </value>
-  </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>172, 17</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>172, 17</value>
-  </metadata>
-  <data name="pictureBox2.ToolTip" xml:space="preserve">
-    <value>Click the Connect icon to the right and enter the details of the SQL instance you want to monitor
-Or:
-* Enter the connection string manually.
-* Enter multiple connection strings,  1 per line
-* Enter server name(s), 1 per line
-
-Source can also be a folder or a S3 bucket to import data from remote DBA Dash agents</value>
-  </data>
-  <data name="label10.Text" xml:space="preserve">
-    <value>Connections are required to each AzureDB to capture data for monitoring.  Alternativley, add a connection to the master database and check the option to scan for AzureDBs on service start and/or check the option to scan for new Azure DBs every 'X' seconds.
-
-You can also click "Scan Now" to persist any new connections to the config file. </value>
-  </data>
-  <data name="label12.Text" xml:space="preserve">
-    <value>For normal deployments this section isn't required
-
-Setting the destination connection to a S3 bucket allows you to send data to a repository database that you don't have direct connectivity to.
-Setting the source connection to a S3 bucket allows you to pull data from those remote sources.
-By default the instance profile credentials are used to connect to S3 buckets - if this isn't available you will need to specify a profile to use or the access/secret keys.</value>
   </data>
 </root>


### PR DESCRIPTION
Improved performance by querying system tables instead of SMO.
Scripting is still via SMO.  Option to disable added.
Change the order of jobs collection to not impact the other collections in the batch.
#298 