### PR TITLE
Fix compiler warnings

### DIFF
--- a/DBADashGUI/DBFiles/DBFilesControl.cs
+++ b/DBADashGUI/DBFiles/DBFilesControl.cs
@@ -19,7 +19,7 @@ namespace DBADashGUI.DBFiles
 
         private List<Int32> InstanceIDs;
         private Int32? DatabaseID;
-        private string? DriveName;
+        private string DriveName;
 
         public bool IncludeCritical
         {

--- a/DBADashGUI/SQLTreeItem.cs
+++ b/DBADashGUI/SQLTreeItem.cs
@@ -94,7 +94,7 @@ namespace DBADashGUI
         private bool IsInstanceOrAzureDB => Type == TreeType.Instance || Type == TreeType.AzureDatabase;
         private bool IsInstanceOrAzureInstance => Type == TreeType.Instance || Type == TreeType.AzureInstance;
 
-        public string? DriveName;
+        public string DriveName;
 
         public DBADashContext Context
         {


### PR DESCRIPTION
Fix warning:
The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.