### PR TITLE
Fix Progress bar for drives with 0% free space

### DIFF
--- a/DBADashGUI/Drives/Drive.cs
+++ b/DBADashGUI/Drives/Drive.cs
@@ -108,9 +108,9 @@ namespace DBADashGUI
         {
             get
             {
-                if (FreeSpace == 0 || DriveCapacity == 0)
+                if (DriveCapacity == 0)
                 {
-                    return 100;
+                    return 0;
                 }
                 else
                 {


### PR DESCRIPTION
Fix % free space calculation used by drive progress bar.  #422