### PR TITLE
JobStats_60MIN partition switching fix

### DIFF
--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -767,6 +767,9 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <PreDeploy Include="Script.PreDeployment1.sql" />
+  </ItemGroup>
   <Target Name="SetDacVersionToAssemblyVersion" AfterTargets="CoreCompile">
     <GetAssemblyIdentity AssemblyFiles="$(IntermediateTargetFullFileName)">
       <Output TaskParameter="Assemblies" PropertyName="IntermediateTargetAssembly" />

--- a/DBADashDB/Script.PreDeployment1.sql
+++ b/DBADashDB/Script.PreDeployment1.sql
@@ -1,0 +1,19 @@
+﻿/* Remove partitioning from Switch.JobStats_60MIN table.  #411 */
+IF EXISTS(
+	SELECT 1 
+	FROM sys.partitions
+	WHERE object_id = OBJECT_ID('Switch.JobStats_60MIN')
+	AND index_id IN(0,1)
+	HAVING COUNT(*) > 1
+	)
+BEGIN
+	PRINT 'Remove partitioning from Switch.JobStats_60MIN'
+	ALTER TABLE [Switch].[JobStats_60MIN] DROP CONSTRAINT [PK_JobStats_60MIN] 
+	ALTER TABLE [Switch].[JobStats_60MIN] ADD  CONSTRAINT [PK_JobStats_60MIN] PRIMARY KEY CLUSTERED 
+	(
+		[InstanceID] ASC,
+		[job_id] ASC,
+		[step_id] ASC,
+		[RunDateTime] ASC
+	) ON [PRIMARY]
+END


### PR DESCRIPTION
Fix issue with partition switching for JobStats_60MIN.  The previous fix for this issue didn't resolve the problem for existing DBA Dash repository databases. #411