### PR TITLE
Add configure Service prompt back

### DIFF
--- a/DBADashGUI/Common.cs
+++ b/DBADashGUI/Common.cs
@@ -416,5 +416,12 @@ namespace DBADashGUI
                 Console.WriteLine("Error deleting temp file:" + ex.ToString());
             }
         }
+        internal static void ConfigureService()
+        {
+            var psi = new ProcessStartInfo(Properties.Resources.ServiceConfigToolName) { UseShellExecute = true };
+            Process.Start(psi);
+            Application.Exit();
+        }
+
     }
 }

--- a/DBADashGUI/ConnectionOptions.cs
+++ b/DBADashGUI/ConnectionOptions.cs
@@ -12,74 +12,16 @@ namespace DBADashGUI
             InitializeComponent();
         }
 
-        public BasicConfig cfg;
+        public bool RequestConfigureService => optConfigure.Checked;
 
         private void BttnOK_Click(object sender, EventArgs e)
         {
-            if (optConfigure.Checked)
-            {
-                ConfigureService();
-            }
-            else
-            {
-                Connect();
-            }
+            this.DialogResult= DialogResult.OK;
         }
-
-        private void Connect()
-        {
-            using (var frm = new DBConnection())
-            {
-                frm.ShowDialog();
-                if (frm.DialogResult == DialogResult.OK)
-                {
-
-                    try
-                    {
-                        DBValidations.GetDBVersion(frm.ConnectionString);
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show("Error validating connection to repository database:" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        return;
-                    }
-
-                    cfg = new BasicConfig
-                    {
-                        Destination = frm.ConnectionString
-                    };
-
-                    if (File.Exists(Common.JsonConfigPath))
-                    {
-                        MessageBox.Show("Config file already exists:" + Common.JsonConfigPath, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    }
-                    else
-                    {
-                        System.IO.File.WriteAllText(Common.JsonConfigPath, cfg.Serialize());
-                        this.DialogResult = DialogResult.OK;
-                        this.Close();
-                    }
-                }
-            }
-        }
-
-
-        private static void ConfigureService()
-        {
-            var psi = new ProcessStartInfo(Properties.Resources.ServiceConfigToolName) { UseShellExecute = true };
-            Process.Start(psi);
-            Application.Exit();
-        }
-
 
         private void ConnectionOptions_Load(object sender, EventArgs e)
         {
-            if (!File.Exists(Properties.Resources.ServiceConfigToolName))
-            {
-                optConfigure.Enabled = false;
-                optConnect.Checked = true;
-                Connect();
-            }
+       
         }
     }
 }

--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -128,8 +129,19 @@ namespace DBADashGUI
             diffSchemaSnapshot.Dock = DockStyle.Fill;
 
             LoadRepositoryConnections();
-            if (repositories.Count == 0)
+            if (repositories.Count == 0) // We don't have a connection to the repository DB yet
             {
+                if (File.Exists(Properties.Resources.ServiceConfigToolName)) // The service configuration tool exists (Not the GUI only package).  Give user the option to configure the service or connect to an existing repository.
+                {
+                    using var frm = new ConnectionOptions(); 
+                    frm.ShowDialog();
+                    if (frm.DialogResult == DialogResult.OK && frm.RequestConfigureService)
+                    {
+                        Common.ConfigureService();
+                        return;
+                    }
+                } 
+                // Prompt the user to connect to an existing DBA Dash repository DB.
                 await AddConnection();
                 if (repositories.Count == 0)
                 {


### PR DESCRIPTION
Add configure service prompt back.  The option to configure the service is shown if the repository connection isn't configured and we have the full installation package that includes the service.  #137