### PR TITLE
Performance tab - visual improvement

### DIFF
--- a/DBADashGUI/Performance/Blocking.cs
+++ b/DBADashGUI/Performance/Blocking.cs
@@ -146,6 +146,8 @@ namespace DBADashGUI.Performance
             chartBlocking.Series = s1;
 
             lblBlocking.Text = databaseID > 0 ? "Blocking: Database" : "Blocking: Instance";
+            toolStrip1.BackColor = databaseID > 0 ? DashColors.DatabaseLevelTitleColor : Control.DefaultBackColor;
+            toolStrip1.ForeColor = toolStrip1.BackColor.ContrastColor();
         }
 
         private void ChartBlocking_DataClick(object sender, ChartPoint chartPoint)

--- a/DBADashGUI/Performance/IOPerformance.cs
+++ b/DBADashGUI/Performance/IOPerformance.cs
@@ -343,7 +343,7 @@ namespace DBADashGUI.Performance
 
             int i = 0;
             iopsMax = 0;
-            mbMax=0;
+            mbMax = 0;
             foreach (DataRow r in dt.Rows)
             {
                 foreach (string s in Columns.Keys)
@@ -398,6 +398,8 @@ namespace DBADashGUI.Performance
                 chartIO.Series.Clear(); // fix tends to zero error
             }
             lblIOPerformance.Text = databaseID > 0 ? "IO Performance: Database" : (string.IsNullOrEmpty(Drive) ? "IO Performance: Instance" : "IO Performance: " + DriveLabel(Drive));
+            toolStrip1.BackColor = databaseID > 0 ? DashColors.DatabaseLevelTitleColor : Control.DefaultBackColor;
+            toolStrip1.ForeColor = toolStrip1.BackColor.ContrastColor();
         }
 
         public string DriveLabel(string drive)

--- a/DBADashGUI/Performance/ObjectExecution.cs
+++ b/DBADashGUI/Performance/ObjectExecution.cs
@@ -84,6 +84,8 @@ namespace DBADashGUI.Performance
             objectExecChart.AxisY.Clear();
             chartMaxDate = DateTime.MinValue;
             lblExecution.Text = databaseid > 0 ? "Execution Stats: Database" : "Execution Stats: Instance";
+            toolStrip1.BackColor = databaseid > 0 ? DashColors.DatabaseLevelTitleColor : Control.DefaultBackColor;
+            toolStrip1.ForeColor = toolStrip1.BackColor.ContrastColor();
 
             var dt = CommonData.ObjectExecutionStats(instanceID, databaseid, objectID, dateGrouping, Metric.Measure, DateRange.FromUTC, DateRange.ToUTC, "");
 

--- a/DBADashGUI/Performance/Performance.Designer.cs
+++ b/DBADashGUI/Performance/Performance.Designer.cs
@@ -28,199 +28,201 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            DBADashGUI.CPUMetric cpuMetric1 = new DBADashGUI.CPUMetric();
-            DBADashGUI.ObjectExecutionMetric objectExecutionMetric1 = new DBADashGUI.ObjectExecutionMetric();
-            DBADashGUI.IOMetric ioMetric1 = new DBADashGUI.IOMetric();
+            components = new System.ComponentModel.Container();
+            CPUMetric cpuMetric1 = new CPUMetric();
+            ObjectExecutionMetric objectExecutionMetric1 = new ObjectExecutionMetric();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Performance));
-            DBADashGUI.BlockingMetric blockingMetric1 = new DBADashGUI.BlockingMetric();
-            DBADashGUI.WaitMetric waitMetric1 = new DBADashGUI.WaitMetric();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
-            this.smoothLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dataPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.timer1 = new System.Windows.Forms.Timer(this.components);
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.cpu1 = new DBADashGUI.Performance.CPU();
-            this.objectExecution1 = new DBADashGUI.Performance.ObjectExecution();
-            this.ioPerformance1 = new DBADashGUI.Performance.IOPerformance();
-            this.blocking1 = new DBADashGUI.Performance.Blocking();
-            this.waits1 = new DBADashGUI.Performance.Waits();
-            this.toolStrip1.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
-            this.SuspendLayout();
+            IOMetric ioMetric1 = new IOMetric();
+            BlockingMetric blockingMetric1 = new BlockingMetric();
+            WaitMetric waitMetric1 = new WaitMetric();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
+            smoothLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            dataPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            timer1 = new System.Windows.Forms.Timer(components);
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            cpu1 = new CPU();
+            objectExecution1 = new ObjectExecution();
+            ioPerformance1 = new IOPerformance();
+            blocking1 = new Blocking();
+            waits1 = new Waits();
+            toolStrip1.SuspendLayout();
+            tableLayoutPanel1.SuspendLayout();
+            SuspendLayout();
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripDropDownButton1,
-            this.tsRefresh});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1757, 27);
-            this.toolStrip1.TabIndex = 2;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripDropDownButton1, tsRefresh });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(1757, 27);
+            toolStrip1.TabIndex = 2;
+            toolStrip1.Text = "toolStrip1";
             // 
             // toolStripDropDownButton1
             // 
-            this.toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.smoothLinesToolStripMenuItem,
-            this.dataPointsToolStripMenuItem});
-            this.toolStripDropDownButton1.Image = global::DBADashGUI.Properties.Resources.LineChart_16x;
-            this.toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripDropDownButton1.Name = "toolStripDropDownButton1";
-            this.toolStripDropDownButton1.Size = new System.Drawing.Size(34, 24);
-            this.toolStripDropDownButton1.Text = "Chart Options";
+            toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { smoothLinesToolStripMenuItem, dataPointsToolStripMenuItem });
+            toolStripDropDownButton1.Image = Properties.Resources.LineChart_16x;
+            toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripDropDownButton1.Name = "toolStripDropDownButton1";
+            toolStripDropDownButton1.Size = new System.Drawing.Size(34, 24);
+            toolStripDropDownButton1.Text = "Chart Options";
             // 
             // smoothLinesToolStripMenuItem
             // 
-            this.smoothLinesToolStripMenuItem.Checked = true;
-            this.smoothLinesToolStripMenuItem.CheckOnClick = true;
-            this.smoothLinesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.smoothLinesToolStripMenuItem.Name = "smoothLinesToolStripMenuItem";
-            this.smoothLinesToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
-            this.smoothLinesToolStripMenuItem.Text = "Smooth Lines";
-            this.smoothLinesToolStripMenuItem.Click += new System.EventHandler(this.SmoothLinesToolStripMenuItem_Click);
+            smoothLinesToolStripMenuItem.Checked = true;
+            smoothLinesToolStripMenuItem.CheckOnClick = true;
+            smoothLinesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            smoothLinesToolStripMenuItem.Name = "smoothLinesToolStripMenuItem";
+            smoothLinesToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
+            smoothLinesToolStripMenuItem.Text = "Smooth Lines";
+            smoothLinesToolStripMenuItem.Click += SmoothLinesToolStripMenuItem_Click;
             // 
             // dataPointsToolStripMenuItem
             // 
-            this.dataPointsToolStripMenuItem.Checked = true;
-            this.dataPointsToolStripMenuItem.CheckOnClick = true;
-            this.dataPointsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.dataPointsToolStripMenuItem.Name = "dataPointsToolStripMenuItem";
-            this.dataPointsToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
-            this.dataPointsToolStripMenuItem.Text = "Data Points";
-            this.dataPointsToolStripMenuItem.Click += new System.EventHandler(this.DataPointsToolStripMenuItem_Click);
+            dataPointsToolStripMenuItem.Checked = true;
+            dataPointsToolStripMenuItem.CheckOnClick = true;
+            dataPointsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            dataPointsToolStripMenuItem.Name = "dataPointsToolStripMenuItem";
+            dataPointsToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
+            dataPointsToolStripMenuItem.Text = "Data Points";
+            dataPointsToolStripMenuItem.Click += DataPointsToolStripMenuItem_Click;
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // timer1
             // 
-            this.timer1.Interval = 10000;
-            this.timer1.Tick += new System.EventHandler(this.Timer1_Tick);
+            timer1.Interval = 10000;
+            timer1.Tick += Timer1_Tick;
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.cpu1, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.objectExecution1, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.ioPerformance1, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.blocking1, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.waits1, 0, 2);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 27);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 5;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1757, 2338);
-            this.tableLayoutPanel1.TabIndex = 8;
+            tableLayoutPanel1.ColumnCount = 1;
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            tableLayoutPanel1.Controls.Add(cpu1, 0, 0);
+            tableLayoutPanel1.Controls.Add(objectExecution1, 0, 4);
+            tableLayoutPanel1.Controls.Add(blocking1, 0, 3);
+            tableLayoutPanel1.Controls.Add(ioPerformance1, 0, 2);
+            tableLayoutPanel1.Controls.Add(waits1, 0, 1);
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel1.Location = new System.Drawing.Point(0, 27);
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 5;
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
+            tableLayoutPanel1.Size = new System.Drawing.Size(1757, 2338);
+            tableLayoutPanel1.TabIndex = 8;
             // 
             // cpu1
             // 
-            this.cpu1.CloseVisible = false;
-            this.cpu1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.cpu1.InstanceID = 0;
-            this.cpu1.Location = new System.Drawing.Point(3, 5);
-            this.cpu1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            cpuMetric1.AggregateType = DBADashGUI.Performance.IMetric.AggregateTypes.Avg;
-            this.cpu1.Metric = cpuMetric1;
-            this.cpu1.MoveUpVisible = false;
-            this.cpu1.Name = "cpu1";
-            this.cpu1.Size = new System.Drawing.Size(1751, 457);
-            this.cpu1.SmoothLines = true;
-            this.cpu1.TabIndex = 4;
+            cpu1.CloseVisible = false;
+            cpu1.Dock = System.Windows.Forms.DockStyle.Fill;
+            cpu1.InstanceID = 0;
+            cpu1.Location = new System.Drawing.Point(3, 5);
+            cpu1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            cpuMetric1.AggregateType = IMetric.AggregateTypes.Avg;
+            cpu1.Metric = cpuMetric1;
+            cpu1.MoveUpVisible = false;
+            cpu1.Name = "cpu1";
+            cpu1.Size = new System.Drawing.Size(1751, 457);
+            cpu1.SmoothLines = true;
+            cpu1.TabIndex = 4;
             // 
             // objectExecution1
             // 
-            this.objectExecution1.CloseVisible = false;
-            this.objectExecution1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.objectExecution1.Location = new System.Drawing.Point(3, 1873);
-            this.objectExecution1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            objectExecution1.CloseVisible = false;
+            objectExecution1.Dock = System.Windows.Forms.DockStyle.Fill;
+            objectExecution1.Location = new System.Drawing.Point(3, 1873);
+            objectExecution1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             objectExecutionMetric1.Measure = "TotalDuration";
-            this.objectExecution1.Metric = objectExecutionMetric1;
-            this.objectExecution1.MoveUpVisible = false;
-            this.objectExecution1.Name = "objectExecution1";
-            this.objectExecution1.Size = new System.Drawing.Size(1751, 460);
-            this.objectExecution1.TabIndex = 7;
+            objectExecution1.Metric = objectExecutionMetric1;
+            objectExecution1.MoveUpVisible = false;
+            objectExecution1.Name = "objectExecution1";
+            objectExecution1.Size = new System.Drawing.Size(1751, 460);
+            objectExecution1.TabIndex = 7;
             // 
             // ioPerformance1
             // 
-            this.ioPerformance1.CloseVisible = false;
-            this.ioPerformance1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ioPerformance1.Drive = "";
-            this.ioPerformance1.FileGroup = "";
-            this.ioPerformance1.Location = new System.Drawing.Point(3, 472);
-            this.ioPerformance1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            ioPerformance1.CloseVisible = false;
+            ioPerformance1.DateGrouping = 0;
+            ioPerformance1.DateGroupingVisible = true;
+            ioPerformance1.Dock = System.Windows.Forms.DockStyle.Fill;
+            ioPerformance1.Drive = "";
+            ioPerformance1.DriveVisible = true;
+            ioPerformance1.FileGroup = "";
+            ioPerformance1.FileGroupVisible = false;
+            ioPerformance1.Location = new System.Drawing.Point(3, 939);
+            ioPerformance1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            ioPerformance1.MeasuresVisible = true;
             ioMetric1.Drive = "";
-            ioMetric1.VisibleMetrics = ((System.Collections.Generic.List<string>)(resources.GetObject("ioMetric1.VisibleMetrics")));
-            this.ioPerformance1.Metric = ioMetric1;
-            this.ioPerformance1.MoveUpVisible = false;
-            this.ioPerformance1.Name = "ioPerformance1";
-            this.ioPerformance1.Size = new System.Drawing.Size(1751, 457);
-            this.ioPerformance1.SmoothLines = true;
-            this.ioPerformance1.TabIndex = 3;
+            ioMetric1.VisibleMetrics = (System.Collections.Generic.List<string>)resources.GetObject("ioMetric1.VisibleMetrics");
+            ioPerformance1.Metric = ioMetric1;
+            ioPerformance1.MoveUpVisible = false;
+            ioPerformance1.Name = "ioPerformance1";
+            ioPerformance1.OptionsVisible = true;
+            ioPerformance1.Size = new System.Drawing.Size(1751, 457);
+            ioPerformance1.SmoothLines = true;
+            ioPerformance1.SummaryVisible = true;
+            ioPerformance1.TabIndex = 3;
             // 
             // blocking1
             // 
-            this.blocking1.CloseVisible = false;
-            this.blocking1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.blocking1.Location = new System.Drawing.Point(3, 1406);
-            this.blocking1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.blocking1.Metric = blockingMetric1;
-            this.blocking1.MoveUpVisible = false;
-            this.blocking1.Name = "blocking1";
-            this.blocking1.Size = new System.Drawing.Size(1751, 457);
-            this.blocking1.TabIndex = 6;
+            blocking1.CloseVisible = false;
+            blocking1.Dock = System.Windows.Forms.DockStyle.Fill;
+            blocking1.Location = new System.Drawing.Point(3, 1406);
+            blocking1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            blocking1.Metric = blockingMetric1;
+            blocking1.MoveUpVisible = false;
+            blocking1.Name = "blocking1";
+            blocking1.Size = new System.Drawing.Size(1751, 457);
+            blocking1.TabIndex = 6;
             // 
             // waits1
             // 
-            this.waits1.CloseVisible = false;
-            this.waits1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.waits1.Location = new System.Drawing.Point(3, 939);
-            this.waits1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            waits1.CloseVisible = false;
+            waits1.Dock = System.Windows.Forms.DockStyle.Fill;
+            waits1.Location = new System.Drawing.Point(3, 472);
+            waits1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             waitMetric1.CriticalWaitsOnly = false;
             waitMetric1.WaitType = null;
-            this.waits1.Metric = waitMetric1;
-            this.waits1.MoveUpVisible = false;
-            this.waits1.Name = "waits1";
-            this.waits1.Size = new System.Drawing.Size(1751, 457);
-            this.waits1.TabIndex = 5;
-            this.waits1.WaitType = null;
+            waits1.Metric = waitMetric1;
+            waits1.MoveUpVisible = false;
+            waits1.Name = "waits1";
+            waits1.Size = new System.Drawing.Size(1751, 457);
+            waits1.TabIndex = 5;
+            waits1.WaitType = null;
             // 
             // Performance
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.AutoScroll = true;
-            this.Controls.Add(this.tableLayoutPanel1);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "Performance";
-            this.Size = new System.Drawing.Size(1757, 2365);
-            this.Load += new System.EventHandler(this.Performance_Load);
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            AutoScroll = true;
+            Controls.Add(tableLayoutPanel1);
+            Controls.Add(toolStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "Performance";
+            Size = new System.Drawing.Size(1757, 2365);
+            Load += Performance_Load;
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            tableLayoutPanel1.ResumeLayout(false);
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/DBADashGUI/Performance/Performance.resx
+++ b/DBADashGUI/Performance/Performance.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing"">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/DBADashSharedGUI/DashColors.cs
+++ b/DBADashSharedGUI/DashColors.cs
@@ -54,5 +54,7 @@
         public static readonly Color LinkColor = TrimbleBlueDark;
         public static readonly Color ProgressBarFrom = Color.White;
         public static readonly Color ProgressBarTo = Color.FromArgb(103, 176, 228);
+
+        public static Color DatabaseLevelTitleColor => TrimbleBlue;
     }
 }


### PR DESCRIPTION
Provide a stronger visual cue to differentiate database-level and instance-level charts. At database level add a different color to the title bar for the charts that represent database-level metrics.  Re-order charts to have the instance-level metrics listed together (Waits moved above IO Performance).  #679