### PR TITLE
Update DB level color

### DIFF
--- a/DBADashGUI/Performance/Blocking.cs
+++ b/DBADashGUI/Performance/Blocking.cs
@@ -1,4 +1,5 @@
-﻿using LiveCharts;
+﻿using DBADashGUI.Theme;
+using LiveCharts;
 using LiveCharts.Configurations;
 using LiveCharts.Wpf;
 using Microsoft.Data.SqlClient;
@@ -146,8 +147,8 @@ namespace DBADashGUI.Performance
             chartBlocking.Series = s1;
 
             lblBlocking.Text = databaseID > 0 ? "Blocking: Database" : "Blocking: Instance";
-            toolStrip1.BackColor = databaseID > 0 ? DashColors.DatabaseLevelTitleColor : Control.DefaultBackColor;
-            toolStrip1.ForeColor = toolStrip1.BackColor.ContrastColor();
+            toolStrip1.Tag = databaseID > 0 ? "ALT": null; // set tag to ALT to use the alternate menu renderer
+            toolStrip1.ApplyTheme(DBADashUser.SelectedTheme);
         }
 
         private void ChartBlocking_DataClick(object sender, ChartPoint chartPoint)

--- a/DBADashGUI/Performance/IOPerformance.cs
+++ b/DBADashGUI/Performance/IOPerformance.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
 using DBADashGUI.Pickers;
+using DBADashGUI.Theme;
 using Font = System.Drawing.Font;
 
 namespace DBADashGUI.Performance
@@ -398,8 +399,8 @@ namespace DBADashGUI.Performance
                 chartIO.Series.Clear(); // fix tends to zero error
             }
             lblIOPerformance.Text = databaseID > 0 ? "IO Performance: Database" : (string.IsNullOrEmpty(Drive) ? "IO Performance: Instance" : "IO Performance: " + DriveLabel(Drive));
-            toolStrip1.BackColor = databaseID > 0 ? DashColors.DatabaseLevelTitleColor : Control.DefaultBackColor;
-            toolStrip1.ForeColor = toolStrip1.BackColor.ContrastColor();
+            toolStrip1.Tag = databaseID > 0 ? "ALT" : null; // set tag to ALT to use the alternate menu renderer
+            toolStrip1.ApplyTheme(DBADashUser.SelectedTheme);
         }
 
         public string DriveLabel(string drive)

--- a/DBADashGUI/Performance/ObjectExecution.cs
+++ b/DBADashGUI/Performance/ObjectExecution.cs
@@ -1,4 +1,5 @@
-﻿using LiveCharts;
+﻿using DBADashGUI.Theme;
+using LiveCharts;
 using LiveCharts.Configurations;
 using LiveCharts.Defaults;
 using LiveCharts.Wpf;
@@ -84,9 +85,8 @@ namespace DBADashGUI.Performance
             objectExecChart.AxisY.Clear();
             chartMaxDate = DateTime.MinValue;
             lblExecution.Text = databaseid > 0 ? "Execution Stats: Database" : "Execution Stats: Instance";
-            toolStrip1.BackColor = databaseid > 0 ? DashColors.DatabaseLevelTitleColor : Control.DefaultBackColor;
-            toolStrip1.ForeColor = toolStrip1.BackColor.ContrastColor();
-
+            toolStrip1.Tag = databaseid > 0 ? "ALT" : null; // set tag to ALT to use the alternate menu renderer
+            toolStrip1.ApplyTheme(DBADashUser.SelectedTheme);
             var dt = CommonData.ObjectExecutionStats(instanceID, databaseid, objectID, dateGrouping, Metric.Measure, DateRange.FromUTC, DateRange.ToUTC, "");
 
             if (dt.Rows.Count == 0)

--- a/DBADashSharedGUI/Theme/DarkModeAltMenuRenderer.cs
+++ b/DBADashSharedGUI/Theme/DarkModeAltMenuRenderer.cs
@@ -1,0 +1,17 @@
+﻿using System.Drawing;
+using System.Runtime.Versioning;
+using DBADashSharedGUI;
+
+namespace DBADashGUI.Theme
+{
+    /// <summary>
+    /// Custom ToolStrip/Menu Renderer for Dark Mode
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public class DarkModeAltMenuRenderer : LightModeAltMenuRenderer
+    {
+        public DarkModeAltMenuRenderer() : base()
+        {
+        }
+    }
+}

--- a/DBADashSharedGUI/Theme/LightModeAltColors.cs
+++ b/DBADashSharedGUI/Theme/LightModeAltColors.cs
@@ -1,0 +1,30 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+using DBADashSharedGUI;
+
+namespace DBADashGUI.Theme
+{
+    /// <summary>
+    /// Professional Color table for menu/toolstrip items in dark mode
+    /// </summary>
+    public class LightModeAltColors : ProfessionalColorTable
+    {
+        public override Color CheckBackground => DashColors.BlueLight;
+
+        public override Color CheckPressedBackground => DashColors.White;
+
+        public override Color CheckSelectedBackground => DashColors.TrimbleBlue;
+
+        public override Color MenuItemSelected => DashColors.Gray10;
+
+        public override Color ToolStripDropDownBackground => DashColors.TrimbleGray;
+
+        public override Color SeparatorDark => DashColors.Gray8;
+
+        public override Color ImageMarginGradientBegin => DashColors.BluePale;
+
+        public override Color ImageMarginGradientEnd => DashColors.BluePale;
+
+        public override Color ImageMarginGradientMiddle => DashColors.BluePale;
+    }
+}

--- a/DBADashSharedGUI/Theme/LightModeAltMenuRenderer.cs
+++ b/DBADashSharedGUI/Theme/LightModeAltMenuRenderer.cs
@@ -1,0 +1,27 @@
+﻿using System.Drawing;
+using System.Runtime.Versioning;
+using DBADashSharedGUI;
+
+namespace DBADashGUI.Theme
+{
+    /// <summary>
+    /// Custom ToolStrip/Menu Renderer for Dark Mode
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public class LightModeAltMenuRenderer : BaseMenuRenderer
+    {
+        public LightModeAltMenuRenderer() : base(new LightModeAltColors())
+        {
+        }
+
+        public override Color MenuBackColor { get; set; } = DashColors.BluePale;
+
+        public override Color MenuForeColor { get; set; } = DashColors.TrimbleBlueDark;
+        public override Color ArrowColor { get; set; } = DashColors.Gray8;
+        public override Color SeparatorColor { get; set; } = DashColors.Gray8;
+
+        public override Color SelectionColor { get; set; } = DashColors.TrimbleBlue;
+
+        public override Color SelectionForeColor { get; set; } = DashColors.White;
+    }
+}

--- a/DBADashSharedGUI/Theme/ThemeExtensions.cs
+++ b/DBADashSharedGUI/Theme/ThemeExtensions.cs
@@ -111,12 +111,26 @@ namespace DBADashGUI.Theme
 
         public static void ApplyTheme(this ToolStrip menu, BaseTheme theme)
         {
-            menu.Renderer = theme is DarkTheme ? new DarkModeMenuRenderer() : new LightModeMenuRenderer();
+            if (menu.Tag !=null && (string)menu.Tag == "ALT")
+            {
+                menu.Renderer = theme is DarkTheme ? new DarkModeAltMenuRenderer() : new LightModeAltMenuRenderer();
+            }
+            else
+            {
+                menu.Renderer = theme is DarkTheme ? new DarkModeMenuRenderer() : new LightModeMenuRenderer();
+            }
         }
 
         public static void ApplyTheme(this MenuStrip menu, BaseTheme theme)
         {
-            menu.Renderer = theme is DarkTheme ? new DarkModeMenuRenderer() : new LightModeMenuRenderer();
+            if (menu.Tag != null && (string)menu.Tag == "ALT")
+            {
+                menu.Renderer = theme is DarkTheme ? new DarkModeAltMenuRenderer() : new LightModeAltMenuRenderer();
+            }
+            else
+            {
+                menu.Renderer = theme is DarkTheme ? new DarkModeMenuRenderer() : new LightModeMenuRenderer();
+            }
         }
 
         public static void ApplyTheme(this CheckedListBox chkL, BaseTheme theme)


### PR DESCRIPTION
Update menu color for database level charts to better highlight which apply at database level.  This was previously implemented for #679 but the change was undone as part of the themes change.