### PR TITLE
Partition switching fix

### DIFF
--- a/DBADashDB/Switch/Tables/JobStats_60MIN.sql
+++ b/DBADashDB/Switch/Tables/JobStats_60MIN.sql
@@ -10,5 +10,5 @@
     [MaxRunDurationSec] INT              NOT NULL,
     [MinRunDurationSec] INT              NOT NULL,
     CONSTRAINT [PK_JobStats_60MIN] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [job_id] ASC, [step_id] ASC, [RunDateTime] ASC)
-) ON PS_JobStats_60MIN(RunDateTime)
+) 
 


### PR DESCRIPTION
Partition switching is failing for JobStats_60MIN as the Switch.JobStats_60MIN is partitioned. This would require a partition number to be specified. Removing the partitioning for Switch.JobStats_60MIN to allow it to work the same as the other tables.

If partition switching failed for a particular table it would prevent the cleanup process from running for other tables. Added some error handling so processing continues. Error thrown at the end of the process.

#410