### PR TITLE
Fix SSDT build issue with msbuild 17.5

### DIFF
--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -246,9 +246,13 @@
     <Build Include="Report\Stored Procedures\LogShippingSummary_Get.sql" />
     <Build Include="dbo\Tables\Waits_60MIN.sql" />
     <Build Include="dbo\Views\NonDefaultDBConfig.sql" />
-    <Build Include="dbo\Functions\PartitionBoundaryHelper.sql" />
-    <Build Include="dbo\Stored Procedures\PartitionTable_Cleanup.sql" />
-    <Build Include="dbo\Stored Procedures\Partitions_Add.sql" />
+    <None Include="dbo\Functions\PartitionBoundaryHelper.sql" />
+    <Build Include="dbo\Stored Procedures\PartitionTable_Cleanup.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
+    <Build Include="dbo\Stored Procedures\Partitions_Add.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
     <Build Include="Security\Switch.sql" />
     <Build Include="Switch\Tables\Waits.sql" />
     <Build Include="Switch\Tables\CPU.sql" />
@@ -257,7 +261,9 @@
     <Build Include="Storage\PF_CPU.sql" />
     <Build Include="Storage\PS_Waits.sql" />
     <Build Include="Storage\PS_CPU.sql" />
-    <Build Include="dbo\Stored Procedures\PurgeData.sql" />
+    <Build Include="dbo\Stored Procedures\PurgeData.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
     <Build Include="dbo\Tables\OSLoadedModules.sql" />
     <Build Include="dbo\Tables\DBTuningOptionsHistory.sql" />
     <Build Include="dbo\Tables\DBTuningOptions.sql" />
@@ -409,9 +415,13 @@
     <Build Include="dbo\Tables\CPU_60MIN.sql" />
     <Build Include="dbo\Stored Procedures\DBSpace_Get.sql" />
     <Build Include="Switch\Tables\SlowQueries.sql" />
-    <Build Include="dbo\Functions\PartitionFunctionName.sql" />
-    <Build Include="dbo\Stored Procedures\DataRetention_Upd.sql" />
-    <Build Include="dbo\Stored Procedures\DataRetention_Get.sql" />
+    <None Include="dbo\Functions\PartitionFunctionName.sql" />
+    <Build Include="dbo\Stored Procedures\DataRetention_Upd.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
+    <Build Include="dbo\Stored Procedures\DataRetention_Get.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
     <Build Include="Switch\Tables\AzureDBResourceStats.sql" />
     <Build Include="Switch\Tables\AzureDBElasticPoolResourceStats.sql" />
     <Build Include="dbo\Stored Procedures\DriveSnapshot_Get.sql" />
@@ -566,7 +576,9 @@
     <Build Include="dbo\Stored Procedures\AzureDBResourceGovernance_Upd.sql" />
     <Build Include="dbo\Views\AzureDBResourceGovernance.sql" />
     <Build Include="dbo\Stored Procedures\AzureDBResourceGovernance_Get.sql" />
-    <Build Include="dbo\Stored Procedures\Partitions_Create.sql" />
+    <Build Include="dbo\Stored Procedures\Partitions_Create.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
     <Build Include="dbo\Stored Procedures\QueryPlans_Upd.sql" />
     <Build Include="dbo\Stored Procedures\QueryText_Upd.sql" />
     <Build Include="dbo\Stored Procedures\RunningQueries_Get.sql" />

--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -1,14 +1,9 @@
 ﻿/*
-Post-Deployment Script Template							
---------------------------------------------------------------------------------------
- This file contains SQL statements that will be appended to the build script.		
- Use SQLCMD syntax to include a file in the post-deployment script.			
- Example:      :r .\myfile.sql								
- Use SQLCMD syntax to reference a variable in the post-deployment script.		
- Example:      :setvar TableName MyTable							
-               SELECT * FROM [$(TableName)]					
---------------------------------------------------------------------------------------
+	Post-Deployment section
 */
+:r ."\dbo\Functions\PartitionBoundaryHelper.sql"
+:r ."\dbo\Functions\PartitionFunctionName.sql"
+
 /* Security */
 GRANT SELECT ON SCHEMA::dbo TO App
 GRANT EXECUTE ON SCHEMA::dbo TO App;

--- a/DBADashDB/dbo/Functions/PartitionBoundaryHelper.sql
+++ b/DBADashDB/dbo/Functions/PartitionBoundaryHelper.sql
@@ -1,8 +1,16 @@
-﻿CREATE FUNCTION PartitionBoundaryHelper(@PartitionFunction SYSNAME,@TableName SYSNAME)
+﻿/* 
+	Created in post deployment. See: https://github.com/trimble-oss/dba-dash/issues/554
+*/
+IF OBJECT_ID('dbo.PartitionBoundaryHelper') IS NULL
+BEGIN
+	EXEC sp_executesql N'CREATE FUNCTION dbo.PartitionBoundaryHelper() RETURNS TABLE AS RETURN SELECT 1 a'
+END
+GO
+ALTER FUNCTION dbo.PartitionBoundaryHelper(@PartitionFunction SYSNAME,@TableName SYSNAME)
 RETURNS TABLE
 AS
 RETURN
-SELECT CAST(lbprv.value AS datetime) lb,CAST(ubprv.value AS datetime) ub,p.partition_number,p.rows
+SELECT CAST(lbprv.value AS DATETIME) lb,CAST(ubprv.value AS DATETIME) ub,p.partition_number,p.rows
 FROM sys.partitions p
 LEFT JOIN sys.partition_range_values lbprv 
 	INNER JOIN sys.partition_functions AS lbpf ON  lbpf.function_id = lbprv.function_id 
@@ -14,3 +22,4 @@ LEFT JOIN sys.partition_range_values ubprv
 									ON p.partition_number = ubprv.boundary_id
 where p.object_id = object_id(@TableName)
 AND p.index_id = 1
+GO

--- a/DBADashDB/dbo/Functions/PartitionFunctionName.sql
+++ b/DBADashDB/dbo/Functions/PartitionFunctionName.sql
@@ -1,4 +1,12 @@
-﻿CREATE FUNCTION dbo.PartitionFunctionName(@TableName SYSNAME)
+﻿/* 
+	Created in post deployment. See: https://github.com/trimble-oss/dba-dash/issues/554
+*/
+IF OBJECT_ID('dbo.PartitionFunctionName') IS NULL
+BEGIN
+	EXEC sp_executesql N'CREATE FUNCTION dbo.PartitionFunctionName() RETURNS TABLE AS RETURN SELECT 1 a'
+END
+GO
+ALTER FUNCTION dbo.PartitionFunctionName(@TableName SYSNAME)
 RETURNS TABLE
 AS
 RETURN
@@ -7,3 +15,4 @@ FROM sys.indexes i
 JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
 JOIN sys.partition_functions pf  ON pf.function_id = ps.function_id
 WHERE i.object_id = OBJECT_ID(@TableName);
+GO

--- a/DBADashDB/dbo/Views/IdentityColumnsInfo.sql
+++ b/DBADashDB/dbo/Views/IdentityColumnsInfo.sql
@@ -10,7 +10,7 @@ SELECT	IC.InstanceID,
 		IC.schema_name,
 		IC.object_name,
 		IC.column_name,
-		T.name AS type,
+		TYPE_NAME(IC.system_type_id) AS type,
 		IC.increment_value,
 		IC.seed_value, 
 		IC.row_count,
@@ -38,7 +38,6 @@ SELECT	IC.InstanceID,
 FROM dbo.IdentityColumns IC
 JOIN dbo.Instances I ON I.InstanceID = IC.InstanceID
 JOIN dbo.Databases D ON D.DatabaseID = IC.DatabaseID
-JOIN sys.types T ON T.system_type_id = IC.system_type_id AND T.system_type_id = T.user_type_id
 OUTER APPLY (SELECT CASE WHEN IC.last_value <0 THEN (ABS(IC.min_ident)-ABS(IC.last_value)) / IC.max_rows ELSE IC.last_value/IC.max_ident END AS pct_ident_used,
 					IC.row_count/IC.max_rows AS pct_rows_used,
 					CASE WHEN IC.last_value < 0 THEN ABS(IC.last_value)+IC.max_ident ELSE IC.max_ident - IC.last_value END AS remaining_ident_count,
@@ -54,6 +53,7 @@ OUTER APPLY(SELECT TOP(1) (IC.last_value-ICH.last_value) / (DATEDIFF(s,ICH.Snaps
 			AND ICH.object_id = IC.object_id
 			AND ICH.SnapshotDate < IC.SnapshotDate
 			AND ICH.SnapshotDate > CAST(DATEADD(d,-31,GETUTCDATE()) AS DATETIME2(2))
+			ORDER BY ICH.SnapshotDate
 			) AS PerDay
 OUTER APPLY(SELECT	calc.remaining_ident_count / CASE WHEN PerDay.avg_ident_per_day <=0 THEN NULL ELSE PerDay.avg_ident_per_day END AS ident_estimated_days,
 					calc.remaining_row_count / CASE WHEN PerDay.avg_rows_per_day <=0 THEN NULL ELSE PerDay.avg_rows_per_day END AS row_estimated_days,


### PR DESCRIPTION
Fix issue where msbuild 17.5 fails with error 71501.  
Move PatritionBoundaryHelper & PartitionFunctionName functions to post-deployment.  
Add suppressions for 71502 where needed. 
Remove sys.types from IdentityColumnsInfo view.
Add missing ORDER BY to IdentityColumnsInfo.
#554