### PR TITLE
Fix rare bug where DBADashAgent_Upd fails to get ID

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/DBADashAgent_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/DBADashAgent_Upd.sql
@@ -25,7 +25,13 @@ BEGIN
 				AND AgentServiceName = @AgentServiceName
 				)
 
-	SET @DBADashAgentID = SCOPE_IDENTITY();
+	/* 
+		Not using SCOPE_IDENTITY as there is potential for no rows to be inserted if two processes attempt the insert
+	*/
+	SELECT @DBADashAgentID = DBADashAgentID
+	FROM dbo.DBADashAgent
+	WHERE AgentHostName = @AgentHostName
+	AND AgentServiceName = @AgentServiceName
 END
 IF @UpdateAgent=1
 BEGIN


### PR DESCRIPTION
In rare circumstances, a null value can be returned for @DBADashAgentID if the row doesn't exist and two threads attempt the insert.  #391