### PR TITLE
Fix WMI collection bugs on older OS

### DIFF
--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -1455,9 +1455,9 @@ CROSS APPLY sys.dm_exec_sql_text(H.sql_handle) txt");
                 foreach (CimInstance vol in results)
                 {
                     var rDrive = drives.NewRow();
-                    rDrive["FreeSpace"] = (UInt64)vol.CimInstanceProperties["FreeSpace"].Value;
+                    rDrive["FreeSpace"] = Convert.ToInt64(vol.CimInstanceProperties["FreeSpace"].Value);
                     rDrive["Name"] = (string)vol.CimInstanceProperties["Name"].Value;
-                    rDrive["Capacity"] = (UInt64)vol.CimInstanceProperties["Capacity"].Value;
+                    rDrive["Capacity"] = Convert.ToInt64(vol.CimInstanceProperties["Capacity"].Value);
                     rDrive["Label"] = (string)vol.CimInstanceProperties["Label"].Value;
                     drives.Rows.Add(rDrive);
                 }


### PR DESCRIPTION
* Fix drivers collection bug on older OS. Using GetClass with WSMan on older OS will fail. This failure will cause it to switch to use DCom where the driver collection will work.
* Fix error that occurs on older versions of Windows (2008 R2):
Unable to cast object of type 'System.String' to type 'System.UInt64'

Bugs introduced by recent commit and didn't escape into a release. 

#299