### PR TITLE
Configure secondary destinations via CLI

### DIFF
--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -92,7 +92,7 @@ jobs:
           Set-Location $InstallPath
           ./dbadashconfig -a SetServiceName --ServiceName $ServiceName
           ./dbadashconfig -c $DBADashFolderDestination -a Add
-          ./dbadashconfig -c "Data Source=localhost;UID=sa;pwd=dbatools.I0;Initial Catalog=DBADashDB_GitHubAction;Encrypt=True;TrustServerCertificate=True;" -a SetDestination      
+          ./dbadashconfig -c "Data Source=localhost;UID=sa;pwd=dbatools.I0;Initial Catalog=DBADashDB_FromFolder;Encrypt=True;TrustServerCertificate=True;" -a SetDestination      
           "Install Service"
           ./DBADashService install --localsystem
 
@@ -124,7 +124,8 @@ jobs:
           Set-Location $InstallPath
           "Configure"
           ./dbadashconfig -a SetServiceName --ServiceName $ServiceName
-          ./dbadashconfig -c $DBADashFolderDestination -a SetDestination
+          ./dbadashconfig -c "Data Source=localhost;UID=sa;pwd=dbatools.I0;Initial Catalog=DBADashDB_Direct;Encrypt=True;TrustServerCertificate=True;" -a AddDestination
+          ./dbadashconfig -c $DBADashFolderDestination -a AddDestination
           ./dbadashconfig -c "Data Source=localhost;UID=sa;pwd=dbatools.I0;Encrypt=True;TrustServerCertificate=True;" -a Add --PlanCollectionEnabled --SlowQueryThresholdMs 1000 --SchemaSnapshotDBs "*"       
           "Install Service"
           ./DBADashService install --localsystem
@@ -156,23 +157,40 @@ jobs:
         run: | 
           ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromFolder\Logs"
 
-      - name: Output CollectionErrorLog
+      - name: Output CollectionErrorLog FromFolder
         shell: powershell
         run: | 
-          Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database "DBADashDB_GitHubAction" -Query "SELECT * FROM dbo.CollectionErrorLog" -TrustServerCertificate | Format-Table
+          Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database "DBADashDB_FromFolder" -Query "SELECT * FROM dbo.CollectionErrorLog" -TrustServerCertificate | Format-Table
 
-      - name: Output Table Counts
+      - name: Output CollectionErrorLog Direct
         shell: powershell
         run: | 
-          ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_GitHubAction" 
+            Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database "DBADashDB_Direct" -Query "SELECT * FROM dbo.CollectionErrorLog" -TrustServerCertificate | Format-Table
 
-      - name: Run Pester Tests
+      - name: Output Table Counts FromFolder
+        shell: powershell
+        run: | 
+          ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_FromFolder" 
+
+      - name: Output Table Counts Direct
+        shell: powershell
+        run: | 
+            ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_Direct" 
+
+      - name: Run Pester Tests FromFolder
         shell: powershell
         run: |     
           Install-Module Pester -Force
           Import-Module Pester -PassThru
-          Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
+          $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_FromFolder" }
+          Invoke-Pester -Container $container -Output Detailed
 
+      - name: Run Pester Tests Direct
+        shell: powershell
+        run: |     
+            $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
+            Invoke-Pester -Container $container -Output Detailed
+      
       - name: Output Log and Check for Errors (DBADashWriteToFolder)
         shell: powershell
         run: | 

--- a/DBADash.Test/DBADashConfig.cs
+++ b/DBADash.Test/DBADashConfig.cs
@@ -1,12 +1,7 @@
-﻿using DBADashConfig.Test;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DBADash;
 
 namespace DBADashConfig.Test
@@ -71,6 +66,34 @@ namespace DBADashConfig.Test
 
             var cfg = BasicConfig.Load<CollectionConfig>();
             Assert.AreEqual(serviceName, cfg.ServiceName);
+        }
+
+        [TestMethod]
+        [DataRow(new string[] { "C:\\Test", "C:\\Test2", "C:\\Test3" })]
+        public void AddRemoveDestinationTest(string[] connectionStrings)
+        {
+            foreach (var connectionString in connectionStrings)
+            {
+                var cfg = BasicConfig.Load<CollectionConfig>();
+                var expectedCnt = cfg.AllDestinations.Count + 1;
+                var psi = new ProcessStartInfo("DBADashConfig",
+                    $"-a AddDestination -c \"{connectionString}\" --SkipValidation");
+                Helper.RunProcess(psi);
+
+                cfg = BasicConfig.Load<CollectionConfig>();
+                Assert.AreEqual(expectedCnt, cfg.AllDestinations.Count);
+            }
+
+            foreach (var connectionString in connectionStrings)
+            {
+                var cfg = BasicConfig.Load<CollectionConfig>();
+                var expectedCnt = cfg.AllDestinations.Count - 1;
+                var psi = new ProcessStartInfo("DBADashConfig",
+                    $"-a RemoveDestination -c \"{connectionString}\"");
+                Helper.RunProcess(psi);
+                cfg = BasicConfig.Load<CollectionConfig>();
+                Assert.AreEqual(expectedCnt, cfg.AllDestinations.Count);
+            }
         }
     }
 }

--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -129,10 +129,11 @@ namespace DBADash
         {
             get
             {
-                var all = new List<DBADashConnection>
+                var all = new List<DBADashConnection>();
+                if (!string.IsNullOrEmpty(Destination))
                 {
-                    DestinationConnection
-                };
+                    all.Add(DestinationConnection);
+                }
                 all.AddRange(SecondaryDestinationConnections);
                 return all;
             }

--- a/DBADashConfig/Options.cs
+++ b/DBADashConfig/Options.cs
@@ -93,7 +93,9 @@ namespace DBADashConfig
             SetServiceName,
             Encrypt,
             Decrypt,
-            SetConfigFileBackupRetention
+            SetConfigFileBackupRetention,
+            AddDestination,
+            RemoveDestination,
         }
     }
 }

--- a/Scripts/CI_Workflow.Tests.ps1
+++ b/Scripts/CI_Workflow.Tests.ps1
@@ -1,8 +1,13 @@
+param(
+    [string]$Database = "DBADashDB_GitHubAction",
+	[string]$Server = "LOCALHOST"
+)
+
 Describe 'CI Workflow checks' {
     BeforeEach {
             $params = @{
-                ServerInstance = "LOCALHOST"
-                Database = "DBADashDB_GitHubAction"
+                ServerInstance = $Server
+                Database = $Database
             }
         }
     It 'Test Instance Count' {


### PR DESCRIPTION
Configure secondary destinations via CLI.
Update GitHub actions to test writing to secondary destinations.  Will detect the issue fixed in #665 if it re-occurs in the future.