### PR TITLE
Fix issue listing databases in Connect dialog

### DIFF
--- a/DBADashSharedGUI/DBConnection.Designer.cs
+++ b/DBADashSharedGUI/DBConnection.Designer.cs
@@ -77,7 +77,7 @@
             this.chkIntegratedSecurity.TabIndex = 2;
             this.chkIntegratedSecurity.Text = "Integrated Security";
             this.chkIntegratedSecurity.UseVisualStyleBackColor = true;
-            this.chkIntegratedSecurity.CheckedChanged += new System.EventHandler(this.chkIntegratedSecurity_CheckedChanged);
+            this.chkIntegratedSecurity.CheckedChanged += new System.EventHandler(this.ChkIntegratedSecurity_CheckedChanged);
             // 
             // pnlAuth
             // 
@@ -136,7 +136,7 @@
             this.bttnConnect.TabIndex = 4;
             this.bttnConnect.Text = "Connect";
             this.bttnConnect.UseVisualStyleBackColor = true;
-            this.bttnConnect.Click += new System.EventHandler(this.bttnConnect_Click);
+            this.bttnConnect.Click += new System.EventHandler(this.BttnConnect_Click);
             // 
             // bttnCancel
             // 
@@ -148,7 +148,7 @@
             this.bttnCancel.TabIndex = 5;
             this.bttnCancel.Text = "Cancel";
             this.bttnCancel.UseVisualStyleBackColor = true;
-            this.bttnCancel.Click += new System.EventHandler(this.bttnCancel_Click);
+            this.bttnCancel.Click += new System.EventHandler(this.BttnCancel_Click);
             // 
             // cboDatabase
             // 
@@ -158,7 +158,7 @@
             this.cboDatabase.Name = "cboDatabase";
             this.cboDatabase.Size = new System.Drawing.Size(358, 28);
             this.cboDatabase.TabIndex = 6;
-            this.cboDatabase.DropDown += new System.EventHandler(this.cboDatabase_Dropdown);
+            this.cboDatabase.DropDown += new System.EventHandler(this.CboDatabase_Dropdown);
             // 
             // lblDatabase
             // 

--- a/DBADashSharedGUI/DBConnection.cs
+++ b/DBADashSharedGUI/DBConnection.cs
@@ -63,38 +63,34 @@ namespace DBADash
             }
         }
 
-        private void chkIntegratedSecurity_CheckedChanged(object sender, EventArgs e)
+        private void ChkIntegratedSecurity_CheckedChanged(object sender, EventArgs e)
         {
             pnlAuth.Enabled = !chkIntegratedSecurity.Checked;
         }
 
-        private void bttnCancel_Click(object sender, EventArgs e)
+        private void BttnCancel_Click(object sender, EventArgs e)
         {
             this.DialogResult = DialogResult.Cancel;
         }
 
-        public void testConnection(string connectionString)
+        public static void TestConnection(string connectionString)
         {
-            SqlConnection cn = new SqlConnection(connectionString);
-            using (cn)
-            {
-                cn.Open();
-            }
-          
+            using var cn = new SqlConnection(connectionString);
+            cn.Open();        
         }
 
-        private void bttnConnect_Click(object sender, EventArgs e)
+        private void BttnConnect_Click(object sender, EventArgs e)
         {
             try
             {
                 this.Cursor = Cursors.WaitCursor;
                 if (ValidateInitialCatalog)
                 {
-                    testConnection(ConnectionString);
+                    TestConnection(ConnectionString);
                 }
                 else
                 {
-                    testConnection(ConnectionStringWithoutInitialCatalog); // Try without initial catalog as DB might not have been created yet
+                    TestConnection(ConnectionStringWithoutInitialCatalog); // Try without initial catalog as DB might not have been created yet
                 }
             }
             catch (Exception ex)
@@ -118,12 +114,12 @@ namespace DBADash
             }
         }
 
-        private void cboDatabase_Dropdown(object sender, EventArgs e)
+        private void CboDatabase_Dropdown(object sender, EventArgs e)
         {
             try
             {
                 cboDatabase.Items.Clear();
-                var DBs = GetDatabases(ConnectionString);
+                var DBs = GetDatabases(ConnectionStringWithoutInitialCatalog);
                 foreach(string db in DBs)
                 {
                     cboDatabase.Items.Add(db);
@@ -137,10 +133,10 @@ namespace DBADash
 
         }
 
-        public List<string> GetDatabases(string ConnectionString)
+        public static List<string> GetDatabases(string ConnectionString)
         {
             using (var cn = new SqlConnection(ConnectionString))
-            using (SqlCommand cmd = new SqlCommand("SELECT name FROM sys.databases WHERE state=0", cn))
+            using (SqlCommand cmd = new("SELECT name FROM sys.databases WHERE state=0", cn))
             {
                 cn.Open();
                 var DBs = new List<string>();


### PR DESCRIPTION
Connect dialog will fail to list databases if the selected database doesn't exist as it uses it as the initial catalog in the connection string to list the DBs. Refactoring
#390