### PR TITLE
Summary Page - Instance Uptime

### DIFF
--- a/DBADashGUI/Checks/Summary.Designer.cs
+++ b/DBADashGUI/Checks/Summary.Designer.cs
@@ -31,56 +31,17 @@
             components = new System.ComponentModel.Container();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Summary));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             dgvSummary = new System.Windows.Forms.DataGridView();
-            toolStrip1 = new System.Windows.Forms.ToolStrip();
-            tsRefresh = new System.Windows.Forms.ToolStripButton();
-            tsCopyGrid = new System.Windows.Forms.ToolStripDropDownButton();
-            copySummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            copyTestSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            tsExportToExcel = new System.Windows.Forms.ToolStripDropDownButton();
-            exportSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            exportTestSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            tsOptions = new System.Windows.Forms.ToolStripDropDownButton();
-            focusedViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            showTestSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            lblRefreshTime = new System.Windows.Forms.ToolStripLabel();
-            toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
-            acknowledgeDumpsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            configureThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            tsClearFilter = new System.Windows.Forms.ToolStripButton();
-            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            timer1 = new System.Windows.Forms.Timer(components);
-            refresh1 = new Refresh();
-            splitContainer1 = new System.Windows.Forms.SplitContainer();
-            dgvTests = new System.Windows.Forms.DataGridView();
             Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             colHidden = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             MemoryDumpStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -108,6 +69,48 @@
             IdentityStatus = new System.Windows.Forms.DataGridViewLinkColumn();
             DatabaseStateStatus = new System.Windows.Forms.DataGridViewLinkColumn();
             UptimeStatus = new System.Windows.Forms.DataGridViewLinkColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopyGrid = new System.Windows.Forms.ToolStripDropDownButton();
+            copySummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            copyTestSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsExportToExcel = new System.Windows.Forms.ToolStripDropDownButton();
+            exportSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            exportTestSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsView = new System.Windows.Forms.ToolStripDropDownButton();
+            focusedViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            showTestSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            lblRefreshTime = new System.Windows.Forms.ToolStripLabel();
+            tsOptions = new System.Windows.Forms.ToolStripDropDownButton();
+            memoryDumpsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            acknowledgeDumpsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            configureThresholdsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            instanceUptimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            acknowledgeUptimeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureThresholdsToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            tsClearFilter = new System.Windows.Forms.ToolStripButton();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            timer1 = new System.Windows.Forms.Timer(components);
+            refresh1 = new Refresh();
+            splitContainer1 = new System.Windows.Forms.SplitContainer();
+            dgvTests = new System.Windows.Forms.DataGridView();
             ((System.ComponentModel.ISupportInitialize)dgvSummary).BeginInit();
             toolStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
@@ -153,366 +156,6 @@
             dgvSummary.CellContentClick += DgvSummary_CellContentClick;
             dgvSummary.ColumnHeaderMouseClick += DgvSummary_ColumnHeaderMouseClick;
             dgvSummary.RowsAdded += DgvSummary_RowAdded;
-            // 
-            // toolStrip1
-            // 
-            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopyGrid, tsExportToExcel, tsOptions, lblRefreshTime, toolStripDropDownButton1, tsClearFilter });
-            toolStrip1.Location = new System.Drawing.Point(0, 0);
-            toolStrip1.Name = "toolStrip1";
-            toolStrip1.Size = new System.Drawing.Size(1800, 27);
-            toolStrip1.TabIndex = 1;
-            toolStrip1.Text = "toolStrip1";
-            // 
-            // tsRefresh
-            // 
-            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsRefresh.Name = "tsRefresh";
-            tsRefresh.Size = new System.Drawing.Size(29, 24);
-            tsRefresh.Text = "Refresh";
-            tsRefresh.Click += TsRefresh_Click;
-            // 
-            // tsCopyGrid
-            // 
-            tsCopyGrid.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsCopyGrid.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { copySummaryToolStripMenuItem, copyTestSummaryToolStripMenuItem });
-            tsCopyGrid.Image = Properties.Resources.ASX_Copy_blue_16x;
-            tsCopyGrid.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsCopyGrid.Name = "tsCopyGrid";
-            tsCopyGrid.Size = new System.Drawing.Size(34, 24);
-            tsCopyGrid.Text = "Copy";
-            // 
-            // copySummaryToolStripMenuItem
-            // 
-            copySummaryToolStripMenuItem.Name = "copySummaryToolStripMenuItem";
-            copySummaryToolStripMenuItem.Size = new System.Drawing.Size(222, 26);
-            copySummaryToolStripMenuItem.Text = "Copy Summary";
-            copySummaryToolStripMenuItem.Click += CopySummaryToolStripMenuItem_Click;
-            // 
-            // copyTestSummaryToolStripMenuItem
-            // 
-            copyTestSummaryToolStripMenuItem.Name = "copyTestSummaryToolStripMenuItem";
-            copyTestSummaryToolStripMenuItem.Size = new System.Drawing.Size(222, 26);
-            copyTestSummaryToolStripMenuItem.Text = "Copy Test Summary";
-            copyTestSummaryToolStripMenuItem.Click += CopyTestSummaryToolStripMenuItem_Click;
-            // 
-            // tsExportToExcel
-            // 
-            tsExportToExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsExportToExcel.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { exportSummaryToolStripMenuItem, exportTestSummaryToolStripMenuItem });
-            tsExportToExcel.Image = Properties.Resources.excel16x16;
-            tsExportToExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsExportToExcel.Name = "tsExportToExcel";
-            tsExportToExcel.Size = new System.Drawing.Size(34, 24);
-            tsExportToExcel.Text = "Export to Excel";
-            // 
-            // exportSummaryToolStripMenuItem
-            // 
-            exportSummaryToolStripMenuItem.Name = "exportSummaryToolStripMenuItem";
-            exportSummaryToolStripMenuItem.Size = new System.Drawing.Size(231, 26);
-            exportSummaryToolStripMenuItem.Text = "Export Summary";
-            exportSummaryToolStripMenuItem.Click += ExportSummaryToolStripMenuItem_Click;
-            // 
-            // exportTestSummaryToolStripMenuItem
-            // 
-            exportTestSummaryToolStripMenuItem.Name = "exportTestSummaryToolStripMenuItem";
-            exportTestSummaryToolStripMenuItem.Size = new System.Drawing.Size(231, 26);
-            exportTestSummaryToolStripMenuItem.Text = "Export Test Summary";
-            exportTestSummaryToolStripMenuItem.Click += ExportTestSummaryToolStripMenuItem_Click;
-            // 
-            // tsOptions
-            // 
-            tsOptions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { focusedViewToolStripMenuItem, showTestSummaryToolStripMenuItem, saveToolStripMenuItem });
-            tsOptions.Image = Properties.Resources.Table_16x;
-            tsOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsOptions.Name = "tsOptions";
-            tsOptions.Size = new System.Drawing.Size(75, 24);
-            tsOptions.Text = "View";
-            // 
-            // focusedViewToolStripMenuItem
-            // 
-            focusedViewToolStripMenuItem.CheckOnClick = true;
-            focusedViewToolStripMenuItem.Name = "focusedViewToolStripMenuItem";
-            focusedViewToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            focusedViewToolStripMenuItem.Text = "Focused View";
-            focusedViewToolStripMenuItem.ToolTipText = "Show only instances and checks that are warning or critical status";
-            focusedViewToolStripMenuItem.Click += FocusedViewToolStripMenuItem_Click;
-            // 
-            // showTestSummaryToolStripMenuItem
-            // 
-            showTestSummaryToolStripMenuItem.Checked = true;
-            showTestSummaryToolStripMenuItem.CheckOnClick = true;
-            showTestSummaryToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            showTestSummaryToolStripMenuItem.Name = "showTestSummaryToolStripMenuItem";
-            showTestSummaryToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            showTestSummaryToolStripMenuItem.Text = "Show Test Summary";
-            showTestSummaryToolStripMenuItem.Click += ShowTestSummaryToolStripMenuItem_Click;
-            // 
-            // saveToolStripMenuItem
-            // 
-            saveToolStripMenuItem.Image = Properties.Resources.Save_16x;
-            saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            saveToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            saveToolStripMenuItem.Text = "Save";
-            saveToolStripMenuItem.Click += SaveToolStripMenuItem_Click;
-            // 
-            // lblRefreshTime
-            // 
-            lblRefreshTime.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            lblRefreshTime.Name = "lblRefreshTime";
-            lblRefreshTime.Size = new System.Drawing.Size(98, 24);
-            lblRefreshTime.Text = "Refresh Time:";
-            // 
-            // toolStripDropDownButton1
-            // 
-            toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { acknowledgeDumpsToolStripMenuItem, configureThresholdsToolStripMenuItem });
-            toolStripDropDownButton1.Image = (System.Drawing.Image)resources.GetObject("toolStripDropDownButton1.Image");
-            toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            toolStripDropDownButton1.Name = "toolStripDropDownButton1";
-            toolStripDropDownButton1.Size = new System.Drawing.Size(129, 24);
-            toolStripDropDownButton1.Text = "Memory Dumps";
-            // 
-            // acknowledgeDumpsToolStripMenuItem
-            // 
-            acknowledgeDumpsToolStripMenuItem.Name = "acknowledgeDumpsToolStripMenuItem";
-            acknowledgeDumpsToolStripMenuItem.Size = new System.Drawing.Size(233, 26);
-            acknowledgeDumpsToolStripMenuItem.Text = "Acknowledge Dumps";
-            acknowledgeDumpsToolStripMenuItem.Click += AcknowledgeDumpsToolStripMenuItem_Click;
-            // 
-            // configureThresholdsToolStripMenuItem
-            // 
-            configureThresholdsToolStripMenuItem.Name = "configureThresholdsToolStripMenuItem";
-            configureThresholdsToolStripMenuItem.Size = new System.Drawing.Size(233, 26);
-            configureThresholdsToolStripMenuItem.Text = "Configure Thresholds";
-            configureThresholdsToolStripMenuItem.Click += ConfigureThresholdsToolStripMenuItem_Click;
-            // 
-            // tsClearFilter
-            // 
-            tsClearFilter.Enabled = false;
-            tsClearFilter.Image = Properties.Resources.Eraser_16x;
-            tsClearFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsClearFilter.Name = "tsClearFilter";
-            tsClearFilter.Size = new System.Drawing.Size(104, 24);
-            tsClearFilter.Text = "Clear Filter";
-            tsClearFilter.Click += TsClearFilter_Click;
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
-            dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            dataGridViewTextBoxColumn1.ReadOnly = true;
-            dataGridViewTextBoxColumn1.Width = 90;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            dataGridViewTextBoxColumn2.HeaderText = "Memory Dump";
-            dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            dataGridViewTextBoxColumn2.ReadOnly = true;
-            dataGridViewTextBoxColumn2.Width = 128;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            dataGridViewTextBoxColumn3.DataPropertyName = "DetectedCorruptionDate ";
-            dataGridViewTextBoxColumn3.HeaderText = "Corruption";
-            dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            dataGridViewTextBoxColumn3.ReadOnly = true;
-            dataGridViewTextBoxColumn3.Width = 103;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            dataGridViewTextBoxColumn4.HeaderText = "Last Good Check DB";
-            dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            dataGridViewTextBoxColumn4.ReadOnly = true;
-            dataGridViewTextBoxColumn4.Width = 137;
-            // 
-            // dataGridViewTextBoxColumn5
-            // 
-            dataGridViewCellStyle8.NullValue = "View";
-            dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle8;
-            dataGridViewTextBoxColumn5.HeaderText = "Alerts";
-            dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            dataGridViewTextBoxColumn5.ReadOnly = true;
-            dataGridViewTextBoxColumn5.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            dataGridViewTextBoxColumn5.Width = 73;
-            // 
-            // dataGridViewTextBoxColumn6
-            // 
-            dataGridViewCellStyle9.NullValue = "View";
-            dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle9;
-            dataGridViewTextBoxColumn6.HeaderText = "Full Backup";
-            dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            dataGridViewTextBoxColumn6.ReadOnly = true;
-            dataGridViewTextBoxColumn6.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
-            dataGridViewTextBoxColumn6.Width = 101;
-            // 
-            // dataGridViewTextBoxColumn7
-            // 
-            dataGridViewCellStyle10.NullValue = "View";
-            dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle10;
-            dataGridViewTextBoxColumn7.HeaderText = "Diff Backup";
-            dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            dataGridViewTextBoxColumn7.ReadOnly = true;
-            dataGridViewTextBoxColumn7.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn8
-            // 
-            dataGridViewTextBoxColumn8.HeaderText = "Log Backup";
-            dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            dataGridViewTextBoxColumn8.ReadOnly = true;
-            dataGridViewTextBoxColumn8.Width = 103;
-            // 
-            // dataGridViewTextBoxColumn9
-            // 
-            dataGridViewTextBoxColumn9.HeaderText = "Log Shipping";
-            dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            dataGridViewTextBoxColumn9.ReadOnly = true;
-            dataGridViewTextBoxColumn9.Width = 110;
-            // 
-            // dataGridViewTextBoxColumn10
-            // 
-            dataGridViewTextBoxColumn10.HeaderText = "Drive Space";
-            dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            dataGridViewTextBoxColumn10.ReadOnly = true;
-            dataGridViewTextBoxColumn10.Width = 105;
-            // 
-            // dataGridViewTextBoxColumn11
-            // 
-            dataGridViewTextBoxColumn11.HeaderText = "Agent Jobs";
-            dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            dataGridViewTextBoxColumn11.ReadOnly = true;
-            dataGridViewTextBoxColumn11.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn12
-            // 
-            dataGridViewTextBoxColumn12.HeaderText = "Availability Groups";
-            dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            dataGridViewTextBoxColumn12.ReadOnly = true;
-            dataGridViewTextBoxColumn12.Width = 141;
-            // 
-            // dataGridViewTextBoxColumn13
-            // 
-            dataGridViewTextBoxColumn13.HeaderText = "File FreeSpace";
-            dataGridViewTextBoxColumn13.MinimumWidth = 6;
-            dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
-            dataGridViewTextBoxColumn13.ReadOnly = true;
-            dataGridViewTextBoxColumn13.Width = 121;
-            // 
-            // dataGridViewTextBoxColumn14
-            // 
-            dataGridViewTextBoxColumn14.HeaderText = "Custom Checks";
-            dataGridViewTextBoxColumn14.MinimumWidth = 6;
-            dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
-            dataGridViewTextBoxColumn14.ReadOnly = true;
-            dataGridViewTextBoxColumn14.Width = 123;
-            // 
-            // dataGridViewTextBoxColumn15
-            // 
-            dataGridViewTextBoxColumn15.HeaderText = "DBADash Errors";
-            dataGridViewTextBoxColumn15.MinimumWidth = 6;
-            dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
-            dataGridViewTextBoxColumn15.ReadOnly = true;
-            dataGridViewTextBoxColumn15.Width = 141;
-            // 
-            // dataGridViewTextBoxColumn16
-            // 
-            dataGridViewTextBoxColumn16.HeaderText = "Snapshot Age";
-            dataGridViewTextBoxColumn16.MinimumWidth = 6;
-            dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
-            dataGridViewTextBoxColumn16.ReadOnly = true;
-            dataGridViewTextBoxColumn16.Width = 116;
-            // 
-            // dataGridViewTextBoxColumn17
-            // 
-            dataGridViewTextBoxColumn17.HeaderText = "Instance Uptime";
-            dataGridViewTextBoxColumn17.MinimumWidth = 6;
-            dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
-            dataGridViewTextBoxColumn17.Width = 127;
-            // 
-            // timer1
-            // 
-            timer1.Enabled = true;
-            timer1.Interval = 10000;
-            timer1.Tick += Timer1_Tick;
-            // 
-            // refresh1
-            // 
-            refresh1.BackColor = System.Drawing.Color.FromArgb(0, 99, 163);
-            refresh1.Dock = System.Windows.Forms.DockStyle.Fill;
-            refresh1.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            refresh1.ForeColor = System.Drawing.Color.White;
-            refresh1.Location = new System.Drawing.Point(0, 27);
-            refresh1.Margin = new System.Windows.Forms.Padding(4);
-            refresh1.Name = "refresh1";
-            refresh1.Size = new System.Drawing.Size(1800, 239);
-            refresh1.TabIndex = 2;
-            // 
-            // splitContainer1
-            // 
-            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            splitContainer1.Location = new System.Drawing.Point(0, 27);
-            splitContainer1.Name = "splitContainer1";
-            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer1.Panel1
-            // 
-            splitContainer1.Panel1.Controls.Add(dgvTests);
-            // 
-            // splitContainer1.Panel2
-            // 
-            splitContainer1.Panel2.Controls.Add(dgvSummary);
-            splitContainer1.Size = new System.Drawing.Size(1800, 239);
-            splitContainer1.SplitterDistance = 118;
-            splitContainer1.TabIndex = 3;
-            // 
-            // dgvTests
-            // 
-            dgvTests.AllowUserToAddRows = false;
-            dgvTests.AllowUserToDeleteRows = false;
-            dgvTests.BackgroundColor = System.Drawing.Color.White;
-            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle11.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            dataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            dgvTests.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle11;
-            dgvTests.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle12.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            dataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            dgvTests.DefaultCellStyle = dataGridViewCellStyle12;
-            dgvTests.Dock = System.Windows.Forms.DockStyle.Fill;
-            dgvTests.Location = new System.Drawing.Point(0, 0);
-            dgvTests.Name = "dgvTests";
-            dgvTests.ReadOnly = true;
-            dgvTests.RowHeadersVisible = false;
-            dgvTests.RowHeadersWidth = 51;
-            dgvTests.RowTemplate.Height = 29;
-            dgvTests.Size = new System.Drawing.Size(1800, 118);
-            dgvTests.TabIndex = 0;
-            dgvTests.CellContentClick += DgvTests_CellContentClick;
-            dgvTests.RowsAdded += DgvTests_RowsAdded;
             // 
             // Instance
             // 
@@ -819,6 +462,394 @@
             UptimeStatus.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             UptimeStatus.Width = 110;
             // 
+            // toolStrip1
+            // 
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopyGrid, tsExportToExcel, tsView, lblRefreshTime, tsOptions, tsClearFilter });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(1800, 27);
+            toolStrip1.TabIndex = 1;
+            toolStrip1.Text = "toolStrip1";
+            // 
+            // tsRefresh
+            // 
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
+            // 
+            // tsCopyGrid
+            // 
+            tsCopyGrid.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopyGrid.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { copySummaryToolStripMenuItem, copyTestSummaryToolStripMenuItem });
+            tsCopyGrid.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopyGrid.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopyGrid.Name = "tsCopyGrid";
+            tsCopyGrid.Size = new System.Drawing.Size(34, 24);
+            tsCopyGrid.Text = "Copy";
+            // 
+            // copySummaryToolStripMenuItem
+            // 
+            copySummaryToolStripMenuItem.Name = "copySummaryToolStripMenuItem";
+            copySummaryToolStripMenuItem.Size = new System.Drawing.Size(222, 26);
+            copySummaryToolStripMenuItem.Text = "Copy Summary";
+            copySummaryToolStripMenuItem.Click += CopySummaryToolStripMenuItem_Click;
+            // 
+            // copyTestSummaryToolStripMenuItem
+            // 
+            copyTestSummaryToolStripMenuItem.Name = "copyTestSummaryToolStripMenuItem";
+            copyTestSummaryToolStripMenuItem.Size = new System.Drawing.Size(222, 26);
+            copyTestSummaryToolStripMenuItem.Text = "Copy Test Summary";
+            copyTestSummaryToolStripMenuItem.Click += CopyTestSummaryToolStripMenuItem_Click;
+            // 
+            // tsExportToExcel
+            // 
+            tsExportToExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExportToExcel.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { exportSummaryToolStripMenuItem, exportTestSummaryToolStripMenuItem });
+            tsExportToExcel.Image = Properties.Resources.excel16x16;
+            tsExportToExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExportToExcel.Name = "tsExportToExcel";
+            tsExportToExcel.Size = new System.Drawing.Size(34, 24);
+            tsExportToExcel.Text = "Export to Excel";
+            // 
+            // exportSummaryToolStripMenuItem
+            // 
+            exportSummaryToolStripMenuItem.Name = "exportSummaryToolStripMenuItem";
+            exportSummaryToolStripMenuItem.Size = new System.Drawing.Size(231, 26);
+            exportSummaryToolStripMenuItem.Text = "Export Summary";
+            exportSummaryToolStripMenuItem.Click += ExportSummaryToolStripMenuItem_Click;
+            // 
+            // exportTestSummaryToolStripMenuItem
+            // 
+            exportTestSummaryToolStripMenuItem.Name = "exportTestSummaryToolStripMenuItem";
+            exportTestSummaryToolStripMenuItem.Size = new System.Drawing.Size(231, 26);
+            exportTestSummaryToolStripMenuItem.Text = "Export Test Summary";
+            exportTestSummaryToolStripMenuItem.Click += ExportTestSummaryToolStripMenuItem_Click;
+            // 
+            // tsView
+            // 
+            tsView.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { focusedViewToolStripMenuItem, showTestSummaryToolStripMenuItem, saveToolStripMenuItem });
+            tsView.Image = Properties.Resources.Table_16x;
+            tsView.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsView.Name = "tsView";
+            tsView.Size = new System.Drawing.Size(75, 24);
+            tsView.Text = "View";
+            // 
+            // focusedViewToolStripMenuItem
+            // 
+            focusedViewToolStripMenuItem.CheckOnClick = true;
+            focusedViewToolStripMenuItem.Name = "focusedViewToolStripMenuItem";
+            focusedViewToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            focusedViewToolStripMenuItem.Text = "Focused View";
+            focusedViewToolStripMenuItem.ToolTipText = "Show only instances and checks that are warning or critical status";
+            focusedViewToolStripMenuItem.Click += FocusedViewToolStripMenuItem_Click;
+            // 
+            // showTestSummaryToolStripMenuItem
+            // 
+            showTestSummaryToolStripMenuItem.Checked = true;
+            showTestSummaryToolStripMenuItem.CheckOnClick = true;
+            showTestSummaryToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            showTestSummaryToolStripMenuItem.Name = "showTestSummaryToolStripMenuItem";
+            showTestSummaryToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            showTestSummaryToolStripMenuItem.Text = "Show Test Summary";
+            showTestSummaryToolStripMenuItem.Click += ShowTestSummaryToolStripMenuItem_Click;
+            // 
+            // saveToolStripMenuItem
+            // 
+            saveToolStripMenuItem.Image = Properties.Resources.Save_16x;
+            saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            saveToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            saveToolStripMenuItem.Text = "Save";
+            saveToolStripMenuItem.Click += SaveToolStripMenuItem_Click;
+            // 
+            // lblRefreshTime
+            // 
+            lblRefreshTime.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            lblRefreshTime.Name = "lblRefreshTime";
+            lblRefreshTime.Size = new System.Drawing.Size(98, 24);
+            lblRefreshTime.Text = "Refresh Time:";
+            // 
+            // tsOptions
+            // 
+            tsOptions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { memoryDumpsToolStripMenuItem1, instanceUptimeToolStripMenuItem });
+            tsOptions.Image = Properties.Resources.SettingsOutline_16x;
+            tsOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsOptions.Name = "tsOptions";
+            tsOptions.Size = new System.Drawing.Size(95, 24);
+            tsOptions.Text = "Options";
+            tsOptions.ToolTipText = "Options";
+            // 
+            // memoryDumpsToolStripMenuItem1
+            // 
+            memoryDumpsToolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { acknowledgeDumpsToolStripMenuItem1, configureThresholdsToolStripMenuItem1 });
+            memoryDumpsToolStripMenuItem1.Name = "memoryDumpsToolStripMenuItem1";
+            memoryDumpsToolStripMenuItem1.Size = new System.Drawing.Size(224, 26);
+            memoryDumpsToolStripMenuItem1.Text = "Memory Dumps";
+            // 
+            // acknowledgeDumpsToolStripMenuItem1
+            // 
+            acknowledgeDumpsToolStripMenuItem1.Name = "acknowledgeDumpsToolStripMenuItem1";
+            acknowledgeDumpsToolStripMenuItem1.Size = new System.Drawing.Size(233, 26);
+            acknowledgeDumpsToolStripMenuItem1.Text = "Acknowledge Dumps";
+            acknowledgeDumpsToolStripMenuItem1.Click += AcknowledgeDumpsToolStripMenuItem_Click;
+            // 
+            // configureThresholdsToolStripMenuItem1
+            // 
+            configureThresholdsToolStripMenuItem1.Name = "configureThresholdsToolStripMenuItem1";
+            configureThresholdsToolStripMenuItem1.Size = new System.Drawing.Size(233, 26);
+            configureThresholdsToolStripMenuItem1.Text = "Configure Thresholds";
+            configureThresholdsToolStripMenuItem1.Click += ConfigureThresholdsToolStripMenuItem_Click;
+            // 
+            // instanceUptimeToolStripMenuItem
+            // 
+            instanceUptimeToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { acknowledgeUptimeToolStripMenuItem, configureThresholdsToolStripMenuItem2 });
+            instanceUptimeToolStripMenuItem.Name = "instanceUptimeToolStripMenuItem";
+            instanceUptimeToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            instanceUptimeToolStripMenuItem.Text = "Instance Uptime";
+            // 
+            // acknowledgeUptimeToolStripMenuItem
+            // 
+            acknowledgeUptimeToolStripMenuItem.Name = "acknowledgeUptimeToolStripMenuItem";
+            acknowledgeUptimeToolStripMenuItem.Size = new System.Drawing.Size(235, 26);
+            acknowledgeUptimeToolStripMenuItem.Text = "Acknowledge Uptime";
+            acknowledgeUptimeToolStripMenuItem.Click += AcknowledgeUptimeToolStripMenuItem_Click;
+            // 
+            // configureThresholdsToolStripMenuItem2
+            // 
+            configureThresholdsToolStripMenuItem2.Name = "configureThresholdsToolStripMenuItem2";
+            configureThresholdsToolStripMenuItem2.Size = new System.Drawing.Size(235, 26);
+            configureThresholdsToolStripMenuItem2.Text = "Configure Thresholds";
+            configureThresholdsToolStripMenuItem2.Click += ConfigureUptimeThresholdsToolStripMenuItem_Click;
+            // 
+            // tsClearFilter
+            // 
+            tsClearFilter.Enabled = false;
+            tsClearFilter.Image = Properties.Resources.Eraser_16x;
+            tsClearFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsClearFilter.Name = "tsClearFilter";
+            tsClearFilter.Size = new System.Drawing.Size(104, 24);
+            tsClearFilter.Text = "Clear Filter";
+            tsClearFilter.Click += TsClearFilter_Click;
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
+            dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.ReadOnly = true;
+            dataGridViewTextBoxColumn1.Width = 90;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            dataGridViewTextBoxColumn2.HeaderText = "Memory Dump";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.ReadOnly = true;
+            dataGridViewTextBoxColumn2.Width = 128;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            dataGridViewTextBoxColumn3.DataPropertyName = "DetectedCorruptionDate ";
+            dataGridViewTextBoxColumn3.HeaderText = "Corruption";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.ReadOnly = true;
+            dataGridViewTextBoxColumn3.Width = 103;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            dataGridViewTextBoxColumn4.HeaderText = "Last Good Check DB";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.ReadOnly = true;
+            dataGridViewTextBoxColumn4.Width = 137;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            dataGridViewCellStyle8.NullValue = "View";
+            dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle8;
+            dataGridViewTextBoxColumn5.HeaderText = "Alerts";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.ReadOnly = true;
+            dataGridViewTextBoxColumn5.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            dataGridViewTextBoxColumn5.Width = 73;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            dataGridViewCellStyle9.NullValue = "View";
+            dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle9;
+            dataGridViewTextBoxColumn6.HeaderText = "Full Backup";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.ReadOnly = true;
+            dataGridViewTextBoxColumn6.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Programmatic;
+            dataGridViewTextBoxColumn6.Width = 101;
+            // 
+            // dataGridViewTextBoxColumn7
+            // 
+            dataGridViewCellStyle10.NullValue = "View";
+            dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle10;
+            dataGridViewTextBoxColumn7.HeaderText = "Diff Backup";
+            dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            dataGridViewTextBoxColumn7.ReadOnly = true;
+            dataGridViewTextBoxColumn7.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn8
+            // 
+            dataGridViewTextBoxColumn8.HeaderText = "Log Backup";
+            dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            dataGridViewTextBoxColumn8.ReadOnly = true;
+            dataGridViewTextBoxColumn8.Width = 103;
+            // 
+            // dataGridViewTextBoxColumn9
+            // 
+            dataGridViewTextBoxColumn9.HeaderText = "Log Shipping";
+            dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            dataGridViewTextBoxColumn9.ReadOnly = true;
+            dataGridViewTextBoxColumn9.Width = 110;
+            // 
+            // dataGridViewTextBoxColumn10
+            // 
+            dataGridViewTextBoxColumn10.HeaderText = "Drive Space";
+            dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            dataGridViewTextBoxColumn10.ReadOnly = true;
+            dataGridViewTextBoxColumn10.Width = 105;
+            // 
+            // dataGridViewTextBoxColumn11
+            // 
+            dataGridViewTextBoxColumn11.HeaderText = "Agent Jobs";
+            dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            dataGridViewTextBoxColumn11.ReadOnly = true;
+            dataGridViewTextBoxColumn11.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn12
+            // 
+            dataGridViewTextBoxColumn12.HeaderText = "Availability Groups";
+            dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            dataGridViewTextBoxColumn12.ReadOnly = true;
+            dataGridViewTextBoxColumn12.Width = 141;
+            // 
+            // dataGridViewTextBoxColumn13
+            // 
+            dataGridViewTextBoxColumn13.HeaderText = "File FreeSpace";
+            dataGridViewTextBoxColumn13.MinimumWidth = 6;
+            dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
+            dataGridViewTextBoxColumn13.ReadOnly = true;
+            dataGridViewTextBoxColumn13.Width = 121;
+            // 
+            // dataGridViewTextBoxColumn14
+            // 
+            dataGridViewTextBoxColumn14.HeaderText = "Custom Checks";
+            dataGridViewTextBoxColumn14.MinimumWidth = 6;
+            dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
+            dataGridViewTextBoxColumn14.ReadOnly = true;
+            dataGridViewTextBoxColumn14.Width = 123;
+            // 
+            // dataGridViewTextBoxColumn15
+            // 
+            dataGridViewTextBoxColumn15.HeaderText = "DBADash Errors";
+            dataGridViewTextBoxColumn15.MinimumWidth = 6;
+            dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
+            dataGridViewTextBoxColumn15.ReadOnly = true;
+            dataGridViewTextBoxColumn15.Width = 141;
+            // 
+            // dataGridViewTextBoxColumn16
+            // 
+            dataGridViewTextBoxColumn16.HeaderText = "Snapshot Age";
+            dataGridViewTextBoxColumn16.MinimumWidth = 6;
+            dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
+            dataGridViewTextBoxColumn16.ReadOnly = true;
+            dataGridViewTextBoxColumn16.Width = 116;
+            // 
+            // dataGridViewTextBoxColumn17
+            // 
+            dataGridViewTextBoxColumn17.HeaderText = "Instance Uptime";
+            dataGridViewTextBoxColumn17.MinimumWidth = 6;
+            dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
+            dataGridViewTextBoxColumn17.Width = 127;
+            // 
+            // timer1
+            // 
+            timer1.Enabled = true;
+            timer1.Interval = 10000;
+            timer1.Tick += Timer1_Tick;
+            // 
+            // refresh1
+            // 
+            refresh1.BackColor = System.Drawing.Color.FromArgb(0, 99, 163);
+            refresh1.Dock = System.Windows.Forms.DockStyle.Fill;
+            refresh1.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            refresh1.ForeColor = System.Drawing.Color.White;
+            refresh1.Location = new System.Drawing.Point(0, 27);
+            refresh1.Margin = new System.Windows.Forms.Padding(4);
+            refresh1.Name = "refresh1";
+            refresh1.Size = new System.Drawing.Size(1800, 239);
+            refresh1.TabIndex = 2;
+            // 
+            // splitContainer1
+            // 
+            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer1.Location = new System.Drawing.Point(0, 27);
+            splitContainer1.Name = "splitContainer1";
+            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            splitContainer1.Panel1.Controls.Add(dgvTests);
+            // 
+            // splitContainer1.Panel2
+            // 
+            splitContainer1.Panel2.Controls.Add(dgvSummary);
+            splitContainer1.Size = new System.Drawing.Size(1800, 239);
+            splitContainer1.SplitterDistance = 118;
+            splitContainer1.TabIndex = 3;
+            // 
+            // dgvTests
+            // 
+            dgvTests.AllowUserToAddRows = false;
+            dgvTests.AllowUserToDeleteRows = false;
+            dgvTests.BackgroundColor = System.Drawing.Color.White;
+            dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle11.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle11.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle11.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle11.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            dgvTests.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle11;
+            dgvTests.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle12.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle12.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle12.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle12.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle12.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            dgvTests.DefaultCellStyle = dataGridViewCellStyle12;
+            dgvTests.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvTests.Location = new System.Drawing.Point(0, 0);
+            dgvTests.Name = "dgvTests";
+            dgvTests.ReadOnly = true;
+            dgvTests.RowHeadersVisible = false;
+            dgvTests.RowHeadersWidth = 51;
+            dgvTests.RowTemplate.Height = 29;
+            dgvTests.Size = new System.Drawing.Size(1800, 118);
+            dgvTests.TabIndex = 0;
+            dgvTests.CellContentClick += DgvTests_CellContentClick;
+            dgvTests.RowsAdded += DgvTests_RowsAdded;
+            // 
             // Summary
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
@@ -863,7 +894,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn15;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn16;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn17;
-        private System.Windows.Forms.ToolStripDropDownButton tsOptions;
+        private System.Windows.Forms.ToolStripDropDownButton tsView;
         private System.Windows.Forms.ToolStripMenuItem focusedViewToolStripMenuItem;
         private System.Windows.Forms.ToolStripLabel lblRefreshTime;
         private System.Windows.Forms.Timer timer1;
@@ -879,9 +910,6 @@
         private System.Windows.Forms.ToolStripMenuItem copySummaryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyTestSummaryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
-        private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownButton1;
-        private System.Windows.Forms.ToolStripMenuItem acknowledgeDumpsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem configureThresholdsToolStripMenuItem;
         private System.Windows.Forms.DataGridViewTextBoxColumn Instance;
         private System.Windows.Forms.DataGridViewCheckBoxColumn colHidden;
         private System.Windows.Forms.DataGridViewTextBoxColumn MemoryDumpStatus;
@@ -909,5 +937,12 @@
         private System.Windows.Forms.DataGridViewLinkColumn IdentityStatus;
         private System.Windows.Forms.DataGridViewLinkColumn DatabaseStateStatus;
         private System.Windows.Forms.DataGridViewLinkColumn UptimeStatus;
+        private System.Windows.Forms.ToolStripDropDownButton tsOptions;
+        private System.Windows.Forms.ToolStripMenuItem memoryDumpsToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem acknowledgeDumpsToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem configureThresholdsToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem instanceUptimeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem acknowledgeUptimeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem configureThresholdsToolStripMenuItem2;
     }
 }

--- a/DBADashGUI/Checks/Summary.cs
+++ b/DBADashGUI/Checks/Summary.cs
@@ -474,12 +474,7 @@ namespace DBADashGUI
             var row = (DataRowView)dgvSummary.Rows[e.RowIndex].DataBoundItem;
             if (e.ColumnIndex == UptimeStatus.Index)
             {
-                using var frm = new UptimeThresholdConfig() { InstanceID = (int)row["InstanceID"] };
-                frm.ShowDialog();
-                if (frm.DialogResult == DialogResult.OK)
-                {
-                    RefreshData();
-                }
+                ShowUptimeThresholdConfig((int)row["InstanceID"]);
             }
             else if (e.ColumnIndex == CorruptionStatus.Index)
             {
@@ -491,6 +486,16 @@ namespace DBADashGUI
                     row["InstanceID"] != DBNull.Value
                         ? new InstanceSelectedEventArgs() { InstanceID = (int)row["InstanceID"], Tab = tab }
                         : new InstanceSelectedEventArgs() { Instance = (string)row["InstanceGroupName"], Tab = tab });
+            }
+        }
+
+        private void ShowUptimeThresholdConfig(int instanceId)
+        {
+            using var frm = new UptimeThresholdConfig() { InstanceID = instanceId };
+            frm.ShowDialog();
+            if (frm.DialogResult == DialogResult.OK)
+            {
+                RefreshData();
             }
         }
 
@@ -685,6 +690,17 @@ namespace DBADashGUI
             {
                 MessageBox.Show("Error saving view options\n", ex.Message, MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private void ConfigureUptimeThresholdsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ShowUptimeThresholdConfig(-1);
+        }
+
+        private void AcknowledgeUptimeToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            CommonData.AcknowledgeInstanceUptime(-1);
+            RefreshData();
         }
     }
 }

--- a/DBADashGUI/Checks/Summary.resx
+++ b/DBADashGUI/Checks/Summary.resx
@@ -141,18 +141,6 @@
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="toolStripDropDownButton1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAEKSURBVEhL3ZG9DsFQHMXvczDZvIOtXsHObuhqkViI3Quw
-        6CYmNoMYJJ0NBiFFIoIytOuf0+TeXP3yde+iyS+3OcP53Z4y3/dJJ4HAsiwyTVMp6BQCBIZhKAWdEcHV
-        vSlBmeB82NFy1KLluEWOPRC5MoHdMWhazwi4RJlALgf4EuT6BI+5kCsTrGddUY658E+QvyXYHq9UnRyC
-        U87f4aUApcXhnrI9Jzg/laQKFntXlHM+lSQK5psL5fvbp/JvJLGCQqmSWM5JkiCT84igXGtSrruKLQ0T
-        luAdmZxHBG37FFuWBC/j5XKOmX8WAH7rcI6ZMffPgjQwN2bXJgDo/COBTpjneQ2dML0PY3cISreGe8HM
-        qgAAAABJRU5ErkJggg==
-</value>
-  </data>
   <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>141, 17</value>
   </metadata>

--- a/DBADashGUI/Checks/UptimeThresholdConfig.cs
+++ b/DBADashGUI/Checks/UptimeThresholdConfig.cs
@@ -119,13 +119,7 @@ namespace DBADashGUI.Checks
 
         private void BttnClearAlert_Click(object sender, EventArgs e)
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("dbo.InstanceUptimeAck", cn) { CommandType = CommandType.StoredProcedure })
-            {
-                cn.Open();
-                cmd.Parameters.AddWithValue("InstanceID", InstanceID);
-                cmd.ExecuteNonQuery();
-            }
+            CommonData.AcknowledgeInstanceUptime(InstanceID);
             MessageBox.Show("Alert cleared", "Update", MessageBoxButtons.OK, MessageBoxIcon.Information);
             this.DialogResult = DialogResult.OK;
             this.Close();

--- a/DBADashGUI/CommonData.cs
+++ b/DBADashGUI/CommonData.cs
@@ -245,5 +245,16 @@ namespace DBADashGUI
                 return dt;
             }
         }
+
+        public static void AcknowledgeInstanceUptime(int instanceId)
+        {
+            using (var cn = new SqlConnection(Common.ConnectionString))
+            using (var cmd = new SqlCommand("dbo.InstanceUptimeAck", cn) { CommandType = CommandType.StoredProcedure })
+            {
+                cn.Open();
+                cmd.Parameters.AddWithValue("InstanceID", instanceId);
+                cmd.ExecuteNonQuery();
+            }
+        }
     }
 }


### PR DESCRIPTION
Add menu item to configure uptime thresholds at root level.  Allows root level configuration even if column is no longer displayed. Add menu option to acknowledge uptime thresholds - improves usability. Moved Memory Dumps menu under new Options menu.
#562