### PR TITLE
RunningQueries - Duplicate column name fix

### DIFF
--- a/DBADashGUI/Performance/RunningQueries.cs
+++ b/DBADashGUI/Performance/RunningQueries.cs
@@ -248,7 +248,7 @@ namespace DBADashGUI.Performance
             dgv.Columns.AddRange(
                 new DataGridViewTextBoxColumn() { HeaderText = "InstanceID", DataPropertyName = "InstanceID", Name = "colInstanceID", Visible = false, Frozen = Common.FreezeKeyColumn },
                 new DataGridViewLinkColumn() { HeaderText = "Instance", DataPropertyName = "InstanceDisplayName", Name = "colInstance", SortMode = DataGridViewColumnSortMode.Automatic, Visible = IsServerLevelSummary, LinkColor = DashColors.LinkColor, Frozen = Common.FreezeKeyColumn },
-                new DataGridViewTextBoxColumn() { HeaderText = "Instance", DataPropertyName = "InstanceDisplayName", SortMode = DataGridViewColumnSortMode.Automatic, Visible = !IsServerLevelSummary, Frozen = Common.FreezeKeyColumn },
+                new DataGridViewTextBoxColumn() { HeaderText = "Instance ", DataPropertyName = "InstanceDisplayName", SortMode = DataGridViewColumnSortMode.Automatic, Visible = !IsServerLevelSummary, Frozen = Common.FreezeKeyColumn },
                 new DataGridViewLinkColumn() { HeaderText = "Snapshot Date", DataPropertyName = "SnapshotDate", Name = "colSnapshotDate", SortMode = DataGridViewColumnSortMode.Automatic, LinkColor = DashColors.LinkColor },
                 new DataGridViewTextBoxColumn() { HeaderText = "Running Queries", DataPropertyName = "RunningQueries", SortMode = DataGridViewColumnSortMode.Automatic, DefaultCellStyle = Common.DataGridViewNumericCellStyle },
                 new DataGridViewTextBoxColumn() { HeaderText = "Blocked Queries", DataPropertyName = "BlockedQueries", SortMode = DataGridViewColumnSortMode.Automatic, DefaultCellStyle = Common.DataGridViewNumericCellStyle },


### PR DESCRIPTION
2 Instance columns are used - 1 link (for server level drill down) and 1 normal.  Add a space to make the columns unique to prevent error when selecting columns.