### PR TITLE
Export to Excel fix

### DIFF
--- a/DBADashGUI/Common.cs
+++ b/DBADashGUI/Common.cs
@@ -191,51 +191,50 @@ namespace DBADashGUI
                 rowIndex += 1;
                 foreach (DataGridViewCell cell in row.Cells)
                 {
-                    if (cell.Visible)
+                    if (!cell.Visible) continue;
+                    colIndex += 1;
+                    if (string.IsNullOrEmpty(cell.FormattedValue as string)) continue;
+                    var cellType = cell.ValueType;
+                    SLStyle style = sl.CreateStyle();
+                    string format = string.IsNullOrEmpty(cell.Style.Format) ? cell.InheritedStyle.Format : cell.Style.Format;
+                    format = format switch
                     {
-                        colIndex += 1;
-                        var cellType = cell.Value == null ? typeof(System.String) : cell.Value.GetType();
-                        SLStyle style = sl.CreateStyle();
-                        string format = string.IsNullOrEmpty(cell.Style.Format) ? cell.InheritedStyle.Format : cell.Style.Format;
-                        format = format switch
-                        {
-                            "P1" => "0.0%",
-                            "P:" or "P2" => "0.00%",
-                            _ => "",
-                        };
-                        if (cellType == typeof(DateTime))
-                        {
-                            format = "yyyy-MM-dd HH:mm";
-                        }
-                        if (!cell.Style.ForeColor.IsEmpty || !cell.Style.BackColor.IsEmpty || !string.IsNullOrEmpty(format))
-                        {
-                            var backColor = cell.Style.BackColor.IsEmpty ? Color.Transparent : cell.Style.BackColor;
-                            style.Fill.SetPattern(DocumentFormat.OpenXml.Spreadsheet.PatternValues.Solid, backColor, backColor);
-                            style.SetFontColor(cell.Style.ForeColor);
-                            style.FormatCode = format;
-                            sl.SetCellStyle(rowIndex, colIndex, style);
-                        }
+                        "P1" => "0.0%",
+                        "P:" or "P2" => "0.00%",
+                        _ => "",
+                    };
+                    if (cellType == typeof(DateTime))
+                    {
+                        format = "yyyy-MM-dd HH:mm";
+                    }
+                    if (!cell.Style.ForeColor.IsEmpty || !cell.Style.BackColor.IsEmpty || !string.IsNullOrEmpty(format))
+                    {
+                        var backColor = cell.Style.BackColor.IsEmpty ? Color.Transparent : cell.Style.BackColor;
+                        style.Fill.SetPattern(DocumentFormat.OpenXml.Spreadsheet.PatternValues.Solid, backColor, backColor);
+                        style.SetFontColor(cell.Style.ForeColor);
+                        style.FormatCode = format;
+                        sl.SetCellStyle(rowIndex, colIndex, style);
+                    }
 
-                        if (cellType == typeof(decimal) || cellType == typeof(float))
+                    if (cellType.IsNumericType())
+                    {
+                        if (!decimal.TryParse(cell.FormattedValue as string, out var decimalValue))
                         {
-                            sl.SetCellValue(rowIndex, colIndex, Convert.ToDecimal(cell.Value));
+                            decimalValue = Convert.ToDecimal(cell.Value);
                         }
-                        else if (cellType == typeof(int) || cellType == typeof(long) || cellType == typeof(short) || cellType == typeof(uint) || cellType == typeof(ulong) || cellType == typeof(ushort))
-                        {
-                            sl.SetCellValue(rowIndex, colIndex, Convert.ToInt64(cell.Value));
-                        }
-                        else if (cellType == typeof(DateTime))
-                        {
-                            sl.SetCellValue(rowIndex, colIndex, Convert.ToDateTime(cell.Value));
-                        }
-                        else if (cellType == typeof(byte[]))
-                        {
-                            sl.SetCellValue(rowIndex, colIndex, Convert.ToString(cell.FormattedValue));
-                        }
-                        else
-                        {
-                            sl.SetCellValue(rowIndex, colIndex, Convert.ToString(cell.Value));
-                        }
+                        sl.SetCellValue(rowIndex, colIndex, Convert.ToDecimal(decimalValue));
+                    }
+                    else if (cellType == typeof(DateTime))
+                    {
+                        sl.SetCellValue(rowIndex, colIndex, Convert.ToDateTime(cell.Value));
+                    }
+                    else if (cellType == typeof(byte[]))
+                    {
+                        sl.SetCellValue(rowIndex, colIndex, Convert.ToString(cell.Value));
+                    }
+                    else
+                    {
+                        sl.SetCellValue(rowIndex, colIndex, Convert.ToString(cell.FormattedValue));
                     }
                 }
             }

--- a/DBADashGUI/ExtensionMethods.cs
+++ b/DBADashGUI/ExtensionMethods.cs
@@ -319,5 +319,25 @@ namespace DBADashGUI
             // If the key does not exist or the value is not a double, return the default value
             return defaultValue;
         }
+        public static bool IsNumericType(this Type type)
+        {
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte:
+                case TypeCode.Decimal:
+                case TypeCode.Double:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.SByte:
+                case TypeCode.Single:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Use formatted value so exported value matches what the user sees in the grid.  e.g. If it's formatted in thousands, the exported value should match what is displayed rather than the raw value. #694