### PR TITLE
Fix Agent Job drilldown on summary tab

### DIFF
--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -1273,22 +1273,22 @@ namespace DBADashGUI
                     if (e.Tab is "tabAlerts" or "tabQS" or "tabDBOptions") // Configuration Node
                     {
                         nInstance.Expand();
-                        tv1.SelectedNode = nInstance.Nodes[0];
+                        tv1.SelectedNode = nInstance.FindChildOfType(SQLTreeItem.TreeType.Configuration);
                     }
                     else if (e.Tab is "tabMirroring" or "tabLogShipping" or "tabBackups" or "tabAG")
                     {
                         nInstance.Expand();
-                        tv1.SelectedNode = nInstance.Nodes[2];
+                        tv1.SelectedNode = nInstance.FindChildOfType(SQLTreeItem.TreeType.HADR);
                     }
                     else if (e.Tab == "tabJobs" && parent == null) // Root Level
                     {
                         nInstance.Expand();
-                        tv1.SelectedNode = nInstance.Nodes[4];
+                        tv1.SelectedNode = nInstance.FindChildOfType(SQLTreeItem.TreeType.AgentJobs);
                     }
                     else if (e.Tab == "tabJobs" && parent != null) // Instance Level Jobs tab
                     {
                         nInstance.Expand();
-                        tv1.SelectedNode = nInstance.LastNode;
+                        tv1.SelectedNode = nInstance.FindChildOfType(SQLTreeItem.TreeType.AgentJobs);
                     }
                     else if (e.Tab is "tabAzureSummary" or "tabPerformance")
                     {
@@ -1297,7 +1297,7 @@ namespace DBADashGUI
                     else if (e.Tab is "tabFiles" or "tabDrives")
                     {
                         nInstance.Expand();
-                        tv1.SelectedNode = nInstance.Nodes[3];
+                        tv1.SelectedNode = nInstance.FindChildOfType(SQLTreeItem.TreeType.Storage);
                     }
                     else
                     {

--- a/DBADashGUI/SQLTreeItem.cs
+++ b/DBADashGUI/SQLTreeItem.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.SqlServer.Management.Common;
+﻿using DBADashGUI.CustomReports;
+using Microsoft.SqlServer.Management.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
-using System.Windows.Forms.DataVisualization.Charting;
-using DBADashGUI.CustomReports;
 
 namespace DBADashGUI
 {
@@ -551,7 +550,7 @@ namespace DBADashGUI
             AddRefreshContextMenu(this);
         }
 
-        public void AddReportsFolder(IEnumerable<CustomReport> reports)
+        public static SQLTreeItem GetReportsFolder(IEnumerable<CustomReport> reports)
         {
             var reportsNode = new SQLTreeItem("Reports", SQLTreeItem.TreeType.ReportsFolder);
             foreach (var report in reports)
@@ -559,6 +558,13 @@ namespace DBADashGUI
                 var reportNode = new SQLTreeItem(report.ReportName, SQLTreeItem.TreeType.CustomReport) { Report = report };
                 reportsNode.Nodes.Add(reportNode);
             }
+
+            return reportsNode;
+        }
+
+        public void AddReportsFolder(IEnumerable<CustomReport> reports)
+        {
+            var reportsNode = GetReportsFolder(reports);
             if (reportsNode.Nodes.Count > 0)
             {
                 this.Nodes.Add(reportsNode);
@@ -800,6 +806,11 @@ namespace DBADashGUI
                 }
             }
             return null;
+        }
+
+        public SQLTreeItem FindChildOfType(TreeType type)
+        {
+            return this.Nodes.Cast<SQLTreeItem>().FirstOrDefault(n => n.Type == type);
         }
     }
 }


### PR DESCRIPTION
Agent jobs drilldown was broken by the introduction of the new reports folder.  Change lookup to find the node of the correct type instead of relying on the node position.  #741