### PR TITLE
Fix issue installing Pester

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Run Pester Tests
         shell: powershell
         run: |     
-          Install-Module Pester -Force
+          Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
 

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Run Pester Tests FromFolder
         shell: powershell
         run: |     
-          Install-Module Pester -Force
+          Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_FromFolder" }
           Invoke-Pester -Container $container -Output Detailed

--- a/.github/workflows/ci_MininalPermissions.yml
+++ b/.github/workflows/ci_MininalPermissions.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Run Pester Tests
         shell: powershell
         run: |     
-          Install-Module Pester -Force
+          Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           $NoWMI=$true
           Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1


### PR DESCRIPTION
Fix error:
 Authenticode issuer 'CN=Jakub Jareš, O=Jakub Jareš, L=Praha, C=CZ' of the new
module 'Pester' with version '5.6.0' from root certificate authority 'CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, C=US' is not matching with the authenticode issuer 'CN=Jakub Jareš, O=Jakub Jareš, L=Praha, C=CZ' of the previously-installed module 'Pester' with version '5.5.0' from root certificate authority 'CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US'. If you still want to install or update, use -SkipPublisherCheck parameter.