### PR TITLE
DBA Dash Upgrades fix for encrypted configs

### DIFF
--- a/Scripts/UpgradeDBADash.ps1
+++ b/Scripts/UpgradeDBADash.ps1
@@ -213,9 +213,9 @@ if ($versionCompare -eq -1 -or $ForceUpgrade){
     }
     # Stop the GUI if running - we don't want locks on any files
     Write-Host "Stop processes"
-    Get-Process -Name DBADash -ErrorAction Ignore | Where-Object { $_.Path -like (Get-Location).Path + "*" } | Stop-Process
-    Get-Process -Name DBADashServiceConfigTool -ErrorAction Ignore | Where-Object { $_.Path -like (Get-Location).Path + "*" } | Stop-Process
-    Get-Process -Name DBADashConfig -ErrorAction Ignore | Where-Object { $_.Path -like (Get-Location).Path + "*" } | Stop-Process
+    Get-Process -Name DBADash -ErrorAction Ignore | Where-Object { $_.Path -like (Get-Location).Path + "*" } | Stop-Process -Force
+    Get-Process -Name DBADashServiceConfigTool -ErrorAction Ignore | Where-Object { $_.Path -like (Get-Location).Path + "*" } | Stop-Process -Force
+    Get-Process -Name DBADashConfig -ErrorAction Ignore | Where-Object { $_.Path -like (Get-Location).Path + "*" } | Stop-Process -Force
     
     # Wait for file locks to be released
     Start-Sleep -Seconds 2


### PR DESCRIPTION
Get service name from Get-WmiObject instead of reading the config file.  It might not be possible to read the config file if it's encrypted.
Add -Force to Stop-Process.  Add a Stop-Process for DBADashService.  In most cases Stop-Service should ensure the service isn't running - this won't work if it's run as a console app though.