### PR TITLE
Fix issue where columns are readonly for SQL connections in config tool

### DIFF
--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -1155,10 +1155,10 @@ namespace DBADashServiceConfig
 
         private void SetCellsReadOnly(int row, ConnectionType connectionType)
         {
-            if (connectionType == ConnectionType.SQL) return;
             foreach (DataGridViewColumn col in dgvConnections.Columns)
             {
-                var isReadOnly = !(col.DataPropertyName == "WriteToSecondaryDestinations" || col.Name is "Delete" or "Edit");
+                var isReadOnly = connectionType != ConnectionType.SQL && !(col.DataPropertyName == "WriteToSecondaryDestinations" || col.Name is "Delete" or "Edit");
+
                 dgvConnections.Rows[row].Cells[col.Index].ReadOnly = isReadOnly;
                 dgvConnections.Rows[row].Cells[col.Index].Style.BackColor = isReadOnly ? Color.Silver : Color.White;
             }


### PR DESCRIPTION
Columns are made readonly for S3 and folder sources to prevent configuration of options that don't apply. When there is a mix of different source connection types, SQL connections can inherit the readonly property, preventing them from been configured.
#660