### PR TITLE
Allow DBA Dash to work when @@SERVERNAME returns NULL

### DIFF
--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -209,9 +209,9 @@ namespace DBADash
             var cinfo = master.ConnectionInfo;
             if (string.IsNullOrEmpty(cinfo.ServerName))
             {
-                throw new Exception("@@SERVERNAME didn't return a value for this SQL instance.  You might need to fix this issue by running sp_addserver.");
+                Log.Warning("@@SERVERNAME returned NULL for {connection}.  Consider fixing with sp_addserver", destination.ConnectionForPrint);
             }
-            else if (cinfo.MajorVersion < 13 && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlDatabase && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlManagedInstance) // 13=2016, 12 might be Azure DB which is OK
+            if (cinfo.MajorVersion < 13 && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlDatabase && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlManagedInstance) // 13=2016, 12 might be Azure DB which is OK
             {
                 throw new Exception("DBA Dash repository database requires SQL 2016 SP1 or later");
             }

--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -207,8 +207,11 @@ namespace DBADash
         {
             var master = destination.MasterConnection();
             var cinfo = master.ConnectionInfo;
-
-            if (cinfo.MajorVersion < 13 && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlDatabase && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlManagedInstance) // 13=2016, 12 might be Azure DB which is OK
+            if (string.IsNullOrEmpty(cinfo.ServerName))
+            {
+                throw new Exception("@@SERVERNAME didn't return a value for this SQL instance.  You might need to fix this issue by running sp_addserver.");
+            }
+            else if (cinfo.MajorVersion < 13 && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlDatabase && cinfo.EngineEdition != Microsoft.SqlServer.Management.Common.DatabaseEngineEdition.SqlManagedInstance) // 13=2016, 12 might be Azure DB which is OK
             {
                 throw new Exception("DBA Dash repository database requires SQL 2016 SP1 or later");
             }

--- a/DBADash/ConnectionInfo.cs
+++ b/DBADash/ConnectionInfo.cs
@@ -63,7 +63,7 @@ namespace DBADash
             }
             connectionInfo.ProductVersion = rdr.GetString(1);
             connectionInfo.DatabaseName = rdr.GetString(2);
-            connectionInfo.ServerName = rdr.GetString(3);
+            connectionInfo.ServerName = rdr.IsDBNull(3) ? "" : rdr.GetString(3);
             connectionInfo.ComputerNetBIOSName = rdr.IsDBNull(4) ? "" : rdr.GetString(4);  /* ComputerNamePhysicalNetBIOS is NULL for AzureDB */
 
             return connectionInfo;

--- a/DBADash/SQL/SQLInstance.sql
+++ b/DBADash/SQL/SQLInstance.sql
@@ -31,7 +31,8 @@ BEGIN
 		SERVERPROPERTY('IsHadrEnabled') IsHadrEnabled,
 		SERVERPROPERTY('EngineEdition') EngineEdition,
 		@ContainedAGID as contained_availability_group_id,
-		@ContainedAGName AS contained_availability_group_name
+		@ContainedAGName AS contained_availability_group_name,
+		ISNULL(CAST(SERVERPROPERTY('MachineName') AS NVARCHAR(128)),'') AS MachineName
 	FROM sys.dm_os_host_info
 END
 ELSE IF OBJECT_ID('sys.dm_os_windows_info') IS NOT NULL
@@ -52,7 +53,8 @@ BEGIN
 		SERVERPROPERTY('IsHadrEnabled') IsHadrEnabled,
 		SERVERPROPERTY('EngineEdition') EngineEdition,
 		@ContainedAGID as contained_availability_group_id,
-		@ContainedAGName AS contained_availability_group_name
+		@ContainedAGName AS contained_availability_group_name,
+		ISNULL(CAST(SERVERPROPERTY('MachineName') AS NVARCHAR(128)),'') AS MachineName
 	FROM sys.dm_os_windows_info
 END
 ELSE
@@ -72,5 +74,6 @@ BEGIN
 		SERVERPROPERTY('IsHadrEnabled') IsHadrEnabled,
 		SERVERPROPERTY('EngineEdition') EngineEdition,
 		@ContainedAGID as contained_availability_group_id,
-		@ContainedAGName AS contained_availability_group_name
+		@ContainedAGName AS contained_availability_group_name,
+		ISNULL(CAST(SERVERPROPERTY('MachineName') AS NVARCHAR(128)),'') AS MachineName
 END

--- a/DBADashGUI/RepositoryConnections.cs
+++ b/DBADashGUI/RepositoryConnections.cs
@@ -36,9 +36,9 @@ namespace DBADashGUI
         {
             var builder1 = new SqlConnectionStringBuilder(connectionString1);
             var builder2 = new SqlConnectionStringBuilder(connectionString2);
-            return builder1.DataSource == builder2.DataSource 
-                   && builder1.InitialCatalog == builder2.InitialCatalog 
-                   && builder1.UserID == builder2.UserID 
+            return builder1.DataSource == builder2.DataSource
+                   && builder1.InitialCatalog == builder2.InitialCatalog
+                   && builder1.UserID == builder2.UserID
                    && builder1.IntegratedSecurity == builder2.IntegratedSecurity;
         }
 
@@ -141,7 +141,7 @@ namespace DBADashGUI
         {
             using var cn = new SqlConnection(ConnectionString);
             cn.Open();
-            using var cmd = new SqlCommand("SELECT @@SERVERNAME + '\\' + DB_NAME() as Name", cn);
+            using var cmd = new SqlCommand("SELECT ISNULL(@@SERVERNAME,ISNULL(CAST(SERVERPROPERTY('MachineName') AS NVARCHAR(128)),'')) + '\\' + DB_NAME() as Name", cn);
             return (string)cmd.ExecuteScalar();
         }
 

--- a/DBADashServiceConfig/ServiceConfig.Designer.cs
+++ b/DBADashServiceConfig/ServiceConfig.Designer.cs
@@ -127,6 +127,7 @@ namespace DBADashServiceConfig
             label13 = new System.Windows.Forms.Label();
             txtSearch = new System.Windows.Forms.TextBox();
             tabDest = new System.Windows.Forms.TabPage();
+            lblServerNameWarning = new System.Windows.Forms.Label();
             lblServiceWarning = new System.Windows.Forms.Label();
             bttnAbout = new System.Windows.Forms.Button();
             groupBox5 = new System.Windows.Forms.GroupBox();
@@ -1265,6 +1266,7 @@ namespace DBADashServiceConfig
             // 
             // tabDest
             // 
+            tabDest.Controls.Add(lblServerNameWarning);
             tabDest.Controls.Add(lblServiceWarning);
             tabDest.Controls.Add(bttnAbout);
             tabDest.Controls.Add(groupBox5);
@@ -1284,6 +1286,17 @@ namespace DBADashServiceConfig
             tabDest.TabIndex = 2;
             tabDest.Text = "Destination:";
             tabDest.UseVisualStyleBackColor = true;
+            // 
+            // lblServerNameWarning
+            // 
+            lblServerNameWarning.AutoSize = true;
+            lblServerNameWarning.ForeColor = System.Drawing.Color.FromArgb(228, 147, 37);
+            lblServerNameWarning.Location = new System.Drawing.Point(103, 209);
+            lblServerNameWarning.Name = "lblServerNameWarning";
+            lblServerNameWarning.Size = new System.Drawing.Size(554, 20);
+            lblServerNameWarning.TabIndex = 25;
+            lblServerNameWarning.Text = "Warning @@SERVERNAME returned NULL.  Consider fixing this using sp_addserver";
+            lblServerNameWarning.Visible = false;
             // 
             // lblServiceWarning
             // 
@@ -1583,6 +1596,7 @@ namespace DBADashServiceConfig
         private System.Windows.Forms.GroupBox groupBox6;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.CheckBox chkEnableMessaging;
+        private System.Windows.Forms.Label lblServerNameWarning;
     }
 }
 

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -23,7 +23,7 @@ using System.Threading.Tasks;
 
 namespace DBADashServiceConfig
 {
-    public partial class ServiceConfig : Form
+    public partial class ServiceConfig : Form, IThemedControl
     {
         public ServiceConfig()
         {
@@ -131,6 +131,11 @@ namespace DBADashServiceConfig
                         }
                         System.Windows.Forms.Cursor.Current = System.Windows.Forms.Cursors.Default;
                     }
+
+                    if (string.IsNullOrEmpty(src.SourceConnection.ConnectionInfo.ServerName))
+                    {
+                        MessageBox.Show("Warning @@SERVERNAME returned NULL.  Consider fixing this using sp_addserver", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
                     if (!addUnvalidated && !validated)
                     {
                         if (doNotAddUnvalidated)
@@ -212,6 +217,7 @@ namespace DBADashServiceConfig
         private bool ValidateDestination()
         {
             errorProvider1.SetError(txtDestination, null);
+            lblServerNameWarning.Visible = false;
             DBADashConnection dest = new(txtDestination.Text);
             lblVersionInfo.ForeColor = Color.Black;
             lblVersionInfo.Text = "";
@@ -242,6 +248,10 @@ namespace DBADashServiceConfig
             {
                 try
                 {
+                    if (string.IsNullOrEmpty(dest.MasterConnection().ConnectionInfo.ServerName))
+                    {
+                        lblServerNameWarning.Visible = true;
+                    }
                     var status = DBValidations.VersionStatus(dest.ConnectionString);
                     if (status.VersionStatus == DBValidations.DBVersionStatusEnum.CreateDB)
                     {
@@ -269,6 +279,7 @@ namespace DBADashServiceConfig
                         lblVersionInfo.ForeColor = DashColors.Fail;
                         bttnDeployDatabase.Enabled = true;
                     }
+
                     return true;
                 }
                 catch (Exception ex)
@@ -1591,6 +1602,17 @@ namespace DBADashServiceConfig
             {
                 MessageBox.Show("ConnectionID populated successfully", "Messaging", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
+        }
+
+        public void ApplyTheme(BaseTheme theme)
+        {
+            foreach (Control c in this.Controls)
+            {
+                c.ApplyTheme(theme);
+            }
+
+            lblServerNameWarning.ForeColor = theme.WarningForeColor;
+            lblServerNameWarning.BackColor = theme.WarningBackColor;
         }
     }
 }


### PR DESCRIPTION
Display a warning that `@@SERVERNAME` is NULL, but allow DBA Dash to work.  If generating a ConnectionID, use the value from `SERVERPROPERTY('MachineName')`  if `@@SERVERNAME` is NULL.