### PR TITLE
Log Shipping - Fix missing Snapshot Date column data

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/Logshipping_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/Logshipping_Get.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROC dbo.Logshipping_Get(
+﻿CREATE PROC dbo.LogShipping_Get(
 		@InstanceIDs VARCHAR(MAX)=NULL,
 		@IncludeCritical BIT=1,
 		@IncludeWarning BIT=1,
@@ -54,6 +54,7 @@ SELECT LSS.InstanceID,
        LSS.LatencyOfLast,
        LSS.TotalTimeBehind,
        LSS.SnapshotAge,
+	   LSS.SnapshotDate,
        LSS.Status,
        LSS.StatusDescription,
 	   f.FileName AS last_file,


### PR DESCRIPTION
On the Log Shipping tab there is a Snapshot Date column in the grid but it's empty instead of containing the date of the collection