### PR TITLE
Topshelf uninstall fix

### DIFF
--- a/DBADash/ServiceTools.cs
+++ b/DBADash/ServiceTools.cs
@@ -159,7 +159,7 @@ namespace DBADash
             {
                 throw new Exception($"Service {serviceName} is not installed");
             }
-            if (!string.Equals(path, ServicePath, StringComparison.CurrentCultureIgnoreCase))
+            if (!path.Contains(ServicePath, StringComparison.CurrentCultureIgnoreCase)) // path might also include -displayname and -servicename parameters if installed by Topshelf
             {
                 throw new Exception($"Service {serviceName} appears to be installed in a different path.  \nExpected: {ServicePath}.  \nActual: {path}");
             }

--- a/DBADash/ServiceTools.cs
+++ b/DBADash/ServiceTools.cs
@@ -22,7 +22,7 @@ namespace DBADash
             using var searcher = new ManagementObjectSearcher("root\\cimv2", "SELECT Name,PathName from Win32_Service");
 
             var collection = searcher.Get().Cast<ManagementBaseObject>()
-                .Where(service => ((string)service.GetPropertyValue("PathName"))?.Contains(path) == true)
+                .Where(service => ((string)service.GetPropertyValue("PathName"))?.Contains(path, StringComparison.InvariantCultureIgnoreCase) == true)
                 .Select(service => (string)service.GetPropertyValue("Name"));
 
             return collection.Any();
@@ -38,7 +38,7 @@ namespace DBADash
             using var searcher = new ManagementObjectSearcher("root\\cimv2", "SELECT Name from Win32_Service");
 
             var collection = searcher.Get().Cast<ManagementBaseObject>()
-                .Where(service => (string)service.GetPropertyValue("Name") == ServiceName)
+                .Where(service => string.Equals((string)service.GetPropertyValue("Name"), ServiceName, StringComparison.InvariantCultureIgnoreCase))
                 .Select(service => (string)service.GetPropertyValue("Name"));
 
             return collection.Any();
@@ -49,7 +49,7 @@ namespace DBADash
             using var searcher = new ManagementObjectSearcher("root\\cimv2", "SELECT Name,PathName from Win32_Service");
 
             var collection = searcher.Get().Cast<ManagementBaseObject>()
-                .Where(service => ((string)service.GetPropertyValue("PathName")).Contains(path))
+                .Where(service => ((string)service.GetPropertyValue("PathName")).Contains(path, StringComparison.InvariantCultureIgnoreCase))
                 .Select(service => (string)service.GetPropertyValue("Name"));
 
             return collection.FirstOrDefault(string.Empty);
@@ -60,7 +60,7 @@ namespace DBADash
             using var searcher = new ManagementObjectSearcher("root\\cimv2", "SELECT Name,PathName from Win32_Service");
 
             var collection = searcher.Get().Cast<ManagementBaseObject>()
-                .Where(service => (string)service.GetPropertyValue("Name") == ServiceName)
+                .Where(service => string.Equals((string)service.GetPropertyValue("Name"), ServiceName, StringComparison.InvariantCultureIgnoreCase))
                 .Select(service => (string)service.GetPropertyValue("PathName"));
 
             return collection.FirstOrDefault(string.Empty);


### PR DESCRIPTION
Fix path validation check to take into account -displayname and -servicename parameters that are part of the path if the service was installed with Topshelf.
Make service path & name comparisons case insensitive.
#826