### PR TITLE
Fix PRIMARY KEY error refreshing summary

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/Summary_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/Summary_Upd.sql
@@ -184,6 +184,12 @@ WHERE IsActive = 1
 AND state IN(3,4,5) /* Recovery Pending, Suspect, Emergency */
 GROUP BY InstanceID
 
+SELECT	EPS.InstanceID,
+		MIN(NULLIF(EPS.ElasticPoolStorageStatus,3)) ElasticPoolStorageStatus
+INTO #ElasticPoolStatus
+FROM dbo.AzureDBElasticPoolStorageStatus EPS
+GROUP BY EPS.InstanceID
+
 SELECT I.InstanceID,
 	I.Instance,
 	I.InstanceGroupName,
@@ -349,7 +355,7 @@ LEFT JOIN #CollectionErrorStatus errSummary  ON I.InstanceID = errSummary.Instan
 LEFT JOIN #FileGroupStatus F ON I.InstanceID = F.InstanceID
 LEFT JOIN #CollectionStatus SSD ON I.InstanceID = SSD.InstanceID
 LEFT JOIN #CustomChecksStatus cus ON cus.InstanceID = I.InstanceID
-LEFT JOIN dbo.AzureDBElasticPoolStorageStatus EPS ON I.InstanceID = EPS.InstanceID
+LEFT JOIN #ElasticPoolStatus EPS ON I.InstanceID = EPS.InstanceID
 LEFT JOIN #QueryStoreStatus QS ON QS.InstanceID = I.InstanceID
 LEFT JOIN #IdentityStatus Ident ON Ident.InstanceID = I.InstanceID
 LEFT JOIN #DatabaseStateStatus DBState ON I.InstanceID = DBState.InstanceID

--- a/DBADashGUI/Performance/AzureSummary.Designer.cs
+++ b/DBADashGUI/Performance/AzureSummary.Designer.cs
@@ -70,116 +70,116 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle39 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle40 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle41 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.dgv = new System.Windows.Forms.DataGridView();
-            this.colInstance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colDB = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.colEdition = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colServiceObjective = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.colElasticPool = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.dgv_DTUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dgv_CPUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dgv_DataHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dgv_LogHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.colMaxDTU = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colMaxDTUUsed = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colUnusedDTUs = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colAvgDTUPercent = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colAVGDTUsUsed = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colMinDTULimit = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colDTULimitMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colMaxCPUPercent = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colMaxDataPct = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colMaxLog = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colAvgCPUPct = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colAvgDataPct = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colAvgLogWrite = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colAllocatedSpaceMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colUsedMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colMaxStorageSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colAlocatedPctMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colUsedPctMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colFileSnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.toolStripLabel2 = new System.Windows.Forms.ToolStripLabel();
-            this.tsCols = new System.Windows.Forms.ToolStripButton();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewProgressBarColumn1 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewProgressBarColumn2 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewProgressBarColumn3 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewProgressBarColumn4 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewProgressBarColumn5 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewProgressBarColumn6 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewProgressBarColumn7 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewProgressBarColumn8 = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dgvPool = new System.Windows.Forms.DataGridView();
-            this.poolInstance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colPoolName = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.dgvPool_DTUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dgvPool_CPUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dgvPool_DataHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.dgvPool_LogHistogram = new System.Windows.Forms.DataGridViewImageColumn();
-            this.poolMaxDTUPct = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolMaxDTU = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolUnusedDTU = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolAVGDTUPct = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolAVGDTU = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolMinDTULimit = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolDTULimitMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colCPULimitMin = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colCPULimitMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.poolMaxCPU = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.poolMaxDataPct = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.poolMaxLogWrite = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.poolAvgCPU = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.poolAvgData = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.poolAvgLogWrite = new CustomProgressControl.DataGridViewProgressBarColumn();
-            this.colAllocatedStoragePct = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colStorageLimit = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colCurrentUsedGB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colCurrentFreeGB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.toolStrip2 = new System.Windows.Forms.ToolStrip();
-            this.tsRefreshPool = new System.Windows.Forms.ToolStripButton();
-            this.tsCopyPool = new System.Windows.Forms.ToolStripButton();
-            this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
-            this.tsExcelPool = new System.Windows.Forms.ToolStripButton();
-            this.tsPoolCols = new System.Windows.Forms.ToolStripButton();
-            ((System.ComponentModel.ISupportInitialize)(this.dgv)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvPool)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
-            this.toolStrip2.SuspendLayout();
-            this.SuspendLayout();
+            dgv = new System.Windows.Forms.DataGridView();
+            colInstance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colDB = new System.Windows.Forms.DataGridViewLinkColumn();
+            colEdition = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colServiceObjective = new System.Windows.Forms.DataGridViewLinkColumn();
+            colElasticPool = new System.Windows.Forms.DataGridViewLinkColumn();
+            dgv_DTUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            dgv_CPUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            dgv_DataHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            dgv_LogHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            colMaxDTU = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colMaxDTUUsed = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colUnusedDTUs = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colAvgDTUPercent = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colAVGDTUsUsed = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colMinDTULimit = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colDTULimitMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colMaxCPUPercent = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colMaxDataPct = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colMaxLog = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colAvgCPUPct = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colAvgDataPct = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colAvgLogWrite = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colAllocatedSpaceMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colUsedMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colMaxStorageSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colAlocatedPctMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colUsedPctMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colFileSnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            toolStripLabel2 = new System.Windows.Forms.ToolStripLabel();
+            tsCols = new System.Windows.Forms.ToolStripButton();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewProgressBarColumn1 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewProgressBarColumn2 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewProgressBarColumn3 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewProgressBarColumn4 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewProgressBarColumn5 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewProgressBarColumn6 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewProgressBarColumn7 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewProgressBarColumn8 = new CustomProgressControl.DataGridViewProgressBarColumn();
+            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dgvPool = new System.Windows.Forms.DataGridView();
+            poolInstance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colPoolName = new System.Windows.Forms.DataGridViewLinkColumn();
+            dgvPool_DTUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            dgvPool_CPUHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            dgvPool_DataHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            dgvPool_LogHistogram = new System.Windows.Forms.DataGridViewImageColumn();
+            poolMaxDTUPct = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolMaxDTU = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolUnusedDTU = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolAVGDTUPct = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolAVGDTU = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolMinDTULimit = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolDTULimitMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colCPULimitMin = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colCPULimitMax = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            poolMaxCPU = new CustomProgressControl.DataGridViewProgressBarColumn();
+            poolMaxDataPct = new CustomProgressControl.DataGridViewProgressBarColumn();
+            poolMaxLogWrite = new CustomProgressControl.DataGridViewProgressBarColumn();
+            poolAvgCPU = new CustomProgressControl.DataGridViewProgressBarColumn();
+            poolAvgData = new CustomProgressControl.DataGridViewProgressBarColumn();
+            poolAvgLogWrite = new CustomProgressControl.DataGridViewProgressBarColumn();
+            colAllocatedStoragePct = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colStorageLimit = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colCurrentUsedGB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colCurrentFreeGB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            splitContainer1 = new System.Windows.Forms.SplitContainer();
+            toolStrip2 = new System.Windows.Forms.ToolStrip();
+            tsRefreshPool = new System.Windows.Forms.ToolStripButton();
+            tsCopyPool = new System.Windows.Forms.ToolStripButton();
+            toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
+            tsExcelPool = new System.Windows.Forms.ToolStripButton();
+            tsPoolCols = new System.Windows.Forms.ToolStripButton();
+            ((System.ComponentModel.ISupportInitialize)dgv).BeginInit();
+            toolStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dgvPool).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
+            splitContainer1.Panel1.SuspendLayout();
+            splitContainer1.Panel2.SuspendLayout();
+            splitContainer1.SuspendLayout();
+            toolStrip2.SuspendLayout();
+            SuspendLayout();
             // 
             // dgv
             // 
-            this.dgv.AllowUserToAddRows = false;
-            this.dgv.AllowUserToDeleteRows = false;
-            this.dgv.AllowUserToOrderColumns = true;
-            this.dgv.BackgroundColor = System.Drawing.Color.White;
+            dgv.AllowUserToAddRows = false;
+            dgv.AllowUserToDeleteRows = false;
+            dgv.AllowUserToOrderColumns = true;
+            dgv.BackgroundColor = System.Drawing.Color.White;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
             dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
@@ -187,37 +187,9 @@
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgv.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.dgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgv.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.colInstance,
-            this.colDB,
-            this.colEdition,
-            this.colServiceObjective,
-            this.colElasticPool,
-            this.dgv_DTUHistogram,
-            this.dgv_CPUHistogram,
-            this.dgv_DataHistogram,
-            this.dgv_LogHistogram,
-            this.colMaxDTU,
-            this.colMaxDTUUsed,
-            this.colUnusedDTUs,
-            this.colAvgDTUPercent,
-            this.colAVGDTUsUsed,
-            this.colMinDTULimit,
-            this.colDTULimitMax,
-            this.colMaxCPUPercent,
-            this.colMaxDataPct,
-            this.colMaxLog,
-            this.colAvgCPUPct,
-            this.colAvgDataPct,
-            this.colAvgLogWrite,
-            this.colAllocatedSpaceMB,
-            this.colUsedMB,
-            this.colMaxStorageSize,
-            this.colAlocatedPctMax,
-            this.colUsedPctMax,
-            this.colFileSnapshotAge});
+            dgv.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgv.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { colInstance, colDB, colEdition, colServiceObjective, colElasticPool, dgv_DTUHistogram, dgv_CPUHistogram, dgv_DataHistogram, dgv_LogHistogram, colMaxDTU, colMaxDTUUsed, colUnusedDTUs, colAvgDTUPercent, colAVGDTUsUsed, colMinDTULimit, colDTULimitMax, colMaxCPUPercent, colMaxDataPct, colMaxLog, colAvgCPUPct, colAvgDataPct, colAvgLogWrite, colAllocatedSpaceMB, colUsedMB, colMaxStorageSize, colAlocatedPctMax, colUsedPctMax, colFileSnapshotAge });
             dataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle20.BackColor = System.Drawing.SystemColors.Window;
             dataGridViewCellStyle20.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
@@ -225,681 +197,676 @@
             dataGridViewCellStyle20.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle20.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle20.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgv.DefaultCellStyle = dataGridViewCellStyle20;
-            this.dgv.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgv.Location = new System.Drawing.Point(0, 0);
-            this.dgv.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgv.Name = "dgv";
-            this.dgv.ReadOnly = true;
-            this.dgv.RowHeadersVisible = false;
-            this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
-            this.dgv.Size = new System.Drawing.Size(1455, 752);
-            this.dgv.TabIndex = 0;
-            this.dgv.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.Dgv_CellContentClick);
-            this.dgv.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.Dgv_RowsAdded);
-            this.dgv.Sorted += new System.EventHandler(this.Dgv_Sorted);
+            dgv.DefaultCellStyle = dataGridViewCellStyle20;
+            dgv.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgv.Location = new System.Drawing.Point(0, 0);
+            dgv.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgv.Name = "dgv";
+            dgv.ReadOnly = true;
+            dgv.RowHeadersVisible = false;
+            dgv.RowHeadersWidth = 51;
+            dgv.RowTemplate.Height = 24;
+            dgv.Size = new System.Drawing.Size(1455, 752);
+            dgv.TabIndex = 0;
+            dgv.CellContentClick += Dgv_CellContentClick;
+            dgv.RowsAdded += Dgv_RowsAdded;
+            dgv.Sorted += Dgv_Sorted;
             // 
             // colInstance
             // 
-            this.colInstance.DataPropertyName = "Instance";
-            this.colInstance.HeaderText = "Instance";
-            this.colInstance.MinimumWidth = 6;
-            this.colInstance.Name = "colInstance";
-            this.colInstance.ReadOnly = true;
-            this.colInstance.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colInstance.Width = 90;
+            colInstance.DataPropertyName = "Instance";
+            colInstance.HeaderText = "Instance";
+            colInstance.MinimumWidth = 6;
+            colInstance.Name = "colInstance";
+            colInstance.ReadOnly = true;
+            colInstance.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colInstance.Width = 90;
             // 
             // colDB
             // 
-            this.colDB.DataPropertyName = "DB";
-            this.colDB.HeaderText = "DB";
-            this.colDB.MinimumWidth = 6;
-            this.colDB.Name = "colDB";
-            this.colDB.ReadOnly = true;
-            this.colDB.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colDB.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colDB.Width = 56;
+            colDB.DataPropertyName = "DB";
+            colDB.HeaderText = "DB";
+            colDB.MinimumWidth = 6;
+            colDB.Name = "colDB";
+            colDB.ReadOnly = true;
+            colDB.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colDB.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colDB.Width = 56;
             // 
             // colEdition
             // 
-            this.colEdition.DataPropertyName = "edition";
-            this.colEdition.HeaderText = "Edition";
-            this.colEdition.MinimumWidth = 6;
-            this.colEdition.Name = "colEdition";
-            this.colEdition.ReadOnly = true;
-            this.colEdition.Width = 80;
+            colEdition.DataPropertyName = "edition";
+            colEdition.HeaderText = "Edition";
+            colEdition.MinimumWidth = 6;
+            colEdition.Name = "colEdition";
+            colEdition.ReadOnly = true;
+            colEdition.Width = 80;
             // 
             // colServiceObjective
             // 
-            this.colServiceObjective.DataPropertyName = "service_objective";
-            this.colServiceObjective.HeaderText = "Service Objective";
-            this.colServiceObjective.LinkColor = System.Drawing.Color.Blue;
-            this.colServiceObjective.MinimumWidth = 6;
-            this.colServiceObjective.Name = "colServiceObjective";
-            this.colServiceObjective.ReadOnly = true;
-            this.colServiceObjective.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colServiceObjective.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colServiceObjective.Width = 135;
+            colServiceObjective.DataPropertyName = "service_objective";
+            colServiceObjective.HeaderText = "Service Objective";
+            colServiceObjective.LinkColor = System.Drawing.Color.Blue;
+            colServiceObjective.MinimumWidth = 6;
+            colServiceObjective.Name = "colServiceObjective";
+            colServiceObjective.ReadOnly = true;
+            colServiceObjective.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colServiceObjective.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colServiceObjective.Width = 135;
             // 
             // colElasticPool
             // 
-            this.colElasticPool.DataPropertyName = "elastic_pool_name";
-            this.colElasticPool.HeaderText = "Elastic Pool";
-            this.colElasticPool.MinimumWidth = 6;
-            this.colElasticPool.Name = "colElasticPool";
-            this.colElasticPool.ReadOnly = true;
-            this.colElasticPool.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colElasticPool.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colElasticPool.Width = 101;
+            colElasticPool.DataPropertyName = "elastic_pool_name";
+            colElasticPool.HeaderText = "Elastic Pool";
+            colElasticPool.MinimumWidth = 6;
+            colElasticPool.Name = "colElasticPool";
+            colElasticPool.ReadOnly = true;
+            colElasticPool.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colElasticPool.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colElasticPool.Width = 101;
             // 
             // dgv_DTUHistogram
             // 
-            this.dgv_DTUHistogram.HeaderText = "DTU Histogram";
-            this.dgv_DTUHistogram.MinimumWidth = 6;
-            this.dgv_DTUHistogram.Name = "dgv_DTUHistogram";
-            this.dgv_DTUHistogram.ReadOnly = true;
-            this.dgv_DTUHistogram.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgv_DTUHistogram.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.dgv_DTUHistogram.Visible = false;
-            this.dgv_DTUHistogram.Width = 123;
+            dgv_DTUHistogram.HeaderText = "DTU Histogram";
+            dgv_DTUHistogram.MinimumWidth = 6;
+            dgv_DTUHistogram.Name = "dgv_DTUHistogram";
+            dgv_DTUHistogram.ReadOnly = true;
+            dgv_DTUHistogram.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dgv_DTUHistogram.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            dgv_DTUHistogram.Visible = false;
+            dgv_DTUHistogram.Width = 123;
             // 
             // dgv_CPUHistogram
             // 
-            this.dgv_CPUHistogram.HeaderText = "CPU Histogram";
-            this.dgv_CPUHistogram.MinimumWidth = 6;
-            this.dgv_CPUHistogram.Name = "dgv_CPUHistogram";
-            this.dgv_CPUHistogram.ReadOnly = true;
-            this.dgv_CPUHistogram.Visible = false;
-            this.dgv_CPUHistogram.Width = 99;
+            dgv_CPUHistogram.HeaderText = "CPU Histogram";
+            dgv_CPUHistogram.MinimumWidth = 6;
+            dgv_CPUHistogram.Name = "dgv_CPUHistogram";
+            dgv_CPUHistogram.ReadOnly = true;
+            dgv_CPUHistogram.Visible = false;
+            dgv_CPUHistogram.Width = 99;
             // 
             // dgv_DataHistogram
             // 
-            this.dgv_DataHistogram.HeaderText = "Data Histogram";
-            this.dgv_DataHistogram.MinimumWidth = 6;
-            this.dgv_DataHistogram.Name = "dgv_DataHistogram";
-            this.dgv_DataHistogram.ReadOnly = true;
-            this.dgv_DataHistogram.Visible = false;
-            this.dgv_DataHistogram.Width = 101;
+            dgv_DataHistogram.HeaderText = "Data Histogram";
+            dgv_DataHistogram.MinimumWidth = 6;
+            dgv_DataHistogram.Name = "dgv_DataHistogram";
+            dgv_DataHistogram.ReadOnly = true;
+            dgv_DataHistogram.Visible = false;
+            dgv_DataHistogram.Width = 101;
             // 
             // dgv_LogHistogram
             // 
-            this.dgv_LogHistogram.HeaderText = "Log Write Histogram";
-            this.dgv_LogHistogram.MinimumWidth = 6;
-            this.dgv_LogHistogram.Name = "dgv_LogHistogram";
-            this.dgv_LogHistogram.ReadOnly = true;
-            this.dgv_LogHistogram.Visible = false;
-            this.dgv_LogHistogram.Width = 129;
+            dgv_LogHistogram.HeaderText = "Log Write Histogram";
+            dgv_LogHistogram.MinimumWidth = 6;
+            dgv_LogHistogram.Name = "dgv_LogHistogram";
+            dgv_LogHistogram.ReadOnly = true;
+            dgv_LogHistogram.Visible = false;
+            dgv_LogHistogram.Width = 129;
             // 
             // colMaxDTU
             // 
-            this.colMaxDTU.DataPropertyName = "Max_DTUPercent";
+            colMaxDTU.DataPropertyName = "Max_DTUPercent";
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle2.Format = "0.#\\%";
             dataGridViewCellStyle2.Padding = new System.Windows.Forms.Padding(4);
-            this.colMaxDTU.DefaultCellStyle = dataGridViewCellStyle2;
-            this.colMaxDTU.HeaderText = "Max DTU (%)";
-            this.colMaxDTU.MinimumWidth = 6;
-            this.colMaxDTU.Name = "colMaxDTU";
-            this.colMaxDTU.ReadOnly = true;
-            this.colMaxDTU.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colMaxDTU.Width = 111;
+            colMaxDTU.DefaultCellStyle = dataGridViewCellStyle2;
+            colMaxDTU.HeaderText = "Max DTU (%)";
+            colMaxDTU.MinimumWidth = 6;
+            colMaxDTU.Name = "colMaxDTU";
+            colMaxDTU.ReadOnly = true;
+            colMaxDTU.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colMaxDTU.Width = 111;
             // 
             // colMaxDTUUsed
             // 
-            this.colMaxDTUUsed.DataPropertyName = "Max_DTUsUsed";
+            colMaxDTUUsed.DataPropertyName = "Max_DTUsUsed";
             dataGridViewCellStyle3.Format = "N0";
-            this.colMaxDTUUsed.DefaultCellStyle = dataGridViewCellStyle3;
-            this.colMaxDTUUsed.HeaderText = "Max DTUs Used";
-            this.colMaxDTUUsed.MinimumWidth = 6;
-            this.colMaxDTUUsed.Name = "colMaxDTUUsed";
-            this.colMaxDTUUsed.ReadOnly = true;
-            this.colMaxDTUUsed.Width = 127;
+            colMaxDTUUsed.DefaultCellStyle = dataGridViewCellStyle3;
+            colMaxDTUUsed.HeaderText = "Max DTUs Used";
+            colMaxDTUUsed.MinimumWidth = 6;
+            colMaxDTUUsed.Name = "colMaxDTUUsed";
+            colMaxDTUUsed.ReadOnly = true;
+            colMaxDTUUsed.Width = 127;
             // 
             // colUnusedDTUs
             // 
-            this.colUnusedDTUs.DataPropertyName = "UnusedDTU";
+            colUnusedDTUs.DataPropertyName = "UnusedDTU";
             dataGridViewCellStyle4.Format = "N0";
-            this.colUnusedDTUs.DefaultCellStyle = dataGridViewCellStyle4;
-            this.colUnusedDTUs.HeaderText = "Unused DTUs";
-            this.colUnusedDTUs.MinimumWidth = 6;
-            this.colUnusedDTUs.Name = "colUnusedDTUs";
-            this.colUnusedDTUs.ReadOnly = true;
-            this.colUnusedDTUs.Width = 116;
+            colUnusedDTUs.DefaultCellStyle = dataGridViewCellStyle4;
+            colUnusedDTUs.HeaderText = "Unused DTUs";
+            colUnusedDTUs.MinimumWidth = 6;
+            colUnusedDTUs.Name = "colUnusedDTUs";
+            colUnusedDTUs.ReadOnly = true;
+            colUnusedDTUs.Width = 116;
             // 
             // colAvgDTUPercent
             // 
-            this.colAvgDTUPercent.DataPropertyName = "Avg_DTUPercent";
+            colAvgDTUPercent.DataPropertyName = "Avg_DTUPercent";
             dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle5.Format = "0.#\\%";
             dataGridViewCellStyle5.Padding = new System.Windows.Forms.Padding(4);
-            this.colAvgDTUPercent.DefaultCellStyle = dataGridViewCellStyle5;
-            this.colAvgDTUPercent.HeaderText = "Avg DTU %";
-            this.colAvgDTUPercent.MinimumWidth = 6;
-            this.colAvgDTUPercent.Name = "colAvgDTUPercent";
-            this.colAvgDTUPercent.ReadOnly = true;
-            this.colAvgDTUPercent.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colAvgDTUPercent.Width = 91;
+            colAvgDTUPercent.DefaultCellStyle = dataGridViewCellStyle5;
+            colAvgDTUPercent.HeaderText = "Avg DTU %";
+            colAvgDTUPercent.MinimumWidth = 6;
+            colAvgDTUPercent.Name = "colAvgDTUPercent";
+            colAvgDTUPercent.ReadOnly = true;
+            colAvgDTUPercent.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colAvgDTUPercent.Width = 91;
             // 
             // colAVGDTUsUsed
             // 
-            this.colAVGDTUsUsed.DataPropertyName = "Avg_DTUsUsed";
+            colAVGDTUsUsed.DataPropertyName = "Avg_DTUsUsed";
             dataGridViewCellStyle6.Format = "N0";
-            this.colAVGDTUsUsed.DefaultCellStyle = dataGridViewCellStyle6;
-            this.colAVGDTUsUsed.HeaderText = "Avg DTUs Used";
-            this.colAVGDTUsUsed.MinimumWidth = 6;
-            this.colAVGDTUsUsed.Name = "colAVGDTUsUsed";
-            this.colAVGDTUsUsed.ReadOnly = true;
-            this.colAVGDTUsUsed.Width = 127;
+            colAVGDTUsUsed.DefaultCellStyle = dataGridViewCellStyle6;
+            colAVGDTUsUsed.HeaderText = "Avg DTUs Used";
+            colAVGDTUsUsed.MinimumWidth = 6;
+            colAVGDTUsUsed.Name = "colAVGDTUsUsed";
+            colAVGDTUsUsed.ReadOnly = true;
+            colAVGDTUsUsed.Width = 127;
             // 
             // colMinDTULimit
             // 
-            this.colMinDTULimit.DataPropertyName = "Min_DTULimit";
+            colMinDTULimit.DataPropertyName = "Min_DTULimit";
             dataGridViewCellStyle7.Format = "N0";
-            this.colMinDTULimit.DefaultCellStyle = dataGridViewCellStyle7;
-            this.colMinDTULimit.HeaderText = "DTU Limit (Min)";
-            this.colMinDTULimit.MinimumWidth = 6;
-            this.colMinDTULimit.Name = "colMinDTULimit";
-            this.colMinDTULimit.ReadOnly = true;
-            this.colMinDTULimit.Width = 124;
+            colMinDTULimit.DefaultCellStyle = dataGridViewCellStyle7;
+            colMinDTULimit.HeaderText = "DTU Limit (Min)";
+            colMinDTULimit.MinimumWidth = 6;
+            colMinDTULimit.Name = "colMinDTULimit";
+            colMinDTULimit.ReadOnly = true;
+            colMinDTULimit.Width = 124;
             // 
             // colDTULimitMax
             // 
-            this.colDTULimitMax.DataPropertyName = "Max_DTULimit";
+            colDTULimitMax.DataPropertyName = "Max_DTULimit";
             dataGridViewCellStyle8.Format = "N0";
-            this.colDTULimitMax.DefaultCellStyle = dataGridViewCellStyle8;
-            this.colDTULimitMax.HeaderText = "DTU Limit (Max)";
-            this.colDTULimitMax.MinimumWidth = 6;
-            this.colDTULimitMax.Name = "colDTULimitMax";
-            this.colDTULimitMax.ReadOnly = true;
-            this.colDTULimitMax.Width = 127;
+            colDTULimitMax.DefaultCellStyle = dataGridViewCellStyle8;
+            colDTULimitMax.HeaderText = "DTU Limit (Max)";
+            colDTULimitMax.MinimumWidth = 6;
+            colDTULimitMax.Name = "colDTULimitMax";
+            colDTULimitMax.ReadOnly = true;
+            colDTULimitMax.Width = 127;
             // 
             // colMaxCPUPercent
             // 
-            this.colMaxCPUPercent.DataPropertyName = "MaxCPUPercent";
+            colMaxCPUPercent.DataPropertyName = "MaxCPUPercent";
             dataGridViewCellStyle9.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle9.Format = "0.#\\%";
             dataGridViewCellStyle9.Padding = new System.Windows.Forms.Padding(4);
-            this.colMaxCPUPercent.DefaultCellStyle = dataGridViewCellStyle9;
-            this.colMaxCPUPercent.HeaderText = "Max CPU %";
-            this.colMaxCPUPercent.MinimumWidth = 6;
-            this.colMaxCPUPercent.Name = "colMaxCPUPercent";
-            this.colMaxCPUPercent.ReadOnly = true;
-            this.colMaxCPUPercent.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colMaxCPUPercent.Width = 91;
+            colMaxCPUPercent.DefaultCellStyle = dataGridViewCellStyle9;
+            colMaxCPUPercent.HeaderText = "Max CPU %";
+            colMaxCPUPercent.MinimumWidth = 6;
+            colMaxCPUPercent.Name = "colMaxCPUPercent";
+            colMaxCPUPercent.ReadOnly = true;
+            colMaxCPUPercent.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colMaxCPUPercent.Width = 91;
             // 
             // colMaxDataPct
             // 
-            this.colMaxDataPct.DataPropertyName = "MaxDataPercent";
+            colMaxDataPct.DataPropertyName = "MaxDataPercent";
             dataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle10.Format = "0.#\\%";
             dataGridViewCellStyle10.Padding = new System.Windows.Forms.Padding(4);
-            this.colMaxDataPct.DefaultCellStyle = dataGridViewCellStyle10;
-            this.colMaxDataPct.HeaderText = "Max Data %";
-            this.colMaxDataPct.MinimumWidth = 6;
-            this.colMaxDataPct.Name = "colMaxDataPct";
-            this.colMaxDataPct.ReadOnly = true;
-            this.colMaxDataPct.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colMaxDataPct.Width = 92;
+            colMaxDataPct.DefaultCellStyle = dataGridViewCellStyle10;
+            colMaxDataPct.HeaderText = "Max Data %";
+            colMaxDataPct.MinimumWidth = 6;
+            colMaxDataPct.Name = "colMaxDataPct";
+            colMaxDataPct.ReadOnly = true;
+            colMaxDataPct.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colMaxDataPct.Width = 92;
             // 
             // colMaxLog
             // 
-            this.colMaxLog.DataPropertyName = "MaxLogWritePercent";
+            colMaxLog.DataPropertyName = "MaxLogWritePercent";
             dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle11.Format = "0.#\\%";
             dataGridViewCellStyle11.Padding = new System.Windows.Forms.Padding(4);
-            this.colMaxLog.DefaultCellStyle = dataGridViewCellStyle11;
-            this.colMaxLog.HeaderText = "Max Log Write %";
-            this.colMaxLog.MinimumWidth = 6;
-            this.colMaxLog.Name = "colMaxLog";
-            this.colMaxLog.ReadOnly = true;
-            this.colMaxLog.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colMaxLog.Width = 120;
+            colMaxLog.DefaultCellStyle = dataGridViewCellStyle11;
+            colMaxLog.HeaderText = "Max Log Write %";
+            colMaxLog.MinimumWidth = 6;
+            colMaxLog.Name = "colMaxLog";
+            colMaxLog.ReadOnly = true;
+            colMaxLog.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colMaxLog.Width = 120;
             // 
             // colAvgCPUPct
             // 
-            this.colAvgCPUPct.DataPropertyName = "AvgCPUPercent";
+            colAvgCPUPct.DataPropertyName = "AvgCPUPercent";
             dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle12.Format = "0.#\\%";
             dataGridViewCellStyle12.Padding = new System.Windows.Forms.Padding(4);
-            this.colAvgCPUPct.DefaultCellStyle = dataGridViewCellStyle12;
-            this.colAvgCPUPct.HeaderText = "Avg CPU %";
-            this.colAvgCPUPct.MinimumWidth = 6;
-            this.colAvgCPUPct.Name = "colAvgCPUPct";
-            this.colAvgCPUPct.ReadOnly = true;
-            this.colAvgCPUPct.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colAvgCPUPct.Width = 90;
+            colAvgCPUPct.DefaultCellStyle = dataGridViewCellStyle12;
+            colAvgCPUPct.HeaderText = "Avg CPU %";
+            colAvgCPUPct.MinimumWidth = 6;
+            colAvgCPUPct.Name = "colAvgCPUPct";
+            colAvgCPUPct.ReadOnly = true;
+            colAvgCPUPct.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colAvgCPUPct.Width = 90;
             // 
             // colAvgDataPct
             // 
-            this.colAvgDataPct.DataPropertyName = "AvgDataPercent";
+            colAvgDataPct.DataPropertyName = "AvgDataPercent";
             dataGridViewCellStyle13.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle13.Format = "0.#\\%";
             dataGridViewCellStyle13.Padding = new System.Windows.Forms.Padding(4);
-            this.colAvgDataPct.DefaultCellStyle = dataGridViewCellStyle13;
-            this.colAvgDataPct.HeaderText = "Avg Data %";
-            this.colAvgDataPct.MinimumWidth = 6;
-            this.colAvgDataPct.Name = "colAvgDataPct";
-            this.colAvgDataPct.ReadOnly = true;
-            this.colAvgDataPct.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colAvgDataPct.Width = 91;
+            colAvgDataPct.DefaultCellStyle = dataGridViewCellStyle13;
+            colAvgDataPct.HeaderText = "Avg Data %";
+            colAvgDataPct.MinimumWidth = 6;
+            colAvgDataPct.Name = "colAvgDataPct";
+            colAvgDataPct.ReadOnly = true;
+            colAvgDataPct.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colAvgDataPct.Width = 91;
             // 
             // colAvgLogWrite
             // 
-            this.colAvgLogWrite.DataPropertyName = "AvgLogWritePercent";
+            colAvgLogWrite.DataPropertyName = "AvgLogWritePercent";
             dataGridViewCellStyle14.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle14.Format = "0.#\\%";
             dataGridViewCellStyle14.Padding = new System.Windows.Forms.Padding(4);
-            this.colAvgLogWrite.DefaultCellStyle = dataGridViewCellStyle14;
-            this.colAvgLogWrite.HeaderText = "Avg Log Write %";
-            this.colAvgLogWrite.MinimumWidth = 6;
-            this.colAvgLogWrite.Name = "colAvgLogWrite";
-            this.colAvgLogWrite.ReadOnly = true;
-            this.colAvgLogWrite.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colAvgLogWrite.Width = 119;
+            colAvgLogWrite.DefaultCellStyle = dataGridViewCellStyle14;
+            colAvgLogWrite.HeaderText = "Avg Log Write %";
+            colAvgLogWrite.MinimumWidth = 6;
+            colAvgLogWrite.Name = "colAvgLogWrite";
+            colAvgLogWrite.ReadOnly = true;
+            colAvgLogWrite.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colAvgLogWrite.Width = 119;
             // 
             // colAllocatedSpaceMB
             // 
-            this.colAllocatedSpaceMB.DataPropertyName = "AllocatedSpaceMB";
+            colAllocatedSpaceMB.DataPropertyName = "AllocatedSpaceMB";
             dataGridViewCellStyle15.Format = "N0";
-            this.colAllocatedSpaceMB.DefaultCellStyle = dataGridViewCellStyle15;
-            this.colAllocatedSpaceMB.HeaderText = "Allocated Space MB";
-            this.colAllocatedSpaceMB.MinimumWidth = 6;
-            this.colAllocatedSpaceMB.Name = "colAllocatedSpaceMB";
-            this.colAllocatedSpaceMB.ReadOnly = true;
-            this.colAllocatedSpaceMB.Visible = false;
-            this.colAllocatedSpaceMB.Width = 125;
+            colAllocatedSpaceMB.DefaultCellStyle = dataGridViewCellStyle15;
+            colAllocatedSpaceMB.HeaderText = "Allocated Space MB";
+            colAllocatedSpaceMB.MinimumWidth = 6;
+            colAllocatedSpaceMB.Name = "colAllocatedSpaceMB";
+            colAllocatedSpaceMB.ReadOnly = true;
+            colAllocatedSpaceMB.Visible = false;
+            colAllocatedSpaceMB.Width = 125;
             // 
             // colUsedMB
             // 
-            this.colUsedMB.DataPropertyName = "UsedSpaceMB";
+            colUsedMB.DataPropertyName = "UsedSpaceMB";
             dataGridViewCellStyle16.Format = "N0";
-            this.colUsedMB.DefaultCellStyle = dataGridViewCellStyle16;
-            this.colUsedMB.HeaderText = "Used MB";
-            this.colUsedMB.MinimumWidth = 6;
-            this.colUsedMB.Name = "colUsedMB";
-            this.colUsedMB.ReadOnly = true;
-            this.colUsedMB.Visible = false;
-            this.colUsedMB.Width = 125;
+            colUsedMB.DefaultCellStyle = dataGridViewCellStyle16;
+            colUsedMB.HeaderText = "Used MB";
+            colUsedMB.MinimumWidth = 6;
+            colUsedMB.Name = "colUsedMB";
+            colUsedMB.ReadOnly = true;
+            colUsedMB.Visible = false;
+            colUsedMB.Width = 125;
             // 
             // colMaxStorageSize
             // 
-            this.colMaxStorageSize.DataPropertyName = "MaxStorageSizeMB";
+            colMaxStorageSize.DataPropertyName = "MaxStorageSizeMB";
             dataGridViewCellStyle17.Format = "N0";
-            this.colMaxStorageSize.DefaultCellStyle = dataGridViewCellStyle17;
-            this.colMaxStorageSize.HeaderText = "Max Storage Size MB";
-            this.colMaxStorageSize.MinimumWidth = 6;
-            this.colMaxStorageSize.Name = "colMaxStorageSize";
-            this.colMaxStorageSize.ReadOnly = true;
-            this.colMaxStorageSize.Visible = false;
-            this.colMaxStorageSize.Width = 125;
+            colMaxStorageSize.DefaultCellStyle = dataGridViewCellStyle17;
+            colMaxStorageSize.HeaderText = "Max Storage Size MB";
+            colMaxStorageSize.MinimumWidth = 6;
+            colMaxStorageSize.Name = "colMaxStorageSize";
+            colMaxStorageSize.ReadOnly = true;
+            colMaxStorageSize.Visible = false;
+            colMaxStorageSize.Width = 125;
             // 
             // colAlocatedPctMax
             // 
-            this.colAlocatedPctMax.DataPropertyName = "AllocatedPctOfMaxSize";
+            colAlocatedPctMax.DataPropertyName = "AllocatedPctOfMaxSize";
             dataGridViewCellStyle18.Format = "P1";
-            this.colAlocatedPctMax.DefaultCellStyle = dataGridViewCellStyle18;
-            this.colAlocatedPctMax.HeaderText = "Allocated % of Max Size";
-            this.colAlocatedPctMax.MinimumWidth = 6;
-            this.colAlocatedPctMax.Name = "colAlocatedPctMax";
-            this.colAlocatedPctMax.ReadOnly = true;
-            this.colAlocatedPctMax.Width = 125;
+            colAlocatedPctMax.DefaultCellStyle = dataGridViewCellStyle18;
+            colAlocatedPctMax.HeaderText = "Allocated % of Max Size";
+            colAlocatedPctMax.MinimumWidth = 6;
+            colAlocatedPctMax.Name = "colAlocatedPctMax";
+            colAlocatedPctMax.ReadOnly = true;
+            colAlocatedPctMax.Width = 125;
             // 
             // colUsedPctMax
             // 
-            this.colUsedPctMax.DataPropertyName = "UsedPctOfMaxSize";
+            colUsedPctMax.DataPropertyName = "UsedPctOfMaxSize";
             dataGridViewCellStyle19.Format = "P1";
-            this.colUsedPctMax.DefaultCellStyle = dataGridViewCellStyle19;
-            this.colUsedPctMax.HeaderText = "Used % Max Size";
-            this.colUsedPctMax.MinimumWidth = 6;
-            this.colUsedPctMax.Name = "colUsedPctMax";
-            this.colUsedPctMax.ReadOnly = true;
-            this.colUsedPctMax.Width = 125;
+            colUsedPctMax.DefaultCellStyle = dataGridViewCellStyle19;
+            colUsedPctMax.HeaderText = "Used % Max Size";
+            colUsedPctMax.MinimumWidth = 6;
+            colUsedPctMax.Name = "colUsedPctMax";
+            colUsedPctMax.ReadOnly = true;
+            colUsedPctMax.Width = 125;
             // 
             // colFileSnapshotAge
             // 
-            this.colFileSnapshotAge.DataPropertyName = "FileSnapshotAge";
-            this.colFileSnapshotAge.HeaderText = "File Snapshot Age";
-            this.colFileSnapshotAge.MinimumWidth = 6;
-            this.colFileSnapshotAge.Name = "colFileSnapshotAge";
-            this.colFileSnapshotAge.ReadOnly = true;
-            this.colFileSnapshotAge.Width = 125;
+            colFileSnapshotAge.DataPropertyName = "FileSnapshotAge";
+            colFileSnapshotAge.HeaderText = "File Snapshot Age";
+            colFileSnapshotAge.MinimumWidth = 6;
+            colFileSnapshotAge.Name = "colFileSnapshotAge";
+            colFileSnapshotAge.ReadOnly = true;
+            colFileSnapshotAge.Width = 125;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.toolStripLabel2,
-            this.tsCols});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1455, 27);
-            this.toolStrip1.TabIndex = 4;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, toolStripLabel2, tsCols });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(1455, 27);
+            toolStrip1.TabIndex = 4;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // toolStripLabel2
             // 
-            this.toolStripLabel2.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripLabel2.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.toolStripLabel2.Name = "toolStripLabel2";
-            this.toolStripLabel2.Size = new System.Drawing.Size(75, 24);
-            this.toolStripLabel2.Text = "Azure DB";
+            toolStripLabel2.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            toolStripLabel2.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            toolStripLabel2.Name = "toolStripLabel2";
+            toolStripLabel2.Size = new System.Drawing.Size(75, 24);
+            toolStripLabel2.Text = "Azure DB";
             // 
             // tsCols
             // 
-            this.tsCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCols.Image = global::DBADashGUI.Properties.Resources.Column_16x;
-            this.tsCols.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCols.Name = "tsCols";
-            this.tsCols.Size = new System.Drawing.Size(29, 24);
-            this.tsCols.Text = "Columns";
-            this.tsCols.Click += new System.EventHandler(this.TsCols_Click);
+            tsCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCols.Image = Properties.Resources.Column_16x;
+            tsCols.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCols.Name = "tsCols";
+            tsCols.Size = new System.Drawing.Size(29, 24);
+            tsCols.Text = "Columns";
+            tsCols.Click += TsCols_Click;
             // 
             // dataGridViewTextBoxColumn1
             // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 125;
+            dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
+            dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.ReadOnly = true;
+            dataGridViewTextBoxColumn1.Width = 125;
             // 
             // dataGridViewTextBoxColumn2
             // 
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "DB";
-            this.dataGridViewTextBoxColumn2.HeaderText = "DB";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 125;
+            dataGridViewTextBoxColumn2.DataPropertyName = "DB";
+            dataGridViewTextBoxColumn2.HeaderText = "DB";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.ReadOnly = true;
+            dataGridViewTextBoxColumn2.Width = 125;
             // 
             // dataGridViewTextBoxColumn3
             // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "edition";
-            this.dataGridViewTextBoxColumn3.HeaderText = "Edition";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 125;
+            dataGridViewTextBoxColumn3.DataPropertyName = "edition";
+            dataGridViewTextBoxColumn3.HeaderText = "Edition";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.ReadOnly = true;
+            dataGridViewTextBoxColumn3.Width = 125;
             // 
             // dataGridViewTextBoxColumn4
             // 
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "service_objective";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Service Objective";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 125;
+            dataGridViewTextBoxColumn4.DataPropertyName = "service_objective";
+            dataGridViewTextBoxColumn4.HeaderText = "Service Objective";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.ReadOnly = true;
+            dataGridViewTextBoxColumn4.Width = 125;
             // 
             // dataGridViewTextBoxColumn5
             // 
-            this.dataGridViewTextBoxColumn5.DataPropertyName = "elastic_pool_name";
-            this.dataGridViewTextBoxColumn5.HeaderText = "Elastic Pool";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.Width = 125;
+            dataGridViewTextBoxColumn5.DataPropertyName = "elastic_pool_name";
+            dataGridViewTextBoxColumn5.HeaderText = "Elastic Pool";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.ReadOnly = true;
+            dataGridViewTextBoxColumn5.Width = 125;
             // 
             // dataGridViewProgressBarColumn1
             // 
-            this.dataGridViewProgressBarColumn1.DataPropertyName = "Max_DTUPercent";
+            dataGridViewProgressBarColumn1.DataPropertyName = "Max_DTUPercent";
             dataGridViewCellStyle21.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle21.Format = "P1";
             dataGridViewCellStyle21.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn1.DefaultCellStyle = dataGridViewCellStyle21;
-            this.dataGridViewProgressBarColumn1.HeaderText = "Max DPU (%)";
-            this.dataGridViewProgressBarColumn1.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn1.Name = "dataGridViewProgressBarColumn1";
-            this.dataGridViewProgressBarColumn1.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn1.Width = 125;
+            dataGridViewProgressBarColumn1.DefaultCellStyle = dataGridViewCellStyle21;
+            dataGridViewProgressBarColumn1.HeaderText = "Max DPU (%)";
+            dataGridViewProgressBarColumn1.MinimumWidth = 6;
+            dataGridViewProgressBarColumn1.Name = "dataGridViewProgressBarColumn1";
+            dataGridViewProgressBarColumn1.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn1.Width = 125;
             // 
             // dataGridViewTextBoxColumn6
             // 
-            this.dataGridViewTextBoxColumn6.DataPropertyName = "Max_DTUPercent";
-            this.dataGridViewTextBoxColumn6.HeaderText = "Max DPU (%)";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.Width = 125;
+            dataGridViewTextBoxColumn6.DataPropertyName = "Max_DTUPercent";
+            dataGridViewTextBoxColumn6.HeaderText = "Max DPU (%)";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.ReadOnly = true;
+            dataGridViewTextBoxColumn6.Width = 125;
             // 
             // dataGridViewTextBoxColumn7
             // 
-            this.dataGridViewTextBoxColumn7.DataPropertyName = "Max_DTUsUsed";
-            this.dataGridViewTextBoxColumn7.HeaderText = "Max DTUs Used";
-            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            this.dataGridViewTextBoxColumn7.ReadOnly = true;
-            this.dataGridViewTextBoxColumn7.Width = 125;
+            dataGridViewTextBoxColumn7.DataPropertyName = "Max_DTUsUsed";
+            dataGridViewTextBoxColumn7.HeaderText = "Max DTUs Used";
+            dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            dataGridViewTextBoxColumn7.ReadOnly = true;
+            dataGridViewTextBoxColumn7.Width = 125;
             // 
             // dataGridViewProgressBarColumn2
             // 
-            this.dataGridViewProgressBarColumn2.DataPropertyName = "Avg_DTUPercent";
+            dataGridViewProgressBarColumn2.DataPropertyName = "Avg_DTUPercent";
             dataGridViewCellStyle22.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle22.Format = "P1";
             dataGridViewCellStyle22.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn2.DefaultCellStyle = dataGridViewCellStyle22;
-            this.dataGridViewProgressBarColumn2.HeaderText = "Avg DTU %";
-            this.dataGridViewProgressBarColumn2.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn2.Name = "dataGridViewProgressBarColumn2";
-            this.dataGridViewProgressBarColumn2.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn2.Width = 125;
+            dataGridViewProgressBarColumn2.DefaultCellStyle = dataGridViewCellStyle22;
+            dataGridViewProgressBarColumn2.HeaderText = "Avg DTU %";
+            dataGridViewProgressBarColumn2.MinimumWidth = 6;
+            dataGridViewProgressBarColumn2.Name = "dataGridViewProgressBarColumn2";
+            dataGridViewProgressBarColumn2.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn2.Width = 125;
             // 
             // dataGridViewTextBoxColumn8
             // 
-            this.dataGridViewTextBoxColumn8.DataPropertyName = "UnusedDTU";
-            this.dataGridViewTextBoxColumn8.HeaderText = "Unused DTUs";
-            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            this.dataGridViewTextBoxColumn8.ReadOnly = true;
-            this.dataGridViewTextBoxColumn8.Width = 125;
+            dataGridViewTextBoxColumn8.DataPropertyName = "UnusedDTU";
+            dataGridViewTextBoxColumn8.HeaderText = "Unused DTUs";
+            dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            dataGridViewTextBoxColumn8.ReadOnly = true;
+            dataGridViewTextBoxColumn8.Width = 125;
             // 
             // dataGridViewTextBoxColumn9
             // 
-            this.dataGridViewTextBoxColumn9.DataPropertyName = "Avg_DTUPercent";
-            this.dataGridViewTextBoxColumn9.HeaderText = "Avg DTU %";
-            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            this.dataGridViewTextBoxColumn9.ReadOnly = true;
-            this.dataGridViewTextBoxColumn9.Width = 125;
+            dataGridViewTextBoxColumn9.DataPropertyName = "Avg_DTUPercent";
+            dataGridViewTextBoxColumn9.HeaderText = "Avg DTU %";
+            dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            dataGridViewTextBoxColumn9.ReadOnly = true;
+            dataGridViewTextBoxColumn9.Width = 125;
             // 
             // dataGridViewTextBoxColumn10
             // 
-            this.dataGridViewTextBoxColumn10.DataPropertyName = "Avg_DTUsUsed";
-            this.dataGridViewTextBoxColumn10.HeaderText = "AVG DTUs Used";
-            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            this.dataGridViewTextBoxColumn10.ReadOnly = true;
-            this.dataGridViewTextBoxColumn10.Width = 125;
+            dataGridViewTextBoxColumn10.DataPropertyName = "Avg_DTUsUsed";
+            dataGridViewTextBoxColumn10.HeaderText = "AVG DTUs Used";
+            dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            dataGridViewTextBoxColumn10.ReadOnly = true;
+            dataGridViewTextBoxColumn10.Width = 125;
             // 
             // dataGridViewProgressBarColumn3
             // 
-            this.dataGridViewProgressBarColumn3.DataPropertyName = "MaxCPUPercent";
+            dataGridViewProgressBarColumn3.DataPropertyName = "MaxCPUPercent";
             dataGridViewCellStyle23.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle23.Format = "P1";
             dataGridViewCellStyle23.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn3.DefaultCellStyle = dataGridViewCellStyle23;
-            this.dataGridViewProgressBarColumn3.HeaderText = "Max CPU %";
-            this.dataGridViewProgressBarColumn3.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn3.Name = "dataGridViewProgressBarColumn3";
-            this.dataGridViewProgressBarColumn3.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn3.Width = 125;
+            dataGridViewProgressBarColumn3.DefaultCellStyle = dataGridViewCellStyle23;
+            dataGridViewProgressBarColumn3.HeaderText = "Max CPU %";
+            dataGridViewProgressBarColumn3.MinimumWidth = 6;
+            dataGridViewProgressBarColumn3.Name = "dataGridViewProgressBarColumn3";
+            dataGridViewProgressBarColumn3.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn3.Width = 125;
             // 
             // dataGridViewProgressBarColumn4
             // 
-            this.dataGridViewProgressBarColumn4.DataPropertyName = "MaxDataPercent";
+            dataGridViewProgressBarColumn4.DataPropertyName = "MaxDataPercent";
             dataGridViewCellStyle24.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle24.Format = "P1";
             dataGridViewCellStyle24.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn4.DefaultCellStyle = dataGridViewCellStyle24;
-            this.dataGridViewProgressBarColumn4.HeaderText = "Max Data %";
-            this.dataGridViewProgressBarColumn4.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn4.Name = "dataGridViewProgressBarColumn4";
-            this.dataGridViewProgressBarColumn4.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn4.Width = 125;
+            dataGridViewProgressBarColumn4.DefaultCellStyle = dataGridViewCellStyle24;
+            dataGridViewProgressBarColumn4.HeaderText = "Max Data %";
+            dataGridViewProgressBarColumn4.MinimumWidth = 6;
+            dataGridViewProgressBarColumn4.Name = "dataGridViewProgressBarColumn4";
+            dataGridViewProgressBarColumn4.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn4.Width = 125;
             // 
             // dataGridViewProgressBarColumn5
             // 
-            this.dataGridViewProgressBarColumn5.DataPropertyName = "MaxLogWritePercent";
+            dataGridViewProgressBarColumn5.DataPropertyName = "MaxLogWritePercent";
             dataGridViewCellStyle25.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle25.Format = "P1";
             dataGridViewCellStyle25.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn5.DefaultCellStyle = dataGridViewCellStyle25;
-            this.dataGridViewProgressBarColumn5.HeaderText = "Max Log Write %";
-            this.dataGridViewProgressBarColumn5.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn5.Name = "dataGridViewProgressBarColumn5";
-            this.dataGridViewProgressBarColumn5.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn5.Width = 125;
+            dataGridViewProgressBarColumn5.DefaultCellStyle = dataGridViewCellStyle25;
+            dataGridViewProgressBarColumn5.HeaderText = "Max Log Write %";
+            dataGridViewProgressBarColumn5.MinimumWidth = 6;
+            dataGridViewProgressBarColumn5.Name = "dataGridViewProgressBarColumn5";
+            dataGridViewProgressBarColumn5.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn5.Width = 125;
             // 
             // dataGridViewProgressBarColumn6
             // 
-            this.dataGridViewProgressBarColumn6.DataPropertyName = "AvgCPUPercent";
+            dataGridViewProgressBarColumn6.DataPropertyName = "AvgCPUPercent";
             dataGridViewCellStyle26.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle26.Format = "P1";
             dataGridViewCellStyle26.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn6.DefaultCellStyle = dataGridViewCellStyle26;
-            this.dataGridViewProgressBarColumn6.HeaderText = "Avg CPU %";
-            this.dataGridViewProgressBarColumn6.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn6.Name = "dataGridViewProgressBarColumn6";
-            this.dataGridViewProgressBarColumn6.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn6.Width = 125;
+            dataGridViewProgressBarColumn6.DefaultCellStyle = dataGridViewCellStyle26;
+            dataGridViewProgressBarColumn6.HeaderText = "Avg CPU %";
+            dataGridViewProgressBarColumn6.MinimumWidth = 6;
+            dataGridViewProgressBarColumn6.Name = "dataGridViewProgressBarColumn6";
+            dataGridViewProgressBarColumn6.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn6.Width = 125;
             // 
             // dataGridViewProgressBarColumn7
             // 
-            this.dataGridViewProgressBarColumn7.DataPropertyName = "AvgDataPercent";
+            dataGridViewProgressBarColumn7.DataPropertyName = "AvgDataPercent";
             dataGridViewCellStyle27.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle27.Format = "P1";
             dataGridViewCellStyle27.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn7.DefaultCellStyle = dataGridViewCellStyle27;
-            this.dataGridViewProgressBarColumn7.HeaderText = "Avg Data %";
-            this.dataGridViewProgressBarColumn7.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn7.Name = "dataGridViewProgressBarColumn7";
-            this.dataGridViewProgressBarColumn7.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn7.Width = 125;
+            dataGridViewProgressBarColumn7.DefaultCellStyle = dataGridViewCellStyle27;
+            dataGridViewProgressBarColumn7.HeaderText = "Avg Data %";
+            dataGridViewProgressBarColumn7.MinimumWidth = 6;
+            dataGridViewProgressBarColumn7.Name = "dataGridViewProgressBarColumn7";
+            dataGridViewProgressBarColumn7.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn7.Width = 125;
             // 
             // dataGridViewProgressBarColumn8
             // 
-            this.dataGridViewProgressBarColumn8.DataPropertyName = "AvgLogWritePercent";
+            dataGridViewProgressBarColumn8.DataPropertyName = "AvgLogWritePercent";
             dataGridViewCellStyle28.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle28.Format = "P1";
             dataGridViewCellStyle28.Padding = new System.Windows.Forms.Padding(4);
-            this.dataGridViewProgressBarColumn8.DefaultCellStyle = dataGridViewCellStyle28;
-            this.dataGridViewProgressBarColumn8.HeaderText = "Avg Log Write %";
-            this.dataGridViewProgressBarColumn8.MinimumWidth = 6;
-            this.dataGridViewProgressBarColumn8.Name = "dataGridViewProgressBarColumn8";
-            this.dataGridViewProgressBarColumn8.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.dataGridViewProgressBarColumn8.Width = 125;
+            dataGridViewProgressBarColumn8.DefaultCellStyle = dataGridViewCellStyle28;
+            dataGridViewProgressBarColumn8.HeaderText = "Avg Log Write %";
+            dataGridViewProgressBarColumn8.MinimumWidth = 6;
+            dataGridViewProgressBarColumn8.Name = "dataGridViewProgressBarColumn8";
+            dataGridViewProgressBarColumn8.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewProgressBarColumn8.Width = 125;
             // 
             // dataGridViewTextBoxColumn11
             // 
-            this.dataGridViewTextBoxColumn11.DataPropertyName = "Min_DTULimit";
-            this.dataGridViewTextBoxColumn11.HeaderText = "DTU Limit (Min)";
-            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            this.dataGridViewTextBoxColumn11.ReadOnly = true;
-            this.dataGridViewTextBoxColumn11.Width = 125;
+            dataGridViewTextBoxColumn11.DataPropertyName = "Min_DTULimit";
+            dataGridViewTextBoxColumn11.HeaderText = "DTU Limit (Min)";
+            dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            dataGridViewTextBoxColumn11.ReadOnly = true;
+            dataGridViewTextBoxColumn11.Width = 125;
             // 
             // dataGridViewTextBoxColumn12
             // 
-            this.dataGridViewTextBoxColumn12.DataPropertyName = "Max_DTULimit";
-            this.dataGridViewTextBoxColumn12.HeaderText = "DTU Limit (Max)";
-            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            this.dataGridViewTextBoxColumn12.ReadOnly = true;
-            this.dataGridViewTextBoxColumn12.Width = 125;
+            dataGridViewTextBoxColumn12.DataPropertyName = "Max_DTULimit";
+            dataGridViewTextBoxColumn12.HeaderText = "DTU Limit (Max)";
+            dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            dataGridViewTextBoxColumn12.ReadOnly = true;
+            dataGridViewTextBoxColumn12.Width = 125;
             // 
             // dataGridViewTextBoxColumn13
             // 
-            this.dataGridViewTextBoxColumn13.DataPropertyName = "MaxCPUPercent";
-            this.dataGridViewTextBoxColumn13.HeaderText = "Max CPU %";
-            this.dataGridViewTextBoxColumn13.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
-            this.dataGridViewTextBoxColumn13.ReadOnly = true;
-            this.dataGridViewTextBoxColumn13.Width = 125;
+            dataGridViewTextBoxColumn13.DataPropertyName = "MaxCPUPercent";
+            dataGridViewTextBoxColumn13.HeaderText = "Max CPU %";
+            dataGridViewTextBoxColumn13.MinimumWidth = 6;
+            dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
+            dataGridViewTextBoxColumn13.ReadOnly = true;
+            dataGridViewTextBoxColumn13.Width = 125;
             // 
             // dataGridViewTextBoxColumn14
             // 
-            this.dataGridViewTextBoxColumn14.DataPropertyName = "MaxDataPercent";
-            this.dataGridViewTextBoxColumn14.HeaderText = "Max Data %";
-            this.dataGridViewTextBoxColumn14.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
-            this.dataGridViewTextBoxColumn14.ReadOnly = true;
-            this.dataGridViewTextBoxColumn14.Width = 125;
+            dataGridViewTextBoxColumn14.DataPropertyName = "MaxDataPercent";
+            dataGridViewTextBoxColumn14.HeaderText = "Max Data %";
+            dataGridViewTextBoxColumn14.MinimumWidth = 6;
+            dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
+            dataGridViewTextBoxColumn14.ReadOnly = true;
+            dataGridViewTextBoxColumn14.Width = 125;
             // 
             // dataGridViewTextBoxColumn15
             // 
-            this.dataGridViewTextBoxColumn15.DataPropertyName = "MaxLogWritePercent";
-            this.dataGridViewTextBoxColumn15.HeaderText = "Max Log Write %";
-            this.dataGridViewTextBoxColumn15.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
-            this.dataGridViewTextBoxColumn15.ReadOnly = true;
-            this.dataGridViewTextBoxColumn15.Width = 125;
+            dataGridViewTextBoxColumn15.DataPropertyName = "MaxLogWritePercent";
+            dataGridViewTextBoxColumn15.HeaderText = "Max Log Write %";
+            dataGridViewTextBoxColumn15.MinimumWidth = 6;
+            dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
+            dataGridViewTextBoxColumn15.ReadOnly = true;
+            dataGridViewTextBoxColumn15.Width = 125;
             // 
             // dataGridViewTextBoxColumn16
             // 
-            this.dataGridViewTextBoxColumn16.DataPropertyName = "AvgCPUPercent";
-            this.dataGridViewTextBoxColumn16.HeaderText = "Avg CPU %";
-            this.dataGridViewTextBoxColumn16.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
-            this.dataGridViewTextBoxColumn16.ReadOnly = true;
-            this.dataGridViewTextBoxColumn16.Width = 125;
+            dataGridViewTextBoxColumn16.DataPropertyName = "AvgCPUPercent";
+            dataGridViewTextBoxColumn16.HeaderText = "Avg CPU %";
+            dataGridViewTextBoxColumn16.MinimumWidth = 6;
+            dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
+            dataGridViewTextBoxColumn16.ReadOnly = true;
+            dataGridViewTextBoxColumn16.Width = 125;
             // 
             // dataGridViewTextBoxColumn17
             // 
-            this.dataGridViewTextBoxColumn17.DataPropertyName = "AvgDataPercent";
-            this.dataGridViewTextBoxColumn17.HeaderText = "Avg Data %";
-            this.dataGridViewTextBoxColumn17.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
-            this.dataGridViewTextBoxColumn17.ReadOnly = true;
-            this.dataGridViewTextBoxColumn17.Width = 125;
+            dataGridViewTextBoxColumn17.DataPropertyName = "AvgDataPercent";
+            dataGridViewTextBoxColumn17.HeaderText = "Avg Data %";
+            dataGridViewTextBoxColumn17.MinimumWidth = 6;
+            dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
+            dataGridViewTextBoxColumn17.ReadOnly = true;
+            dataGridViewTextBoxColumn17.Width = 125;
             // 
             // dataGridViewTextBoxColumn18
             // 
-            this.dataGridViewTextBoxColumn18.DataPropertyName = "AvgLogWritePercent";
-            this.dataGridViewTextBoxColumn18.HeaderText = "Avg Log Write %";
-            this.dataGridViewTextBoxColumn18.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
-            this.dataGridViewTextBoxColumn18.ReadOnly = true;
-            this.dataGridViewTextBoxColumn18.Width = 125;
+            dataGridViewTextBoxColumn18.DataPropertyName = "AvgLogWritePercent";
+            dataGridViewTextBoxColumn18.HeaderText = "Avg Log Write %";
+            dataGridViewTextBoxColumn18.MinimumWidth = 6;
+            dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
+            dataGridViewTextBoxColumn18.ReadOnly = true;
+            dataGridViewTextBoxColumn18.Width = 125;
             // 
             // dgvPool
             // 
-            this.dgvPool.AllowUserToAddRows = false;
-            this.dgvPool.AllowUserToDeleteRows = false;
-            this.dgvPool.AllowUserToOrderColumns = true;
-            this.dgvPool.BackgroundColor = System.Drawing.Color.White;
+            dgvPool.AllowUserToAddRows = false;
+            dgvPool.AllowUserToDeleteRows = false;
+            dgvPool.AllowUserToOrderColumns = true;
+            dgvPool.BackgroundColor = System.Drawing.Color.White;
             dataGridViewCellStyle29.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle29.BackColor = System.Drawing.SystemColors.Control;
             dataGridViewCellStyle29.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
@@ -907,34 +874,9 @@
             dataGridViewCellStyle29.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle29.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle29.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvPool.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle29;
-            this.dgvPool.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvPool.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.poolInstance,
-            this.colPoolName,
-            this.dgvPool_DTUHistogram,
-            this.dgvPool_CPUHistogram,
-            this.dgvPool_DataHistogram,
-            this.dgvPool_LogHistogram,
-            this.poolMaxDTUPct,
-            this.poolMaxDTU,
-            this.poolUnusedDTU,
-            this.poolAVGDTUPct,
-            this.poolAVGDTU,
-            this.poolMinDTULimit,
-            this.poolDTULimitMax,
-            this.colCPULimitMin,
-            this.colCPULimitMax,
-            this.poolMaxCPU,
-            this.poolMaxDataPct,
-            this.poolMaxLogWrite,
-            this.poolAvgCPU,
-            this.poolAvgData,
-            this.poolAvgLogWrite,
-            this.colAllocatedStoragePct,
-            this.colStorageLimit,
-            this.colCurrentUsedGB,
-            this.colCurrentFreeGB});
+            dgvPool.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle29;
+            dgvPool.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvPool.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { poolInstance, colPoolName, dgvPool_DTUHistogram, dgvPool_CPUHistogram, dgvPool_DataHistogram, dgvPool_LogHistogram, poolMaxDTUPct, poolMaxDTU, poolUnusedDTU, poolAVGDTUPct, poolAVGDTU, poolMinDTULimit, poolDTULimitMax, colCPULimitMin, colCPULimitMax, poolMaxCPU, poolMaxDataPct, poolMaxLogWrite, poolAvgCPU, poolAvgData, poolAvgLogWrite, colAllocatedStoragePct, colStorageLimit, colCurrentUsedGB, colCurrentFreeGB });
             dataGridViewCellStyle42.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle42.BackColor = System.Drawing.SystemColors.Window;
             dataGridViewCellStyle42.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
@@ -942,396 +884,390 @@
             dataGridViewCellStyle42.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle42.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle42.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvPool.DefaultCellStyle = dataGridViewCellStyle42;
-            this.dgvPool.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvPool.Location = new System.Drawing.Point(0, 27);
-            this.dgvPool.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvPool.Name = "dgvPool";
-            this.dgvPool.ReadOnly = true;
-            this.dgvPool.RowHeadersVisible = false;
-            this.dgvPool.RowHeadersWidth = 51;
-            this.dgvPool.RowTemplate.Height = 24;
-            this.dgvPool.Size = new System.Drawing.Size(1455, 440);
-            this.dgvPool.TabIndex = 5;
-            this.dgvPool.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvPool_CellContentClick);
-            this.dgvPool.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvPol_RowsAdded);
-            this.dgvPool.Sorted += new System.EventHandler(this.DgvPool_Sorted);
+            dgvPool.DefaultCellStyle = dataGridViewCellStyle42;
+            dgvPool.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvPool.Location = new System.Drawing.Point(0, 27);
+            dgvPool.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvPool.Name = "dgvPool";
+            dgvPool.ReadOnly = true;
+            dgvPool.RowHeadersVisible = false;
+            dgvPool.RowHeadersWidth = 51;
+            dgvPool.RowTemplate.Height = 24;
+            dgvPool.Size = new System.Drawing.Size(1455, 440);
+            dgvPool.TabIndex = 5;
+            dgvPool.CellContentClick += DgvPool_CellContentClick;
+            dgvPool.RowsAdded += DgvPol_RowsAdded;
+            dgvPool.Sorted += DgvPool_Sorted;
             // 
             // poolInstance
             // 
-            this.poolInstance.DataPropertyName = "Instance";
-            this.poolInstance.HeaderText = "Instance";
-            this.poolInstance.MinimumWidth = 6;
-            this.poolInstance.Name = "poolInstance";
-            this.poolInstance.ReadOnly = true;
-            this.poolInstance.Width = 90;
+            poolInstance.DataPropertyName = "Instance";
+            poolInstance.HeaderText = "Instance";
+            poolInstance.MinimumWidth = 6;
+            poolInstance.Name = "poolInstance";
+            poolInstance.ReadOnly = true;
+            poolInstance.Width = 90;
             // 
             // colPoolName
             // 
-            this.colPoolName.DataPropertyName = "elastic_pool_name";
-            this.colPoolName.HeaderText = "Elastic Pool";
-            this.colPoolName.MinimumWidth = 6;
-            this.colPoolName.Name = "colPoolName";
-            this.colPoolName.ReadOnly = true;
-            this.colPoolName.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colPoolName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colPoolName.Width = 101;
+            colPoolName.DataPropertyName = "elastic_pool_name";
+            colPoolName.HeaderText = "Elastic Pool";
+            colPoolName.MinimumWidth = 6;
+            colPoolName.Name = "colPoolName";
+            colPoolName.ReadOnly = true;
+            colPoolName.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colPoolName.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colPoolName.Width = 101;
             // 
             // dgvPool_DTUHistogram
             // 
-            this.dgvPool_DTUHistogram.HeaderText = "DTU Histogram";
-            this.dgvPool_DTUHistogram.MinimumWidth = 6;
-            this.dgvPool_DTUHistogram.Name = "dgvPool_DTUHistogram";
-            this.dgvPool_DTUHistogram.ReadOnly = true;
-            this.dgvPool_DTUHistogram.Visible = false;
-            this.dgvPool_DTUHistogram.Width = 111;
+            dgvPool_DTUHistogram.HeaderText = "DTU Histogram";
+            dgvPool_DTUHistogram.MinimumWidth = 6;
+            dgvPool_DTUHistogram.Name = "dgvPool_DTUHistogram";
+            dgvPool_DTUHistogram.ReadOnly = true;
+            dgvPool_DTUHistogram.Visible = false;
+            dgvPool_DTUHistogram.Width = 111;
             // 
             // dgvPool_CPUHistogram
             // 
-            this.dgvPool_CPUHistogram.HeaderText = "CPU Histogram";
-            this.dgvPool_CPUHistogram.MinimumWidth = 6;
-            this.dgvPool_CPUHistogram.Name = "dgvPool_CPUHistogram";
-            this.dgvPool_CPUHistogram.ReadOnly = true;
-            this.dgvPool_CPUHistogram.Visible = false;
-            this.dgvPool_CPUHistogram.Width = 110;
+            dgvPool_CPUHistogram.HeaderText = "CPU Histogram";
+            dgvPool_CPUHistogram.MinimumWidth = 6;
+            dgvPool_CPUHistogram.Name = "dgvPool_CPUHistogram";
+            dgvPool_CPUHistogram.ReadOnly = true;
+            dgvPool_CPUHistogram.Visible = false;
+            dgvPool_CPUHistogram.Width = 110;
             // 
             // dgvPool_DataHistogram
             // 
-            this.dgvPool_DataHistogram.HeaderText = "Data Histogram";
-            this.dgvPool_DataHistogram.MinimumWidth = 6;
-            this.dgvPool_DataHistogram.Name = "dgvPool_DataHistogram";
-            this.dgvPool_DataHistogram.ReadOnly = true;
-            this.dgvPool_DataHistogram.Visible = false;
-            this.dgvPool_DataHistogram.Width = 112;
+            dgvPool_DataHistogram.HeaderText = "Data Histogram";
+            dgvPool_DataHistogram.MinimumWidth = 6;
+            dgvPool_DataHistogram.Name = "dgvPool_DataHistogram";
+            dgvPool_DataHistogram.ReadOnly = true;
+            dgvPool_DataHistogram.Visible = false;
+            dgvPool_DataHistogram.Width = 112;
             // 
             // dgvPool_LogHistogram
             // 
-            this.dgvPool_LogHistogram.HeaderText = "Log Histogram";
-            this.dgvPool_LogHistogram.MinimumWidth = 6;
-            this.dgvPool_LogHistogram.Name = "dgvPool_LogHistogram";
-            this.dgvPool_LogHistogram.ReadOnly = true;
-            this.dgvPool_LogHistogram.Visible = false;
-            this.dgvPool_LogHistogram.Width = 106;
+            dgvPool_LogHistogram.HeaderText = "Log Histogram";
+            dgvPool_LogHistogram.MinimumWidth = 6;
+            dgvPool_LogHistogram.Name = "dgvPool_LogHistogram";
+            dgvPool_LogHistogram.ReadOnly = true;
+            dgvPool_LogHistogram.Visible = false;
+            dgvPool_LogHistogram.Width = 106;
             // 
             // poolMaxDTUPct
             // 
-            this.poolMaxDTUPct.DataPropertyName = "Max_DTUPercent";
-            this.poolMaxDTUPct.HeaderText = "Max DTU %";
-            this.poolMaxDTUPct.MinimumWidth = 6;
-            this.poolMaxDTUPct.Name = "poolMaxDTUPct";
-            this.poolMaxDTUPct.ReadOnly = true;
-            this.poolMaxDTUPct.Width = 91;
+            poolMaxDTUPct.DataPropertyName = "Max_DTUPercent";
+            poolMaxDTUPct.HeaderText = "Max DTU %";
+            poolMaxDTUPct.MinimumWidth = 6;
+            poolMaxDTUPct.Name = "poolMaxDTUPct";
+            poolMaxDTUPct.ReadOnly = true;
+            poolMaxDTUPct.Width = 91;
             // 
             // poolMaxDTU
             // 
-            this.poolMaxDTU.DataPropertyName = "Max_DTUsUsed";
-            this.poolMaxDTU.HeaderText = "Max DTUs Used";
-            this.poolMaxDTU.MinimumWidth = 6;
-            this.poolMaxDTU.Name = "poolMaxDTU";
-            this.poolMaxDTU.ReadOnly = true;
-            this.poolMaxDTU.Width = 127;
+            poolMaxDTU.DataPropertyName = "Max_DTUsUsed";
+            poolMaxDTU.HeaderText = "Max DTUs Used";
+            poolMaxDTU.MinimumWidth = 6;
+            poolMaxDTU.Name = "poolMaxDTU";
+            poolMaxDTU.ReadOnly = true;
+            poolMaxDTU.Width = 127;
             // 
             // poolUnusedDTU
             // 
-            this.poolUnusedDTU.DataPropertyName = "UnusedDTU";
-            this.poolUnusedDTU.HeaderText = "Unused DTUs";
-            this.poolUnusedDTU.MinimumWidth = 6;
-            this.poolUnusedDTU.Name = "poolUnusedDTU";
-            this.poolUnusedDTU.ReadOnly = true;
-            this.poolUnusedDTU.Width = 116;
+            poolUnusedDTU.DataPropertyName = "UnusedDTU";
+            poolUnusedDTU.HeaderText = "Unused DTUs";
+            poolUnusedDTU.MinimumWidth = 6;
+            poolUnusedDTU.Name = "poolUnusedDTU";
+            poolUnusedDTU.ReadOnly = true;
+            poolUnusedDTU.Width = 116;
             // 
             // poolAVGDTUPct
             // 
-            this.poolAVGDTUPct.DataPropertyName = "Avg_DTUPercent";
-            this.poolAVGDTUPct.HeaderText = "Avg DTU %";
-            this.poolAVGDTUPct.MinimumWidth = 6;
-            this.poolAVGDTUPct.Name = "poolAVGDTUPct";
-            this.poolAVGDTUPct.ReadOnly = true;
-            this.poolAVGDTUPct.Width = 91;
+            poolAVGDTUPct.DataPropertyName = "Avg_DTUPercent";
+            poolAVGDTUPct.HeaderText = "Avg DTU %";
+            poolAVGDTUPct.MinimumWidth = 6;
+            poolAVGDTUPct.Name = "poolAVGDTUPct";
+            poolAVGDTUPct.ReadOnly = true;
+            poolAVGDTUPct.Width = 91;
             // 
             // poolAVGDTU
             // 
-            this.poolAVGDTU.DataPropertyName = "Avg_DTUsUsed";
-            this.poolAVGDTU.HeaderText = "Avg DTUs Used";
-            this.poolAVGDTU.MinimumWidth = 6;
-            this.poolAVGDTU.Name = "poolAVGDTU";
-            this.poolAVGDTU.ReadOnly = true;
-            this.poolAVGDTU.Width = 127;
+            poolAVGDTU.DataPropertyName = "Avg_DTUsUsed";
+            poolAVGDTU.HeaderText = "Avg DTUs Used";
+            poolAVGDTU.MinimumWidth = 6;
+            poolAVGDTU.Name = "poolAVGDTU";
+            poolAVGDTU.ReadOnly = true;
+            poolAVGDTU.Width = 127;
             // 
             // poolMinDTULimit
             // 
-            this.poolMinDTULimit.DataPropertyName = "Min_DTULimit";
-            this.poolMinDTULimit.HeaderText = "DTU Limit (Min)";
-            this.poolMinDTULimit.MinimumWidth = 6;
-            this.poolMinDTULimit.Name = "poolMinDTULimit";
-            this.poolMinDTULimit.ReadOnly = true;
-            this.poolMinDTULimit.Visible = false;
-            this.poolMinDTULimit.Width = 124;
+            poolMinDTULimit.DataPropertyName = "Min_DTULimit";
+            poolMinDTULimit.HeaderText = "DTU Limit (Min)";
+            poolMinDTULimit.MinimumWidth = 6;
+            poolMinDTULimit.Name = "poolMinDTULimit";
+            poolMinDTULimit.ReadOnly = true;
+            poolMinDTULimit.Visible = false;
+            poolMinDTULimit.Width = 124;
             // 
             // poolDTULimitMax
             // 
-            this.poolDTULimitMax.DataPropertyName = "Max_DTULimit";
-            this.poolDTULimitMax.HeaderText = "DTU Limit (Max)";
-            this.poolDTULimitMax.MinimumWidth = 6;
-            this.poolDTULimitMax.Name = "poolDTULimitMax";
-            this.poolDTULimitMax.ReadOnly = true;
-            this.poolDTULimitMax.Width = 127;
+            poolDTULimitMax.DataPropertyName = "Max_DTULimit";
+            poolDTULimitMax.HeaderText = "DTU Limit (Max)";
+            poolDTULimitMax.MinimumWidth = 6;
+            poolDTULimitMax.Name = "poolDTULimitMax";
+            poolDTULimitMax.ReadOnly = true;
+            poolDTULimitMax.Width = 127;
             // 
             // colCPULimitMin
             // 
-            this.colCPULimitMin.DataPropertyName = "MinCPULimit";
+            colCPULimitMin.DataPropertyName = "MinCPULimit";
             dataGridViewCellStyle30.Format = "N2";
-            this.colCPULimitMin.DefaultCellStyle = dataGridViewCellStyle30;
-            this.colCPULimitMin.HeaderText = "CPU Limit (Min)";
-            this.colCPULimitMin.MinimumWidth = 6;
-            this.colCPULimitMin.Name = "colCPULimitMin";
-            this.colCPULimitMin.ReadOnly = true;
-            this.colCPULimitMin.Visible = false;
-            this.colCPULimitMin.Width = 123;
+            colCPULimitMin.DefaultCellStyle = dataGridViewCellStyle30;
+            colCPULimitMin.HeaderText = "CPU Limit (Min)";
+            colCPULimitMin.MinimumWidth = 6;
+            colCPULimitMin.Name = "colCPULimitMin";
+            colCPULimitMin.ReadOnly = true;
+            colCPULimitMin.Visible = false;
+            colCPULimitMin.Width = 123;
             // 
             // colCPULimitMax
             // 
-            this.colCPULimitMax.DataPropertyName = "MaxCPULimit";
+            colCPULimitMax.DataPropertyName = "MaxCPULimit";
             dataGridViewCellStyle31.Format = "N2";
-            this.colCPULimitMax.DefaultCellStyle = dataGridViewCellStyle31;
-            this.colCPULimitMax.HeaderText = "CPU Limit (Max)";
-            this.colCPULimitMax.MinimumWidth = 6;
-            this.colCPULimitMax.Name = "colCPULimitMax";
-            this.colCPULimitMax.ReadOnly = true;
-            this.colCPULimitMax.Width = 126;
+            colCPULimitMax.DefaultCellStyle = dataGridViewCellStyle31;
+            colCPULimitMax.HeaderText = "CPU Limit (Max)";
+            colCPULimitMax.MinimumWidth = 6;
+            colCPULimitMax.Name = "colCPULimitMax";
+            colCPULimitMax.ReadOnly = true;
+            colCPULimitMax.Width = 126;
             // 
             // poolMaxCPU
             // 
-            this.poolMaxCPU.DataPropertyName = "MaxCPUPercent";
+            poolMaxCPU.DataPropertyName = "MaxCPUPercent";
             dataGridViewCellStyle32.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle32.Format = "0.#\\%";
             dataGridViewCellStyle32.Padding = new System.Windows.Forms.Padding(4);
-            this.poolMaxCPU.DefaultCellStyle = dataGridViewCellStyle32;
-            this.poolMaxCPU.HeaderText = "Max CPU %";
-            this.poolMaxCPU.MinimumWidth = 6;
-            this.poolMaxCPU.Name = "poolMaxCPU";
-            this.poolMaxCPU.ReadOnly = true;
-            this.poolMaxCPU.Width = 91;
+            poolMaxCPU.DefaultCellStyle = dataGridViewCellStyle32;
+            poolMaxCPU.HeaderText = "Max CPU %";
+            poolMaxCPU.MinimumWidth = 6;
+            poolMaxCPU.Name = "poolMaxCPU";
+            poolMaxCPU.ReadOnly = true;
+            poolMaxCPU.Width = 91;
             // 
             // poolMaxDataPct
             // 
-            this.poolMaxDataPct.DataPropertyName = "MaxDataPercent";
+            poolMaxDataPct.DataPropertyName = "MaxDataPercent";
             dataGridViewCellStyle33.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle33.Format = "0.#\\%";
             dataGridViewCellStyle33.Padding = new System.Windows.Forms.Padding(4);
-            this.poolMaxDataPct.DefaultCellStyle = dataGridViewCellStyle33;
-            this.poolMaxDataPct.HeaderText = "Max Data %";
-            this.poolMaxDataPct.MinimumWidth = 6;
-            this.poolMaxDataPct.Name = "poolMaxDataPct";
-            this.poolMaxDataPct.ReadOnly = true;
-            this.poolMaxDataPct.Width = 92;
+            poolMaxDataPct.DefaultCellStyle = dataGridViewCellStyle33;
+            poolMaxDataPct.HeaderText = "Max Data %";
+            poolMaxDataPct.MinimumWidth = 6;
+            poolMaxDataPct.Name = "poolMaxDataPct";
+            poolMaxDataPct.ReadOnly = true;
+            poolMaxDataPct.Width = 92;
             // 
             // poolMaxLogWrite
             // 
-            this.poolMaxLogWrite.DataPropertyName = "MaxLogWritePercent";
+            poolMaxLogWrite.DataPropertyName = "MaxLogWritePercent";
             dataGridViewCellStyle34.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle34.Format = "0.#\\%";
             dataGridViewCellStyle34.Padding = new System.Windows.Forms.Padding(4);
-            this.poolMaxLogWrite.DefaultCellStyle = dataGridViewCellStyle34;
-            this.poolMaxLogWrite.HeaderText = "Max Log Write %";
-            this.poolMaxLogWrite.MinimumWidth = 6;
-            this.poolMaxLogWrite.Name = "poolMaxLogWrite";
-            this.poolMaxLogWrite.ReadOnly = true;
-            this.poolMaxLogWrite.Width = 120;
+            poolMaxLogWrite.DefaultCellStyle = dataGridViewCellStyle34;
+            poolMaxLogWrite.HeaderText = "Max Log Write %";
+            poolMaxLogWrite.MinimumWidth = 6;
+            poolMaxLogWrite.Name = "poolMaxLogWrite";
+            poolMaxLogWrite.ReadOnly = true;
+            poolMaxLogWrite.Width = 120;
             // 
             // poolAvgCPU
             // 
-            this.poolAvgCPU.DataPropertyName = "AvgCPUPercent";
+            poolAvgCPU.DataPropertyName = "AvgCPUPercent";
             dataGridViewCellStyle35.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle35.Format = "0.#\\%";
             dataGridViewCellStyle35.Padding = new System.Windows.Forms.Padding(4);
-            this.poolAvgCPU.DefaultCellStyle = dataGridViewCellStyle35;
-            this.poolAvgCPU.HeaderText = "Avg CPU %";
-            this.poolAvgCPU.MinimumWidth = 6;
-            this.poolAvgCPU.Name = "poolAvgCPU";
-            this.poolAvgCPU.ReadOnly = true;
-            this.poolAvgCPU.Width = 90;
+            poolAvgCPU.DefaultCellStyle = dataGridViewCellStyle35;
+            poolAvgCPU.HeaderText = "Avg CPU %";
+            poolAvgCPU.MinimumWidth = 6;
+            poolAvgCPU.Name = "poolAvgCPU";
+            poolAvgCPU.ReadOnly = true;
+            poolAvgCPU.Width = 90;
             // 
             // poolAvgData
             // 
-            this.poolAvgData.DataPropertyName = "AvgDataPercent";
+            poolAvgData.DataPropertyName = "AvgDataPercent";
             dataGridViewCellStyle36.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle36.Format = "0.#\\%";
             dataGridViewCellStyle36.Padding = new System.Windows.Forms.Padding(4);
-            this.poolAvgData.DefaultCellStyle = dataGridViewCellStyle36;
-            this.poolAvgData.HeaderText = "Avg Data %";
-            this.poolAvgData.MinimumWidth = 6;
-            this.poolAvgData.Name = "poolAvgData";
-            this.poolAvgData.ReadOnly = true;
-            this.poolAvgData.Width = 91;
+            poolAvgData.DefaultCellStyle = dataGridViewCellStyle36;
+            poolAvgData.HeaderText = "Avg Data %";
+            poolAvgData.MinimumWidth = 6;
+            poolAvgData.Name = "poolAvgData";
+            poolAvgData.ReadOnly = true;
+            poolAvgData.Width = 91;
             // 
             // poolAvgLogWrite
             // 
-            this.poolAvgLogWrite.DataPropertyName = "AvgLogWritePercent";
+            poolAvgLogWrite.DataPropertyName = "AvgLogWritePercent";
             dataGridViewCellStyle37.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleRight;
             dataGridViewCellStyle37.Format = "0.#\\%";
             dataGridViewCellStyle37.Padding = new System.Windows.Forms.Padding(4);
-            this.poolAvgLogWrite.DefaultCellStyle = dataGridViewCellStyle37;
-            this.poolAvgLogWrite.HeaderText = "Avg Log Write %";
-            this.poolAvgLogWrite.MinimumWidth = 6;
-            this.poolAvgLogWrite.Name = "poolAvgLogWrite";
-            this.poolAvgLogWrite.ReadOnly = true;
-            this.poolAvgLogWrite.Width = 119;
+            poolAvgLogWrite.DefaultCellStyle = dataGridViewCellStyle37;
+            poolAvgLogWrite.HeaderText = "Avg Log Write %";
+            poolAvgLogWrite.MinimumWidth = 6;
+            poolAvgLogWrite.Name = "poolAvgLogWrite";
+            poolAvgLogWrite.ReadOnly = true;
+            poolAvgLogWrite.Width = 119;
             // 
             // colAllocatedStoragePct
             // 
-            this.colAllocatedStoragePct.DataPropertyName = "current_allocated_storage_percent";
+            colAllocatedStoragePct.DataPropertyName = "current_allocated_storage_percent";
             dataGridViewCellStyle38.Format = "###.#\\%";
             dataGridViewCellStyle38.NullValue = null;
-            this.colAllocatedStoragePct.DefaultCellStyle = dataGridViewCellStyle38;
-            this.colAllocatedStoragePct.HeaderText = "Current Allocated Storage %";
-            this.colAllocatedStoragePct.MinimumWidth = 6;
-            this.colAllocatedStoragePct.Name = "colAllocatedStoragePct";
-            this.colAllocatedStoragePct.ReadOnly = true;
-            this.colAllocatedStoragePct.Width = 197;
+            colAllocatedStoragePct.DefaultCellStyle = dataGridViewCellStyle38;
+            colAllocatedStoragePct.HeaderText = "Current Allocated Storage %";
+            colAllocatedStoragePct.MinimumWidth = 6;
+            colAllocatedStoragePct.Name = "colAllocatedStoragePct";
+            colAllocatedStoragePct.ReadOnly = true;
+            colAllocatedStoragePct.Width = 197;
             // 
             // colStorageLimit
             // 
-            this.colStorageLimit.DataPropertyName = "current_elastic_pool_storage_limit_gb";
+            colStorageLimit.DataPropertyName = "current_elastic_pool_storage_limit_gb";
             dataGridViewCellStyle39.Format = "#,##0.0";
             dataGridViewCellStyle39.NullValue = null;
-            this.colStorageLimit.DefaultCellStyle = dataGridViewCellStyle39;
-            this.colStorageLimit.HeaderText = "Current Storage Limit (GB)";
-            this.colStorageLimit.MinimumWidth = 6;
-            this.colStorageLimit.Name = "colStorageLimit";
-            this.colStorageLimit.ReadOnly = true;
-            this.colStorageLimit.Width = 160;
+            colStorageLimit.DefaultCellStyle = dataGridViewCellStyle39;
+            colStorageLimit.HeaderText = "Current Storage Limit (GB)";
+            colStorageLimit.MinimumWidth = 6;
+            colStorageLimit.Name = "colStorageLimit";
+            colStorageLimit.ReadOnly = true;
+            colStorageLimit.Width = 160;
             // 
             // colCurrentUsedGB
             // 
-            this.colCurrentUsedGB.DataPropertyName = "current_elastic_pool_storage_used_gb";
+            colCurrentUsedGB.DataPropertyName = "current_elastic_pool_storage_used_gb";
             dataGridViewCellStyle40.Format = "#,##0.0";
-            this.colCurrentUsedGB.DefaultCellStyle = dataGridViewCellStyle40;
-            this.colCurrentUsedGB.HeaderText = "Current Used GB";
-            this.colCurrentUsedGB.MinimumWidth = 6;
-            this.colCurrentUsedGB.Name = "colCurrentUsedGB";
-            this.colCurrentUsedGB.ReadOnly = true;
-            this.colCurrentUsedGB.Width = 115;
+            colCurrentUsedGB.DefaultCellStyle = dataGridViewCellStyle40;
+            colCurrentUsedGB.HeaderText = "Current Used GB";
+            colCurrentUsedGB.MinimumWidth = 6;
+            colCurrentUsedGB.Name = "colCurrentUsedGB";
+            colCurrentUsedGB.ReadOnly = true;
+            colCurrentUsedGB.Width = 115;
             // 
             // colCurrentFreeGB
             // 
-            this.colCurrentFreeGB.DataPropertyName = "current_elastic_pool_storage_free_gb";
+            colCurrentFreeGB.DataPropertyName = "current_elastic_pool_storage_free_gb";
             dataGridViewCellStyle41.Format = "#,##0.0";
-            this.colCurrentFreeGB.DefaultCellStyle = dataGridViewCellStyle41;
-            this.colCurrentFreeGB.HeaderText = "Current Free GB";
-            this.colCurrentFreeGB.MinimumWidth = 6;
-            this.colCurrentFreeGB.Name = "colCurrentFreeGB";
-            this.colCurrentFreeGB.ReadOnly = true;
-            this.colCurrentFreeGB.Width = 111;
+            colCurrentFreeGB.DefaultCellStyle = dataGridViewCellStyle41;
+            colCurrentFreeGB.HeaderText = "Current Free GB";
+            colCurrentFreeGB.MinimumWidth = 6;
+            colCurrentFreeGB.Name = "colCurrentFreeGB";
+            colCurrentFreeGB.ReadOnly = true;
+            colCurrentFreeGB.Width = 111;
             // 
             // splitContainer1
             // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 27);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer1.Location = new System.Drawing.Point(0, 27);
+            splitContainer1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            splitContainer1.Name = "splitContainer1";
+            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.dgv);
+            splitContainer1.Panel1.Controls.Add(dgv);
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.dgvPool);
-            this.splitContainer1.Panel2.Controls.Add(this.toolStrip2);
-            this.splitContainer1.Size = new System.Drawing.Size(1455, 1224);
-            this.splitContainer1.SplitterDistance = 752;
-            this.splitContainer1.SplitterWidth = 5;
-            this.splitContainer1.TabIndex = 6;
+            splitContainer1.Panel2.Controls.Add(dgvPool);
+            splitContainer1.Panel2.Controls.Add(toolStrip2);
+            splitContainer1.Size = new System.Drawing.Size(1455, 1224);
+            splitContainer1.SplitterDistance = 752;
+            splitContainer1.SplitterWidth = 5;
+            splitContainer1.TabIndex = 6;
             // 
             // toolStrip2
             // 
-            this.toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefreshPool,
-            this.tsCopyPool,
-            this.toolStripLabel1,
-            this.tsExcelPool,
-            this.tsPoolCols});
-            this.toolStrip2.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip2.Name = "toolStrip2";
-            this.toolStrip2.Size = new System.Drawing.Size(1455, 27);
-            this.toolStrip2.TabIndex = 6;
-            this.toolStrip2.Text = "toolStrip2";
+            toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefreshPool, tsCopyPool, toolStripLabel1, tsExcelPool, tsPoolCols });
+            toolStrip2.Location = new System.Drawing.Point(0, 0);
+            toolStrip2.Name = "toolStrip2";
+            toolStrip2.Size = new System.Drawing.Size(1455, 27);
+            toolStrip2.TabIndex = 6;
+            toolStrip2.Text = "toolStrip2";
             // 
             // tsRefreshPool
             // 
-            this.tsRefreshPool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefreshPool.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefreshPool.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefreshPool.Name = "tsRefreshPool";
-            this.tsRefreshPool.Size = new System.Drawing.Size(29, 24);
-            this.tsRefreshPool.Text = "toolStripButton1";
-            this.tsRefreshPool.Click += new System.EventHandler(this.TsRefreshPool_Click);
+            tsRefreshPool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefreshPool.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefreshPool.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefreshPool.Name = "tsRefreshPool";
+            tsRefreshPool.Size = new System.Drawing.Size(29, 24);
+            tsRefreshPool.Text = "Refresh";
+            tsRefreshPool.Click += TsRefreshPool_Click;
             // 
             // tsCopyPool
             // 
-            this.tsCopyPool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopyPool.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopyPool.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopyPool.Name = "tsCopyPool";
-            this.tsCopyPool.Size = new System.Drawing.Size(29, 24);
-            this.tsCopyPool.Text = "Copy";
-            this.tsCopyPool.Click += new System.EventHandler(this.TsCopyPool_Click);
+            tsCopyPool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopyPool.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopyPool.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopyPool.Name = "tsCopyPool";
+            tsCopyPool.Size = new System.Drawing.Size(29, 24);
+            tsCopyPool.Text = "Copy";
+            tsCopyPool.Click += TsCopyPool_Click;
             // 
             // toolStripLabel1
             // 
-            this.toolStripLabel1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripLabel1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.toolStripLabel1.Name = "toolStripLabel1";
-            this.toolStripLabel1.Size = new System.Drawing.Size(88, 24);
-            this.toolStripLabel1.Text = "Elastic Pool";
+            toolStripLabel1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            toolStripLabel1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            toolStripLabel1.Name = "toolStripLabel1";
+            toolStripLabel1.Size = new System.Drawing.Size(88, 24);
+            toolStripLabel1.Text = "Elastic Pool";
             // 
             // tsExcelPool
             // 
-            this.tsExcelPool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcelPool.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcelPool.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcelPool.Name = "tsExcelPool";
-            this.tsExcelPool.Size = new System.Drawing.Size(29, 24);
-            this.tsExcelPool.Text = "Export Excel";
-            this.tsExcelPool.Click += new System.EventHandler(this.TsExcelPool_Click);
+            tsExcelPool.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcelPool.Image = Properties.Resources.excel16x16;
+            tsExcelPool.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcelPool.Name = "tsExcelPool";
+            tsExcelPool.Size = new System.Drawing.Size(29, 24);
+            tsExcelPool.Text = "Export Excel";
+            tsExcelPool.Click += TsExcelPool_Click;
             // 
             // tsPoolCols
             // 
-            this.tsPoolCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsPoolCols.Image = global::DBADashGUI.Properties.Resources.Column_16x;
-            this.tsPoolCols.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsPoolCols.Name = "tsPoolCols";
-            this.tsPoolCols.Size = new System.Drawing.Size(29, 24);
-            this.tsPoolCols.Text = "Columns";
-            this.tsPoolCols.Click += new System.EventHandler(this.TsPoolCols_Click);
+            tsPoolCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsPoolCols.Image = Properties.Resources.Column_16x;
+            tsPoolCols.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsPoolCols.Name = "tsPoolCols";
+            tsPoolCols.Size = new System.Drawing.Size(29, 24);
+            tsPoolCols.Text = "Columns";
+            tsPoolCols.Click += TsPoolCols_Click;
             // 
             // AzureSummary
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.splitContainer1);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "AzureSummary";
-            this.Size = new System.Drawing.Size(1455, 1251);
-            this.Load += new System.EventHandler(this.AzureSummary_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.dgv)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvPool)).EndInit();
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            this.splitContainer1.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
-            this.toolStrip2.ResumeLayout(false);
-            this.toolStrip2.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(splitContainer1);
+            Controls.Add(toolStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "AzureSummary";
+            Size = new System.Drawing.Size(1455, 1251);
+            Load += AzureSummary_Load;
+            ((System.ComponentModel.ISupportInitialize)dgv).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)dgvPool).EndInit();
+            splitContainer1.Panel1.ResumeLayout(false);
+            splitContainer1.Panel2.ResumeLayout(false);
+            splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
+            splitContainer1.ResumeLayout(false);
+            toolStrip2.ResumeLayout(false);
+            toolStrip2.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/DBADashGUI/Performance/AzureSummary.resx
+++ b/DBADashGUI/Performance/AzureSummary.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">


### PR DESCRIPTION
A primary key violation occurs when refreshing the summary when monitoring azure instances with multiple elastic pools. 
Fix refresh label on Azure Summary tab.
#650