### PR TITLE
Fix Instance Counts when Show Counts option is used

### DIFF
--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -497,7 +497,7 @@ namespace DBADashGUI
                 foreach (SQLTreeItem n in root.Nodes.Cast<SQLTreeItem>()
                              .Where(t => t.Type == SQLTreeItem.TreeType.InstanceFolder))
                 {
-                    n.Text += "    {" + n.Nodes.Count + "}";
+                    n.Text += "    {" + n.Nodes.Cast<SQLTreeItem>().Count(child => child.Type is SQLTreeItem.TreeType.Instance or SQLTreeItem.TreeType.AzureInstance) + "}";
                 }
             }
 


### PR DESCRIPTION
Count was broken by #759.  Count the instance type nodes only rather than all child nodes.