### PR TITLE
Service Configuration tool - show what custom collections are setup at instance level

### DIFF
--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -328,7 +328,7 @@ namespace DBADashServiceConfig
             dgvConnections.Columns.Add(new DataGridViewComboBoxColumn() { DataPropertyName = "IOCollectionLevel", HeaderText = "IO Collection Level", DataSource = Enum.GetValues(typeof(DBADashSource.IOCollectionLevels)) });
             dgvConnections.Columns.Add(new DataGridViewCheckBoxColumn() { DataPropertyName = "WriteToSecondaryDestinations", HeaderText = "Write to Secondary Destinations" });
             dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "Schedule", HeaderText = "Schedule", Text = "Schedule", UseColumnTextForLinkValue = true, LinkColor = DashColors.LinkColor });
-            dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "CustomCollections", HeaderText = "Custom Collections", Text = "View/Edit", UseColumnTextForLinkValue = true, LinkColor = DashColors.LinkColor });
+            dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "CustomCollections", HeaderText = "Custom Collections", Text = "View/Edit", LinkColor = DashColors.LinkColor });
             dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "Edit", HeaderText = "Copy Connection", Text = "Copy", UseColumnTextForLinkValue = true, LinkColor = DashColors.LinkColor });
             dgvConnections.Columns.Add(new DataGridViewLinkColumn() { Name = "Delete", HeaderText = "Delete", Text = "Delete", UseColumnTextForLinkValue = true, LinkColor = DashColors.LinkColor });
 
@@ -1115,7 +1115,7 @@ namespace DBADashServiceConfig
                     if (frm.DialogResult == DialogResult.OK)
                     {
                         src.CustomCollections = frm.CustomCollections;
-                        dgvConnections.Refresh();
+                        SetDgv();
                     }
                 }
                 else
@@ -1188,6 +1188,7 @@ namespace DBADashServiceConfig
             {
                 var src = (DBADashSource)dgvConnections.Rows[i].DataBoundItem;
                 SetCellsReadOnly(i, src.SourceConnection.Type);
+                dgvConnections.Rows[i].Cells["CustomCollections"].Value = src.CustomCollections.Keys.Count==0 ? "Add Collection" : string.Join(", ",src.CustomCollections.Keys.OrderBy(key => key)); 
             }
         }
 

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -488,11 +488,19 @@ namespace DBADashServiceConfig
                 UpdateScanInterval();
                 SetDgv();
                 RefreshEncryption();
+                UpdateCustomCollectionCount();
             }
             finally
             {
                 IsSetFromJson = false;
             }
+        }
+
+        private void UpdateCustomCollectionCount()
+        {
+            bttnCustomCollections.Text = $"Custom Collections ({collectionConfig.CustomCollections.Count})";
+            bttnCustomCollections.Font = collectionConfig.CustomCollections.Count > 0 ? new Font(bttnCustomCollections.Font, FontStyle.Bold) : new Font(bttnCustomCollections.Font, FontStyle.Regular);
+            toolTip1.SetToolTip(bttnCustomCollections, collectionConfig.CustomCollections.Count > 0 ? string.Join(", ", collectionConfig.CustomCollections.Keys.OrderBy(k=>k)) : "No Custom Collections Defined");
         }
 
         private void SetJson()
@@ -1407,6 +1415,7 @@ namespace DBADashServiceConfig
             if (frm.ShowDialog() != DialogResult.OK) return;
             collectionConfig.CustomCollections = frm.CustomCollections;
             SetJson();
+            UpdateCustomCollectionCount();
         }
 
         private void BttnCustomCollectionsNew_Click(object sender, EventArgs e)


### PR DESCRIPTION
Show list of collections instead of View/Edit.
Show a count of custom collections on the Custom Collections button for all instances. Also show a tooltip with the name of the defined collections.
#794