### PR TITLE
Fix divide by zero error that can occur loading Summary tab

### DIFF
--- a/DBADashDB/dbo/Views/BackupStats.sql
+++ b/DBADashDB/dbo/Views/BackupStats.sql
@@ -36,7 +36,7 @@ SELECT 		B.DatabaseID,
 			CASE WHEN B.backup_size = B.compressed_backup_size OR B.compressed_backup_size IS NULL THEN CAST(0 AS BIT) ELSE CAST(1 AS BIT) END AS IsCompressed,
 			B.backup_size/POWER(1024.0,3) AS BackupSizeGB,
 			B.compressed_backup_size/POWER(1024.0,3) AS BackupSizeCompressedGB,
-			1.0-((B.compressed_backup_size*1.0)/B.backup_size) AS CompressionSavingPct,
+			1.0-((B.compressed_backup_size*1.0)/NULLIF(B.backup_size,0)) AS CompressionSavingPct,
 			CASE WHEN B.encryptor_type IS NULL THEN CAST(0 AS BIT) ELSE CAST(1 AS BIT) END AS IsEncrypted,
             B.compression_algorithm
 FROM dbo.Backups B

--- a/DBADashDB/dbo/Views/DriveStatus.sql
+++ b/DBADashDB/dbo/Views/DriveStatus.sql
@@ -10,7 +10,7 @@ SELECT I.InstanceID,
 	D.Capacity/POWER(1024.0,3) TotalGB,
 	D.UsedSpace/POWER(1024.0,3) UsedGB,
 	D.FreeSpace/POWER(1024.0,3) FreeGB,
-	D.FreeSpace/CAST(D.Capacity AS DECIMAL) AS PctFreeSpace,
+	D.FreeSpace/CAST(NULLIF(D.Capacity,0) AS DECIMAL) AS PctFreeSpace,
 	DATEDIFF(mi,SSD.SnapshotDate,GETUTCDATE()) AS SnapshotAgeMins,
 	SSD.SnapshotDate,
 	CASE WHEN cdt.WarningThreshold IS NULL AND cdt.CriticalThreshold IS NULL THEN 3 WHEN DATEDIFF(mi,SSD.SnapshotDate,GETUTCDATE()) > cdt.CriticalThreshold THEN 1 WHEN DATEDIFF(mi,SSD.SnapshotDate,GETUTCDATE()) > cdt.WarningThreshold THEN 2 ELSE 4 END AS SnapshotStatus,
@@ -39,9 +39,9 @@ OUTER APPLY(SELECT TOP(1) T.WarningThreshold, T.CriticalThreshold
 			AND T.Reference = 'Drives'
 			ORDER BY T.InstanceID DESC) cdt
 OUTER APPLY(SELECT CASE WHEN cfg.DriveCheckType = '%' 
-		AND FreeSpace/CAST(Capacity AS DECIMAL) < cfg.DriveCriticalThreshold THEN 1
+		AND FreeSpace/CAST(NULLIF(Capacity,0) AS DECIMAL) < cfg.DriveCriticalThreshold THEN 1
 		WHEN cfg.DriveCheckType = '%' 
-		AND FreeSpace/CAST(Capacity AS DECIMAL) < cfg.DriveWarningThreshold THEN 2
+		AND FreeSpace/CAST(NULLIF(Capacity,0) AS DECIMAL) < cfg.DriveWarningThreshold THEN 2
 		WHEN cfg.DriveCheckType = 'G' 
 		AND FreeSpace/POWER(1024.0,3)< cfg.DriveCriticalThreshold THEN 1
 		WHEN cfg.DriveCheckType = 'G' 

--- a/DBADashGUI/Checks/Summary.Designer.cs
+++ b/DBADashGUI/Checks/Summary.Designer.cs
@@ -31,15 +31,40 @@
             this.components = new System.ComponentModel.Container();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dgvSummary = new System.Windows.Forms.DataGridView();
+            this.Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.colShowInSummary = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            this.MemoryDumpStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.CorruptionStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.LastGoodCheckDBStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.AlertStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.FullBackupStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.DiffBackupStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.LogBackupStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.DriveStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.JobStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.LogShippingStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.MirroringStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.AGStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.LogFreeSpaceStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.FileFreeSpaceStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.PctMaxSizeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.ElasticPoolStorageStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.QueryStoreStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.CustomCheckStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.CollectionErrorStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.SnapshotAgeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.DBMailStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.IdentityStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            this.UptimeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.tsRefresh = new System.Windows.Forms.ToolStripButton();
             this.tsCopy = new System.Windows.Forms.ToolStripButton();
@@ -70,31 +95,6 @@
             this.dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
             this.refresh1 = new DBADashGUI.Refresh();
-            this.Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colShowInSummary = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.MemoryDumpStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.CorruptionStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LastGoodCheckDBStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.AlertStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.FullBackupStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.DiffBackupStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.LogBackupStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.DriveStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.JobStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.LogShippingStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.MirroringStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.AGStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.LogFreeSpaceStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.FileFreeSpaceStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.PctMaxSizeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.ElasticPoolStorageStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.QueryStoreStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.CustomCheckStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.CollectionErrorStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.SnapshotAgeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.DBMailStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.IdentityStatus = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.UptimeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dgvSummary)).BeginInit();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -160,274 +160,6 @@
             this.dgvSummary.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvSummary_CellContentClick);
             this.dgvSummary.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DgvSummary_ColumnHeaderMouseClick);
             this.dgvSummary.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvSummary_RowAdded);
-            // 
-            // toolStrip1
-            // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.tsOptions,
-            this.lblRefreshTime});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1800, 27);
-            this.toolStrip1.TabIndex = 1;
-            this.toolStrip1.Text = "toolStrip1";
-            // 
-            // tsRefresh
-            // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
-            // 
-            // tsCopy
-            // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
-            // 
-            // tsExcel
-            // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
-            // 
-            // tsOptions
-            // 
-            this.tsOptions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsOptions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.focusedViewToolStripMenuItem,
-            this.memoryDumpsToolStripMenuItem,
-            this.showHiddenToolStripMenuItem});
-            this.tsOptions.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
-            this.tsOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsOptions.Name = "tsOptions";
-            this.tsOptions.Size = new System.Drawing.Size(34, 24);
-            this.tsOptions.Text = "Options";
-            // 
-            // focusedViewToolStripMenuItem
-            // 
-            this.focusedViewToolStripMenuItem.CheckOnClick = true;
-            this.focusedViewToolStripMenuItem.Name = "focusedViewToolStripMenuItem";
-            this.focusedViewToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
-            this.focusedViewToolStripMenuItem.Text = "Focused View";
-            this.focusedViewToolStripMenuItem.ToolTipText = "Show only instances and checks that are warning or critical status";
-            this.focusedViewToolStripMenuItem.Click += new System.EventHandler(this.FocusedViewToolStripMenuItem_Click);
-            // 
-            // memoryDumpsToolStripMenuItem
-            // 
-            this.memoryDumpsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.acknowledgeDumpsToolStripMenuItem,
-            this.configureThresholdsToolStripMenuItem});
-            this.memoryDumpsToolStripMenuItem.Name = "memoryDumpsToolStripMenuItem";
-            this.memoryDumpsToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
-            this.memoryDumpsToolStripMenuItem.Text = "Memory Dumps";
-            // 
-            // acknowledgeDumpsToolStripMenuItem
-            // 
-            this.acknowledgeDumpsToolStripMenuItem.Name = "acknowledgeDumpsToolStripMenuItem";
-            this.acknowledgeDumpsToolStripMenuItem.Size = new System.Drawing.Size(233, 26);
-            this.acknowledgeDumpsToolStripMenuItem.Text = "Acknowledge Dumps";
-            this.acknowledgeDumpsToolStripMenuItem.Click += new System.EventHandler(this.AcknowledgeDumpsToolStripMenuItem_Click);
-            // 
-            // configureThresholdsToolStripMenuItem
-            // 
-            this.configureThresholdsToolStripMenuItem.Name = "configureThresholdsToolStripMenuItem";
-            this.configureThresholdsToolStripMenuItem.Size = new System.Drawing.Size(233, 26);
-            this.configureThresholdsToolStripMenuItem.Text = "Configure Thresholds";
-            this.configureThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureThresholdsToolStripMenuItem_Click);
-            // 
-            // showHiddenToolStripMenuItem
-            // 
-            this.showHiddenToolStripMenuItem.CheckOnClick = true;
-            this.showHiddenToolStripMenuItem.Name = "showHiddenToolStripMenuItem";
-            this.showHiddenToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
-            this.showHiddenToolStripMenuItem.Text = "Show Hidden";
-            this.showHiddenToolStripMenuItem.Click += new System.EventHandler(this.TsRefresh_Click);
-            // 
-            // lblRefreshTime
-            // 
-            this.lblRefreshTime.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.lblRefreshTime.Name = "lblRefreshTime";
-            this.lblRefreshTime.Size = new System.Drawing.Size(98, 24);
-            this.lblRefreshTime.Text = "Refresh Time:";
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 90;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.HeaderText = "Memory Dump";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 128;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "DetectedCorruptionDate ";
-            this.dataGridViewTextBoxColumn3.HeaderText = "Corruption";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 103;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.HeaderText = "Last Good Check DB";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 137;
-            // 
-            // dataGridViewTextBoxColumn5
-            // 
-            dataGridViewCellStyle8.NullValue = "View";
-            this.dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle8;
-            this.dataGridViewTextBoxColumn5.HeaderText = "Alerts";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.dataGridViewTextBoxColumn5.Width = 73;
-            // 
-            // dataGridViewTextBoxColumn6
-            // 
-            dataGridViewCellStyle9.NullValue = "View";
-            this.dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle9;
-            this.dataGridViewTextBoxColumn6.HeaderText = "Full Backup";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            this.dataGridViewTextBoxColumn6.Width = 101;
-            // 
-            // dataGridViewTextBoxColumn7
-            // 
-            dataGridViewCellStyle10.NullValue = "View";
-            this.dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle10;
-            this.dataGridViewTextBoxColumn7.HeaderText = "Diff Backup";
-            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            this.dataGridViewTextBoxColumn7.ReadOnly = true;
-            this.dataGridViewTextBoxColumn7.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn8
-            // 
-            this.dataGridViewTextBoxColumn8.HeaderText = "Log Backup";
-            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            this.dataGridViewTextBoxColumn8.ReadOnly = true;
-            this.dataGridViewTextBoxColumn8.Width = 103;
-            // 
-            // dataGridViewTextBoxColumn9
-            // 
-            this.dataGridViewTextBoxColumn9.HeaderText = "Log Shipping";
-            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            this.dataGridViewTextBoxColumn9.ReadOnly = true;
-            this.dataGridViewTextBoxColumn9.Width = 110;
-            // 
-            // dataGridViewTextBoxColumn10
-            // 
-            this.dataGridViewTextBoxColumn10.HeaderText = "Drive Space";
-            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            this.dataGridViewTextBoxColumn10.ReadOnly = true;
-            this.dataGridViewTextBoxColumn10.Width = 105;
-            // 
-            // dataGridViewTextBoxColumn11
-            // 
-            this.dataGridViewTextBoxColumn11.HeaderText = "Agent Jobs";
-            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            this.dataGridViewTextBoxColumn11.ReadOnly = true;
-            this.dataGridViewTextBoxColumn11.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn12
-            // 
-            this.dataGridViewTextBoxColumn12.HeaderText = "Availability Groups";
-            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            this.dataGridViewTextBoxColumn12.ReadOnly = true;
-            this.dataGridViewTextBoxColumn12.Width = 141;
-            // 
-            // dataGridViewTextBoxColumn13
-            // 
-            this.dataGridViewTextBoxColumn13.HeaderText = "File FreeSpace";
-            this.dataGridViewTextBoxColumn13.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
-            this.dataGridViewTextBoxColumn13.ReadOnly = true;
-            this.dataGridViewTextBoxColumn13.Width = 121;
-            // 
-            // dataGridViewTextBoxColumn14
-            // 
-            this.dataGridViewTextBoxColumn14.HeaderText = "Custom Checks";
-            this.dataGridViewTextBoxColumn14.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
-            this.dataGridViewTextBoxColumn14.ReadOnly = true;
-            this.dataGridViewTextBoxColumn14.Width = 123;
-            // 
-            // dataGridViewTextBoxColumn15
-            // 
-            this.dataGridViewTextBoxColumn15.HeaderText = "DBADash Errors";
-            this.dataGridViewTextBoxColumn15.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
-            this.dataGridViewTextBoxColumn15.ReadOnly = true;
-            this.dataGridViewTextBoxColumn15.Width = 141;
-            // 
-            // dataGridViewTextBoxColumn16
-            // 
-            this.dataGridViewTextBoxColumn16.HeaderText = "Snapshot Age";
-            this.dataGridViewTextBoxColumn16.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
-            this.dataGridViewTextBoxColumn16.ReadOnly = true;
-            this.dataGridViewTextBoxColumn16.Width = 116;
-            // 
-            // dataGridViewTextBoxColumn17
-            // 
-            this.dataGridViewTextBoxColumn17.HeaderText = "Instance Uptime";
-            this.dataGridViewTextBoxColumn17.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
-            this.dataGridViewTextBoxColumn17.Width = 127;
-            // 
-            // timer1
-            // 
-            this.timer1.Enabled = true;
-            this.timer1.Interval = 10000;
-            this.timer1.Tick += new System.EventHandler(this.Timer1_Tick);
-            // 
-            // refresh1
-            // 
-            this.refresh1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(99)))), ((int)(((byte)(163)))));
-            this.refresh1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.refresh1.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.refresh1.ForeColor = System.Drawing.Color.White;
-            this.refresh1.Location = new System.Drawing.Point(0, 0);
-            this.refresh1.Margin = new System.Windows.Forms.Padding(4);
-            this.refresh1.Name = "refresh1";
-            this.refresh1.Size = new System.Drawing.Size(1800, 266);
-            this.refresh1.TabIndex = 2;
             // 
             // Instance
             // 
@@ -713,13 +445,281 @@
             this.UptimeStatus.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             this.UptimeStatus.Width = 127;
             // 
+            // toolStrip1
+            // 
+            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.tsRefresh,
+            this.tsCopy,
+            this.tsExcel,
+            this.tsOptions,
+            this.lblRefreshTime});
+            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.Size = new System.Drawing.Size(1800, 27);
+            this.toolStrip1.TabIndex = 1;
+            this.toolStrip1.Text = "toolStrip1";
+            // 
+            // tsRefresh
+            // 
+            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsRefresh.Name = "tsRefresh";
+            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
+            this.tsRefresh.Text = "Refresh";
+            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            // 
+            // tsCopy
+            // 
+            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
+            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsCopy.Name = "tsCopy";
+            this.tsCopy.Size = new System.Drawing.Size(29, 24);
+            this.tsCopy.Text = "Copy";
+            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            // 
+            // tsExcel
+            // 
+            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
+            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsExcel.Name = "tsExcel";
+            this.tsExcel.Size = new System.Drawing.Size(29, 24);
+            this.tsExcel.Text = "Export Excel";
+            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            // 
+            // tsOptions
+            // 
+            this.tsOptions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.tsOptions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.focusedViewToolStripMenuItem,
+            this.memoryDumpsToolStripMenuItem,
+            this.showHiddenToolStripMenuItem});
+            this.tsOptions.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
+            this.tsOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.tsOptions.Name = "tsOptions";
+            this.tsOptions.Size = new System.Drawing.Size(34, 24);
+            this.tsOptions.Text = "Options";
+            // 
+            // focusedViewToolStripMenuItem
+            // 
+            this.focusedViewToolStripMenuItem.CheckOnClick = true;
+            this.focusedViewToolStripMenuItem.Name = "focusedViewToolStripMenuItem";
+            this.focusedViewToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
+            this.focusedViewToolStripMenuItem.Text = "Focused View";
+            this.focusedViewToolStripMenuItem.ToolTipText = "Show only instances and checks that are warning or critical status";
+            this.focusedViewToolStripMenuItem.Click += new System.EventHandler(this.FocusedViewToolStripMenuItem_Click);
+            // 
+            // memoryDumpsToolStripMenuItem
+            // 
+            this.memoryDumpsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.acknowledgeDumpsToolStripMenuItem,
+            this.configureThresholdsToolStripMenuItem});
+            this.memoryDumpsToolStripMenuItem.Name = "memoryDumpsToolStripMenuItem";
+            this.memoryDumpsToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
+            this.memoryDumpsToolStripMenuItem.Text = "Memory Dumps";
+            // 
+            // acknowledgeDumpsToolStripMenuItem
+            // 
+            this.acknowledgeDumpsToolStripMenuItem.Name = "acknowledgeDumpsToolStripMenuItem";
+            this.acknowledgeDumpsToolStripMenuItem.Size = new System.Drawing.Size(233, 26);
+            this.acknowledgeDumpsToolStripMenuItem.Text = "Acknowledge Dumps";
+            this.acknowledgeDumpsToolStripMenuItem.Click += new System.EventHandler(this.AcknowledgeDumpsToolStripMenuItem_Click);
+            // 
+            // configureThresholdsToolStripMenuItem
+            // 
+            this.configureThresholdsToolStripMenuItem.Name = "configureThresholdsToolStripMenuItem";
+            this.configureThresholdsToolStripMenuItem.Size = new System.Drawing.Size(233, 26);
+            this.configureThresholdsToolStripMenuItem.Text = "Configure Thresholds";
+            this.configureThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureThresholdsToolStripMenuItem_Click);
+            // 
+            // showHiddenToolStripMenuItem
+            // 
+            this.showHiddenToolStripMenuItem.CheckOnClick = true;
+            this.showHiddenToolStripMenuItem.Name = "showHiddenToolStripMenuItem";
+            this.showHiddenToolStripMenuItem.Size = new System.Drawing.Size(198, 26);
+            this.showHiddenToolStripMenuItem.Text = "Show Hidden";
+            this.showHiddenToolStripMenuItem.Click += new System.EventHandler(this.TsRefresh_Click);
+            // 
+            // lblRefreshTime
+            // 
+            this.lblRefreshTime.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.lblRefreshTime.Name = "lblRefreshTime";
+            this.lblRefreshTime.Size = new System.Drawing.Size(98, 24);
+            this.lblRefreshTime.Text = "Refresh Time:";
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            this.dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
+            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            this.dataGridViewTextBoxColumn1.ReadOnly = true;
+            this.dataGridViewTextBoxColumn1.Width = 90;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            this.dataGridViewTextBoxColumn2.HeaderText = "Memory Dump";
+            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            this.dataGridViewTextBoxColumn2.ReadOnly = true;
+            this.dataGridViewTextBoxColumn2.Width = 128;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            this.dataGridViewTextBoxColumn3.DataPropertyName = "DetectedCorruptionDate ";
+            this.dataGridViewTextBoxColumn3.HeaderText = "Corruption";
+            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            this.dataGridViewTextBoxColumn3.ReadOnly = true;
+            this.dataGridViewTextBoxColumn3.Width = 103;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            this.dataGridViewTextBoxColumn4.HeaderText = "Last Good Check DB";
+            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            this.dataGridViewTextBoxColumn4.ReadOnly = true;
+            this.dataGridViewTextBoxColumn4.Width = 137;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            dataGridViewCellStyle8.NullValue = "View";
+            this.dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle8;
+            this.dataGridViewTextBoxColumn5.HeaderText = "Alerts";
+            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            this.dataGridViewTextBoxColumn5.ReadOnly = true;
+            this.dataGridViewTextBoxColumn5.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.dataGridViewTextBoxColumn5.Width = 73;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            dataGridViewCellStyle9.NullValue = "View";
+            this.dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle9;
+            this.dataGridViewTextBoxColumn6.HeaderText = "Full Backup";
+            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            this.dataGridViewTextBoxColumn6.ReadOnly = true;
+            this.dataGridViewTextBoxColumn6.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            this.dataGridViewTextBoxColumn6.Width = 101;
+            // 
+            // dataGridViewTextBoxColumn7
+            // 
+            dataGridViewCellStyle10.NullValue = "View";
+            this.dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle10;
+            this.dataGridViewTextBoxColumn7.HeaderText = "Diff Backup";
+            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            this.dataGridViewTextBoxColumn7.ReadOnly = true;
+            this.dataGridViewTextBoxColumn7.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn8
+            // 
+            this.dataGridViewTextBoxColumn8.HeaderText = "Log Backup";
+            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            this.dataGridViewTextBoxColumn8.ReadOnly = true;
+            this.dataGridViewTextBoxColumn8.Width = 103;
+            // 
+            // dataGridViewTextBoxColumn9
+            // 
+            this.dataGridViewTextBoxColumn9.HeaderText = "Log Shipping";
+            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            this.dataGridViewTextBoxColumn9.ReadOnly = true;
+            this.dataGridViewTextBoxColumn9.Width = 110;
+            // 
+            // dataGridViewTextBoxColumn10
+            // 
+            this.dataGridViewTextBoxColumn10.HeaderText = "Drive Space";
+            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            this.dataGridViewTextBoxColumn10.ReadOnly = true;
+            this.dataGridViewTextBoxColumn10.Width = 105;
+            // 
+            // dataGridViewTextBoxColumn11
+            // 
+            this.dataGridViewTextBoxColumn11.HeaderText = "Agent Jobs";
+            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            this.dataGridViewTextBoxColumn11.ReadOnly = true;
+            this.dataGridViewTextBoxColumn11.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn12
+            // 
+            this.dataGridViewTextBoxColumn12.HeaderText = "Availability Groups";
+            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            this.dataGridViewTextBoxColumn12.ReadOnly = true;
+            this.dataGridViewTextBoxColumn12.Width = 141;
+            // 
+            // dataGridViewTextBoxColumn13
+            // 
+            this.dataGridViewTextBoxColumn13.HeaderText = "File FreeSpace";
+            this.dataGridViewTextBoxColumn13.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
+            this.dataGridViewTextBoxColumn13.ReadOnly = true;
+            this.dataGridViewTextBoxColumn13.Width = 121;
+            // 
+            // dataGridViewTextBoxColumn14
+            // 
+            this.dataGridViewTextBoxColumn14.HeaderText = "Custom Checks";
+            this.dataGridViewTextBoxColumn14.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
+            this.dataGridViewTextBoxColumn14.ReadOnly = true;
+            this.dataGridViewTextBoxColumn14.Width = 123;
+            // 
+            // dataGridViewTextBoxColumn15
+            // 
+            this.dataGridViewTextBoxColumn15.HeaderText = "DBADash Errors";
+            this.dataGridViewTextBoxColumn15.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
+            this.dataGridViewTextBoxColumn15.ReadOnly = true;
+            this.dataGridViewTextBoxColumn15.Width = 141;
+            // 
+            // dataGridViewTextBoxColumn16
+            // 
+            this.dataGridViewTextBoxColumn16.HeaderText = "Snapshot Age";
+            this.dataGridViewTextBoxColumn16.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
+            this.dataGridViewTextBoxColumn16.ReadOnly = true;
+            this.dataGridViewTextBoxColumn16.Width = 116;
+            // 
+            // dataGridViewTextBoxColumn17
+            // 
+            this.dataGridViewTextBoxColumn17.HeaderText = "Instance Uptime";
+            this.dataGridViewTextBoxColumn17.MinimumWidth = 6;
+            this.dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
+            this.dataGridViewTextBoxColumn17.Width = 127;
+            // 
+            // timer1
+            // 
+            this.timer1.Enabled = true;
+            this.timer1.Interval = 10000;
+            this.timer1.Tick += new System.EventHandler(this.Timer1_Tick);
+            // 
+            // refresh1
+            // 
+            this.refresh1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(99)))), ((int)(((byte)(163)))));
+            this.refresh1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.refresh1.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.refresh1.ForeColor = System.Drawing.Color.White;
+            this.refresh1.Location = new System.Drawing.Point(0, 27);
+            this.refresh1.Margin = new System.Windows.Forms.Padding(4);
+            this.refresh1.Name = "refresh1";
+            this.refresh1.Size = new System.Drawing.Size(1800, 239);
+            this.refresh1.TabIndex = 2;
+            // 
             // Summary
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.dgvSummary);
-            this.Controls.Add(this.toolStrip1);
             this.Controls.Add(this.refresh1);
+            this.Controls.Add(this.toolStrip1);
             this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "Summary";
             this.Size = new System.Drawing.Size(1800, 266);

--- a/DBADashGUI/Checks/Summary.cs
+++ b/DBADashGUI/Checks/Summary.cs
@@ -87,11 +87,16 @@ namespace DBADashGUI
         {
             dgvSummary.Columns[0].Frozen = Common.FreezeKeyColumn;
             ResetStatusCols();
-            refresh1.Visible = true;
+            refresh1.ShowRefresh();
             dgvSummary.Visible = false;
             refreshInstanceIDs = new List<int>(InstanceIDs);
             GetSummaryAsync().ContinueWith(task =>
             {
+                if (task.Exception != null)
+                {
+                    refresh1.SetFailed("Error:" + task.Exception.ToString());
+                    return;
+                }
                 DataTable dt = task.Result;
                 dgvSummary.AutoGenerateColumns = false;
                 var cols = (statusColumns.Keys).ToList<string>();

--- a/DBADashGUI/Performance/SlowQueries.cs
+++ b/DBADashGUI/Performance/SlowQueries.cs
@@ -314,14 +314,14 @@ namespace DBADashGUI
             ToggleSummary(true);
 
             dgvSummary.Visible = false;
-            refresh1.Show();
+            refresh1.ShowRefresh();
             GetSlowQueriesSummary().ContinueWith(task =>
             {
                 try
                 {
                     var dt = task.Result;
                     FormatTop(dt.Rows.Count);
-                    refresh1.Invoke(() => refresh1.Visible = false);
+                    refresh1.Invoke(() => refresh1.HideRefresh());
                     dgvSummary.Invoke(() =>
                     {
                         dgvSummary.AutoGenerateColumns = false;

--- a/DBADashGUI/Refresh.Designer.cs
+++ b/DBADashGUI/Refresh.Designer.cs
@@ -31,6 +31,7 @@
             this.components = new System.ComponentModel.Container();
             this.lblRefresh = new System.Windows.Forms.Label();
             this.timer1 = new System.Windows.Forms.Timer(this.components);
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // lblRefresh
@@ -43,11 +44,12 @@
             this.lblRefresh.TabIndex = 0;
             this.lblRefresh.Text = "Refresh in progress";
             this.lblRefresh.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.toolTip1.SetToolTip(this.lblRefresh, "Double click to copy text");
             // 
             // timer1
             // 
             this.timer1.Interval = 500;
-            this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
+            this.timer1.Tick += new System.EventHandler(this.Timer1_Tick);
             // 
             // Refresh
             // 
@@ -55,7 +57,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.lblRefresh);
             this.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "Refresh";
             this.Size = new System.Drawing.Size(188, 188);
             this.VisibleChanged += new System.EventHandler(this.Refresh_VisibilityChanged);
@@ -67,5 +69,6 @@
 
         private System.Windows.Forms.Label lblRefresh;
         private System.Windows.Forms.Timer timer1;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/DBADashGUI/Refresh.cs
+++ b/DBADashGUI/Refresh.cs
@@ -20,7 +20,7 @@ namespace DBADashGUI
             SetStyle(ControlStyles.DoubleBuffer, true);
         }
 
-        private void reset()
+        private void Reset()
         {
             this.BackColor = DashColors.TrimbleBlue;
             this.ForeColor = Color.White;
@@ -28,9 +28,21 @@ namespace DBADashGUI
             timer1.Enabled = this.Visible && Common.IsApplicationRunning;
         }
 
+        public void ShowRefresh()
+        {
+            this.Visible = true;
+            Reset();
+        }
+
+        public void HideRefresh()
+        {
+            timer1.Enabled = false;
+            this.Visible = false;
+        }
+
         private readonly string baseText = "Refresh in progress";
 
-        private void timer1_Tick(object sender, EventArgs e)
+        private void Timer1_Tick(object sender, EventArgs e)
         {
             
             if (lblRefresh.Text.Length > baseText.Length + 20)
@@ -58,7 +70,7 @@ namespace DBADashGUI
 
         private void Refresh_VisibilityChanged(object sender, EventArgs e)
         {
-            reset();                       
+            Reset();                       
         }
     }
 }

--- a/DBADashGUI/Refresh.resx
+++ b/DBADashGUI/Refresh.resx
@@ -57,6 +57,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>118, 17</value>
+  </metadata>
   <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>


### PR DESCRIPTION
Divide by zero can occur if drive capacity is zero.
Fix potential issue if backup_size is zero.
Handle errors on Summary refresh. If an error occurs the refresh screen will now show the error. Previously it would look like the query was still running.
#436