### PR TITLE
Config Tool search fix

### DIFF
--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -1211,7 +1211,7 @@ namespace DBADashServiceConfig
             currencyManager1.SuspendBinding();
             foreach (DataGridViewRow row in dgvConnections.Rows)
             {
-                if (string.IsNullOrEmpty(txtSearch.Text) || (row.Cells["ConnectionString"].Value.ToString() ?? "").Contains(txtSearch.Text, StringComparison.CurrentCultureIgnoreCase) || (row.Cells["ConnectionID"].Value.ToString() ?? "").Contains(txtSearch.Text, StringComparison.CurrentCultureIgnoreCase))
+                if (string.IsNullOrEmpty(txtSearch.Text) || (row.Cells["ConnectionString"].Value as string ?? "").Contains(txtSearch.Text, StringComparison.CurrentCultureIgnoreCase) || (row.Cells["ConnectionID"].Value as string ?? "").Contains(txtSearch.Text, StringComparison.CurrentCultureIgnoreCase))
                 {
                     row.Visible = true;
                 }


### PR DESCRIPTION
Fix object reference not set to an instance of an object error that can occur when searching if the ConnectionID is null.