### PR TITLE
Update GitHub actions to use setup-msbuild@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet build DBADashGUI -o DBADashBuild\DBADashGUIOnly
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
         
       - name: Build DB
         run: msbuild dbadashdb -property:Configuration=CLI

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet build DBADashGUI -o DBADashBuild\DBADashGUIOnly
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
         
       - name: Build DB
         run: msbuild dbadashdb -property:Configuration=CLI

--- a/.github/workflows/ci_MininalPermissions.yml
+++ b/.github/workflows/ci_MininalPermissions.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet build DBADashGUI -o DBADashBuild\DBADashGUIOnly
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
         
       - name: Build DB
         run: msbuild dbadashdb -property:Configuration=CLI

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
         run: dotnet build -c CLI
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Build
         run: msbuild dbadashdb -property:Configuration=CLI

--- a/.github/workflows/tag-create-release.yml
+++ b/.github/workflows/tag-create-release.yml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet build DBADashGUI -o DBADashBuild\DBADashGUIOnly
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.3
+        uses: microsoft/setup-msbuild@v2
         
       - name: Build DB
         run: msbuild dbadashdb -property:Configuration=CLI


### PR DESCRIPTION
Fix Node.js build warnings with Microsoft/setup-msbuild@v1.3 by upgrading to latest version.