### PR TITLE
Truncate tooltips in DataGridView control

### DIFF
--- a/DBADashGUI/Config.cs
+++ b/DBADashGUI/Config.cs
@@ -30,6 +30,7 @@ namespace DBADashGUI
         public static int BuildReferenceUpdateExclusionPeriod;
         public static double IdleWarningThresholdForSleepingSessionWithOpenTran;
         public static double IdleCriticalThresholdForSleepingSessionWithOpenTran;
+        public static int CellToolTipMaxLength;
 
         static Config()
         {
@@ -70,6 +71,7 @@ namespace DBADashGUI
             BuildReferenceUpdateExclusionPeriod = settings.GetValueAsInt("GUIBuildReferenceUpdateExclusionPeriod", 2);
             IdleWarningThresholdForSleepingSessionWithOpenTran = settings.GetValueAsDouble("IdleWarningThresholdForSleepingSessionWithOpenTran", 1);
             IdleCriticalThresholdForSleepingSessionWithOpenTran = settings.GetValueAsDouble("IdleCriticalThresholdForSleepingSessionWithOpenTran", 600);
+            CellToolTipMaxLength = settings.GetValueAsInt("GUICellToolTipMaxLength", 1000);
         }
 
         public static int GetValueAsInt(object value, int defaultValue)

--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -227,6 +227,7 @@ namespace DBADashGUI
             Common.SetConnectionString(connection);
             try
             {
+                Config.RefreshConfig();
                 DBADashUser.GetUser();
                 customReports = CustomReports.CustomReports.GetCustomReports();
                 GetCommandLineTags();
@@ -235,6 +236,7 @@ namespace DBADashGUI
                 AddInstanes();
                 AddTimeZoneMenus();
                 SetConnectionState(true);
+                ThemeExtensions.CellToolTipMaxLength = Config.CellToolTipMaxLength;
             }
             catch (Exception ex)
             {

--- a/DBADashSharedGUI/Theme/ThemeExtensions.cs
+++ b/DBADashSharedGUI/Theme/ThemeExtensions.cs
@@ -7,6 +7,7 @@ using ComboBox = System.Windows.Forms.ComboBox;
 using Control = System.Windows.Forms.Control;
 using TextBox = System.Windows.Forms.TextBox;
 using TreeView = System.Windows.Forms.TreeView;
+using System;
 
 namespace DBADashGUI.Theme
 {
@@ -17,6 +18,8 @@ namespace DBADashGUI.Theme
     public static class ThemeExtensions
     {
         public static BaseTheme CurrentTheme { get; set; } = new BaseTheme();
+
+        public static int CellToolTipMaxLength { get; set; } = 1000;
 
         public static void ApplyTheme(this Control control)
         {
@@ -111,7 +114,7 @@ namespace DBADashGUI.Theme
 
         public static void ApplyTheme(this ToolStrip menu, BaseTheme theme)
         {
-            if (menu.Tag !=null && (string)menu.Tag == "ALT")
+            if (menu.Tag != null && (string)menu.Tag == "ALT")
             {
                 menu.Renderer = theme is DarkTheme ? new DarkModeAltMenuRenderer() : new LightModeAltMenuRenderer();
             }
@@ -188,6 +191,12 @@ namespace DBADashGUI.Theme
             {
                 col.LinkColor = theme.LinkColor;
             }
+            dgv.ShowCellToolTips = CellToolTipMaxLength > 0;
+            dgv.CellFormatting -= TruncateTooltipTextHandler;
+            if (CellToolTipMaxLength > 0)
+            {
+                dgv.CellFormatting += TruncateTooltipTextHandler;
+            }
         }
 
         public static void ApplyTheme(this TreeView tv, BaseTheme theme)
@@ -201,6 +210,19 @@ namespace DBADashGUI.Theme
             chart.BackColor = theme.BackgroundColor;
             chart.ForeColor = theme.ForegroundColor;
             chart.DefaultLegend.Foreground = new SolidColorBrush(theme.ForegroundColor.ToMediaColor());
+        }
+
+        public static void TruncateTooltipTextHandler(object? sender, DataGridViewCellFormattingEventArgs e)
+        {
+            if (e.Value == null) return;
+            if (sender is not DataGridView gridView) return;
+
+            var currentTooltip = gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].ToolTipText;
+
+            if (currentTooltip.Length <= CellToolTipMaxLength) return;
+            var tooltipText = CellToolTipMaxLength > 0 ? string.Concat(currentTooltip.AsSpan(0, CellToolTipMaxLength), "...") : "";
+
+            gridView.Rows[e.RowIndex].Cells[e.ColumnIndex].ToolTipText = tooltipText;
         }
     }
 }


### PR DESCRIPTION
Large tooltips can cause application crashes. By truncating the text manually, we can also ensure that the end of the text is truncated rather than the beginning in most cases. The default length is 1000 chars which can be customized.
#761 