### PR TITLE
Detect incomplete upgrade

### DIFF
--- a/DBADash/Upgrade/Upgrade.cs
+++ b/DBADash/Upgrade/Upgrade.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading.Tasks;
 
@@ -20,6 +21,10 @@ namespace DBADash
         public const string AppURL = "http://dbadash.com";
         public const string AuthorURL = "https://github.com/DavidWiseman";
         public const string ServiceFileName = "DBADashService.exe";
+        public const string UpgradeFile = "DBADash.Upgrade";
+        public const string IncompleteUpgradeMessage = $"Incomplete upgrade of DBA Dash detected.  File '{DBADash.Upgrade.UpgradeFile}' found in directory. Upgrade might have failed due to locked files. More info: https://dbadash.com/upgrades/";
+
+        public static bool IsUpgradeIncomplete => File.Exists(Path.Combine(ApplicationPath, UpgradeFile));
 
         public enum DeploymentTypes
         {
@@ -45,7 +50,7 @@ namespace DBADash
             return Assembly.GetExecutingAssembly().GetName().Version;
         }
 
-        public static async Task UpgradeDBADashAsync(string tag = "", bool startGUI = false, bool startConfig = false,bool noExit=true)
+        public static async Task UpgradeDBADashAsync(string tag = "", bool startGUI = false, bool startConfig = false, bool noExit = true)
         {
             var client = new GitHubClient(new ProductHeaderValue(GITHUB_APP));
             var upgradeScript = await client.Repository.Content.GetRawContentByRef(GITHUB_OWNER, GITHUB_REPO, GITHUB_SCRIPTPATH + GITHUB_UPGRADESCRIPT, GITHUB_BRANCH);
@@ -76,8 +81,7 @@ namespace DBADash
 
         public static string LatestVersionLink => $"https://github.com/{Upgrade.GITHUB_OWNER}/{Upgrade.GITHUB_REPO}/releases/latest";
 
-        public static bool IsAdministrator =>
-            new WindowsPrincipal(WindowsIdentity.GetCurrent())
-                .IsInRole(WindowsBuiltInRole.Administrator);
+        public static bool IsAdministrator => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && new WindowsPrincipal(WindowsIdentity.GetCurrent())
+            .IsInRole(WindowsBuiltInRole.Administrator);
     }
 }

--- a/DBADashConfig/Program.cs
+++ b/DBADashConfig/Program.cs
@@ -10,7 +10,12 @@ static void CommandLineUpgrade()
     try
     {
         var latest = Upgrade.GetLatestVersionAsync().GetAwaiter().GetResult();
-        if (Upgrade.IsUpgradeAvailable(latest))
+        if (Upgrade.IsUpgradeIncomplete)
+        {
+            Log.Warning(Upgrade.IncompleteUpgradeMessage);
+            Log.Information("Upgrade will be attempted");
+        }
+        if (Upgrade.IsUpgradeAvailable(latest) || Upgrade.IsUpgradeIncomplete)
         {
             if (Upgrade.IsAdministrator)
             {
@@ -239,13 +244,10 @@ try
               File.WriteAllText(jsonConfigPath, config.Serialize());
 
               Log.Information("Complete.  Restart the service to apply the config change");
-
           });
-
 }
 catch (Exception ex)
 {
     Log.Error(ex, "Error running DBADashConfig");
     Environment.Exit(1);
 }
-

--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -86,6 +86,8 @@ namespace DBADashGUI
 
         private async void Main_Load(object sender, EventArgs e)
         {
+            await CommonShared.CheckForIncompleteUpgrade();
+            if (Upgrade.IsUpgradeIncomplete) return;
             if (Properties.Settings.Default.SettingsUpgradeRequired)
             {
                 Properties.Settings.Default.Upgrade();
@@ -961,7 +963,7 @@ namespace DBADashGUI
             {
                 DataRetentionForm = new();
                 DataRetentionForm.FormClosed += delegate { DataRetentionForm = null; };
-            }   
+            }
             DataRetentionForm.Show();
             DataRetentionForm.Focus();
         }
@@ -1124,7 +1126,8 @@ namespace DBADashGUI
             {
                 Tags = String.Join(",", SelectedTags())
             };
-            ManageInstancesForm.FormClosing += delegate {
+            ManageInstancesForm.FormClosing += delegate
+            {
                 if (ManageInstancesForm.InstanceActiveFlagChanged || ManageInstancesForm.InstanceSummaryVisibleChanged)
                 {
                     AddInstanes(); // refresh the tree if instances deleted/restored
@@ -1133,7 +1136,7 @@ namespace DBADashGUI
                         summary1.RefreshData();
                     }
                 }
-                ManageInstancesForm = null; 
+                ManageInstancesForm = null;
             };
             ManageInstancesForm.Show();
         }
@@ -1185,7 +1188,7 @@ namespace DBADashGUI
                 SelectedDatabaseA = new DatabaseItem() { DatabaseID = n.DatabaseID, DatabaseName = n.DatabaseName }
             };
             DBDiffForm.FormClosed += delegate { DBDiffForm = null; };
-            DBDiffForm.Show();         
+            DBDiffForm.Show();
         }
 
         private static JobDiff JobDiffForm = null;

--- a/DBADashService/Program.cs
+++ b/DBADashService/Program.cs
@@ -30,6 +30,13 @@ namespace DBADashService
                .Enrich.WithProperty("MachineName", Environment.MachineName)
                .CreateLogger();
 
+            if (DBADash.Upgrade.IsUpgradeIncomplete)
+            {
+                const string message = $"Incomplete upgrade of DBA Dash detected.  File '{DBADash.Upgrade.UpgradeFile}' found in directory. Upgrade might have failed due to locked files. More info: https://dbadash.com/upgrades/";
+                Log.Logger.Error(message);
+                throw new Exception(message);
+            }
+
             var rc = HostFactory.Run(x =>
             {
                 x.Service<ScheduleService>(s =>

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -279,8 +279,10 @@ namespace DBADashServiceConfig
             MessageBox.Show("Config saved.  Restart service to apply changes.", "Save", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
-        private void ServiceConfig_Load(object sender, EventArgs e)
+        private async void ServiceConfig_Load(object sender, EventArgs e)
         {
+            await CommonShared.CheckForIncompleteUpgrade();
+            if (Upgrade.IsUpgradeIncomplete) return;
             dgvConnections.AutoGenerateColumns = false;
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { Name = "ConnectionString", DataPropertyName = "ConnectionString", HeaderText = "Connection String", Width = 300 });
             dgvConnections.Columns.Add(new DataGridViewTextBoxColumn() { Name = "ConnectionID", DataPropertyName = "ConnectionID", HeaderText = "Connection ID", ToolTipText = "The ConnectionID is used to uniquely identify the SQL Instance in the repository database.  The ConnectionID is automatically assigned to @@SERVERNAME but you can override this with a custom value.  If you change the ConnectionID for an existing server it will appear as a new instance in the repository database." });

--- a/DBADashSharedGUI/CommonShared.cs
+++ b/DBADashSharedGUI/CommonShared.cs
@@ -1,4 +1,5 @@
-﻿using DBADashGUI;
+﻿using DBADash;
+using DBADashGUI;
 using System.Diagnostics;
 using System.Runtime.Versioning;
 
@@ -56,5 +57,18 @@ namespace DBADashSharedGUI
             }
         }
 
+        public static async Task CheckForIncompleteUpgrade()
+        {
+            if (!DBADash.Upgrade.IsUpgradeIncomplete) ;
+            MessageBox.Show(DBADash.Upgrade.IncompleteUpgradeMessage, "Error", MessageBoxButtons.OK,
+                MessageBoxIcon.Error);
+            if (MessageBox.Show("Retry upgrade?", "Retry", MessageBoxButtons.YesNo, MessageBoxIcon.Question) ==
+                DialogResult.Yes)
+            {
+                await Upgrade.UpgradeDBADashAsync();
+            }
+
+            Application.Exit();
+        }
     }
 }


### PR DESCRIPTION
If "DBADash.Upgrade" fille exists, the Expand-Archive process failed during the upgrade and the user should be prompted to retry. Update PowerShell upgrade script to add a retry.
#530