### PR TITLE
DatabasePermissions collection fix for compatibility level 70

### DIFF
--- a/DBADash/SQL/SQLDatabasePermissions.sql
+++ b/DBADash/SQL/SQLDatabasePermissions.sql
@@ -23,10 +23,11 @@ CREATE TABLE #permissions
 
 
 DECLARE DBs CURSOR FAST_FORWARD READ_ONLY LOCAL FOR
-SELECT name
-FROM sys.databases
-WHERE state  = 0
-AND HAS_DBACCESS(name)=1
+    SELECT name
+    FROM sys.databases
+    WHERE state  = 0
+    AND HAS_DBACCESS(name)=1
+    AND compatibility_level >=80
 
 OPEN DBs
 FETCH NEXT FROM DBs INTO @DBName


### PR DESCRIPTION
Fix "Incorrect syntax near 'Latin1_General_BIN'." error that occurs for databases with compatibility level set to 70 (SQL 7.0).  Issue only possible on SQL 2005 instances. #545