### PR TITLE
Issue 886: Add COLLATE DATABASE_DEFAULT to equality comparison of SQLTableSize

### DIFF
--- a/DBADash/SQL/SQLTableSize.sql
+++ b/DBADash/SQL/SQLTableSize.sql
@@ -32,12 +32,12 @@ AND D.database_id <> 2
 AND EXISTS(
 		SELECT 1 
 		FROM STRING_SPLIT(@TableSizeDatabases,',') SS
-		WHERE (RTRIM(LTRIM(SS.value)) = D.name OR SS.value ='*')
+		WHERE (RTRIM(LTRIM(SS.value)) = D.name COLLATE DATABASE_DEFAULT OR SS.value ='*')
 )
 AND NOT EXISTS(
 			SELECT 1 
 			FROM STRING_SPLIT(@TableSizeDatabases,',') SS
-			WHERE STUFF(RTRIM(LTRIM(SS.value)),1,1,'') = D.name 
+			WHERE STUFF(RTRIM(LTRIM(SS.value)),1,1,'') = D.name COLLATE DATABASE_DEFAULT
 			AND RTRIM(LTRIM(SS.value)) LIKE '-%'
 	)
 


### PR DESCRIPTION
To resolve issue #886: Added a `COLLATE DATABASE_DEFAULT` to the equality comparison of SQLTableSize.sql to resolve collation conflicts when there is a mismatch between server and database configuration. 

Running the query manually **before**:
![before](https://github.com/trimble-oss/dba-dash/assets/2857220/bee2f824-6578-4cf7-8b65-1b498246a4b6)

Running the query manually **after**:
![image](https://github.com/trimble-oss/dba-dash/assets/2857220/0bcd7805-5538-4be3-a3a5-bbe72afe2222)