### PR TITLE
Update .NET SDK in GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.101
+          dotnet-version: 6.0.x
+          dotnet-quality: 'ga'
+      
+      - name: Check SDK version
+        run: dotnet --list-sdks
 
       - name: Build
         run: dotnet build -c CLI

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.101
+          dotnet-version: 6.0.x
+          dotnet-quality: 'ga'
+      
+      - name: Check SDK version
+        run: dotnet --list-sdks
 
       - name: Build
         run: dotnet build -c CLI

--- a/.github/workflows/ci_MininalPermissions.yml
+++ b/.github/workflows/ci_MininalPermissions.yml
@@ -21,7 +21,11 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.101
+          dotnet-version: 6.0.x
+          dotnet-quality: 'ga'
+      
+      - name: Check SDK version
+        run: dotnet --list-sdks
 
       - name: Build
         run: dotnet build -c CLI

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,11 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.101
+          dotnet-version: 6.0.x
+          dotnet-quality: 'ga'
+      
+      - name: Check SDK version
+        run: dotnet --list-sdks
 
       - name: Build
         run: dotnet build -c CLI

--- a/.github/workflows/tag-create-release.yml
+++ b/.github/workflows/tag-create-release.yml
@@ -20,7 +20,11 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.101
+          dotnet-version: 6.0.x
+          dotnet-quality: 'ga'
+      
+      - name: Check SDK version
+        run: dotnet --list-sdks
 
       - name: Build
         run: dotnet build -c CLI


### PR DESCRIPTION
Build with latest version of SDK.  Previously this was set to 6.0.101 due to breaking changes. Backward compatibility was broken with update to actions/setup-dotnet@v3.  Issue is now documented and latest version is preferred.
 #42