### PR TITLE
Custom Reports - Drill-down fix for datetime columns

### DIFF
--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -597,7 +597,7 @@ namespace DBADashGUI.CustomReports
             report.CustomReportResults[selectedTableIndex].LinkColumns?.TryGetValue(colName, out linkColumnInfo);
             try
             {
-                linkColumnInfo?.Navigate(context, dgv.Rows[e.RowIndex]);
+                linkColumnInfo?.Navigate(context, dgv.Rows[e.RowIndex], selectedTableIndex);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Convert dates back to UTC (if converted) for passing back to the database to simplify drill-downs.  #252