### PR TITLE
Remove NOT NULL from dbo.IdentityColumnsHistory

### DIFF
--- a/DBADashDB/dbo/Tables/IdentityColumnsHistory.sql
+++ b/DBADashDB/dbo/Tables/IdentityColumnsHistory.sql
@@ -3,7 +3,7 @@
 	DatabaseID INT NOT NULL REFERENCES dbo.Databases(DatabaseID),
 	object_id INT NOT NULL,
 	SnapshotDate DATETIME2(2) NOT NULL,
-	last_value BIGINT NOT NULL,
+	last_value BIGINT NULL,
 	row_count BIGINT NOT NULL,
 	CONSTRAINT PK_IdentityColumnsHistory PRIMARY KEY(InstanceID,DatabaseID,object_id,SnapshotDate) WITH(DATA_COMPRESSION=PAGE) ON PS_IdentityColumnsHistory(SnapshotDate) 
 ) ON PS_IdentityColumnsHistory(SnapshotDate)


### PR DESCRIPTION
Fix error that occurs if last_value is NULL.
#670