### PR TITLE
Set Target Recovery Interval to 60

### DIFF
--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -35,6 +35,7 @@
     <CompatibilityMode>130</CompatibilityMode>
     <TargetFrameworkProfile />
     <AutoUpdateStatisticsAsynchronously>True</AutoUpdateStatisticsAsynchronously>
+    <TargetRecoveryTimePeriod>60</TargetRecoveryTimePeriod>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <BuildScriptName>$(MSBuildProjectName).sql</BuildScriptName>


### PR DESCRIPTION
The default target recovery interval is 60 since 2016.  The setting needs to be included in the dacpac or it will override the default with 0.  
Note: This change will apply to new deployments of DBA Dash.
#530