### PR TITLE
Trigger collection support on various tabs

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/DDLSnapshots_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/DDLSnapshots_Get.sql
@@ -5,7 +5,8 @@
 	@PageNumber INT=1
 )
 AS
-SELECT I.InstanceGroupName,
+SELECT I.InstanceID,
+       I.InstanceGroupName,
        ss.DatabaseID,
        ss.SnapshotDate,
        ss.ValidatedDate,

--- a/DBADashGUI/Bak/BackupsControl.Designer.cs
+++ b/DBADashGUI/Bak/BackupsControl.Designer.cs
@@ -31,6 +31,7 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BackupsControl));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
@@ -40,610 +41,629 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BackupsControl));
-            this.dgvBackups = new System.Windows.Forms.DataGridView();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
-            this.configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsCols = new System.Windows.Forms.ToolStripButton();
-            this.tsBack = new System.Windows.Forms.ToolStripButton();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.dgvSummary = new System.Windows.Forms.DataGridView();
-            this.toolStrip2 = new System.Windows.Forms.ToolStrip();
-            this.tsCopyDetail = new System.Windows.Forms.ToolStripButton();
-            this.tsExcelDetail = new System.Windows.Forms.ToolStripButton();
-            this.tsDetailCols = new System.Windows.Forms.ToolStripButton();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn19 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn20 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn21 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn22 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn23 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn24 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn25 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn26 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn27 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn28 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.statusFilterToolStrip1 = new DBADashGUI.StatusFilterToolStrip();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvBackups)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvSummary)).BeginInit();
-            this.toolStrip2.SuspendLayout();
-            this.SuspendLayout();
+            dgvBackups = new System.Windows.Forms.DataGridView();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
+            configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsCols = new System.Windows.Forms.ToolStripButton();
+            tsBack = new System.Windows.Forms.ToolStripButton();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            splitContainer1 = new System.Windows.Forms.SplitContainer();
+            dgvSummary = new System.Windows.Forms.DataGridView();
+            toolStrip2 = new System.Windows.Forms.ToolStrip();
+            tsCopyDetail = new System.Windows.Forms.ToolStripButton();
+            tsExcelDetail = new System.Windows.Forms.ToolStripButton();
+            statusFilterToolStrip1 = new StatusFilterToolStrip();
+            tsDetailCols = new System.Windows.Forms.ToolStripButton();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn19 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn20 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn21 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn22 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn23 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn24 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn25 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn26 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn27 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn28 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)dgvBackups).BeginInit();
+            toolStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
+            splitContainer1.Panel1.SuspendLayout();
+            splitContainer1.Panel2.SuspendLayout();
+            splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dgvSummary).BeginInit();
+            toolStrip2.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // dgvBackups
             // 
-            this.dgvBackups.AllowUserToAddRows = false;
-            this.dgvBackups.AllowUserToDeleteRows = false;
-            this.dgvBackups.BackgroundColor = System.Drawing.Color.White;
-            this.dgvBackups.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
+            dgvBackups.AllowUserToAddRows = false;
+            dgvBackups.AllowUserToDeleteRows = false;
+            dgvBackups.BackgroundColor = System.Drawing.Color.White;
+            dgvBackups.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvBackups.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.dgvBackups.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvBackups.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dgvBackups.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvBackups.DefaultCellStyle = dataGridViewCellStyle2;
-            this.dgvBackups.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvBackups.Location = new System.Drawing.Point(0, 27);
-            this.dgvBackups.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvBackups.Name = "dgvBackups";
-            this.dgvBackups.ReadOnly = true;
+            dgvBackups.DefaultCellStyle = dataGridViewCellStyle2;
+            dgvBackups.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvBackups.Location = new System.Drawing.Point(0, 27);
+            dgvBackups.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvBackups.Name = "dgvBackups";
+            dgvBackups.ReadOnly = true;
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvBackups.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
-            this.dgvBackups.RowHeadersVisible = false;
-            this.dgvBackups.RowHeadersWidth = 51;
-            this.dgvBackups.Size = new System.Drawing.Size(1947, 483);
-            this.dgvBackups.TabIndex = 0;
-            this.dgvBackups.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvBackups_CellContentClick);
-            this.dgvBackups.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvBackups_RowsAdded);
+            dgvBackups.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dgvBackups.RowHeadersVisible = false;
+            dgvBackups.RowHeadersWidth = 51;
+            dgvBackups.Size = new System.Drawing.Size(1947, 470);
+            dgvBackups.TabIndex = 0;
+            dgvBackups.CellContentClick += DgvBackups_CellContentClick;
+            dgvBackups.RowsAdded += DgvBackups_RowsAdded;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.tsConfigure,
-            this.tsCols,
-            this.tsBack});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1947, 27);
-            this.toolStrip1.TabIndex = 1;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, tsConfigure, tsCols, tsBack, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(1947, 27);
+            toolStrip1.TabIndex = 1;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // tsConfigure
             // 
-            this.tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.configureInstanceThresholdsToolStripMenuItem,
-            this.configureRootThresholdsToolStripMenuItem});
-            this.tsConfigure.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
-            this.tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsConfigure.Name = "tsConfigure";
-            this.tsConfigure.Size = new System.Drawing.Size(34, 24);
-            this.tsConfigure.Text = "Configure";
+            tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { configureInstanceThresholdsToolStripMenuItem, configureRootThresholdsToolStripMenuItem });
+            tsConfigure.Image = Properties.Resources.SettingsOutline_16x;
+            tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsConfigure.Name = "tsConfigure";
+            tsConfigure.Size = new System.Drawing.Size(34, 24);
+            tsConfigure.Text = "Configure";
             // 
             // configureInstanceThresholdsToolStripMenuItem
             // 
-            this.configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
-            this.configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
-            this.configureInstanceThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureInstanceThresholdsToolStripMenuItem_Click);
+            configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
+            configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
+            configureInstanceThresholdsToolStripMenuItem.Click += ConfigureInstanceThresholdsToolStripMenuItem_Click;
             // 
             // configureRootThresholdsToolStripMenuItem
             // 
-            this.configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
-            this.configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
-            this.configureRootThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureRootThresholdsToolStripMenuItem_Click);
+            configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
+            configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
+            configureRootThresholdsToolStripMenuItem.Click += ConfigureRootThresholdsToolStripMenuItem_Click;
             // 
             // tsCols
             // 
-            this.tsCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCols.Image = global::DBADashGUI.Properties.Resources.Column_16x;
-            this.tsCols.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCols.Name = "tsCols";
-            this.tsCols.Size = new System.Drawing.Size(29, 24);
-            this.tsCols.Text = "Columns";
-            this.tsCols.Click += new System.EventHandler(this.TsCols_Click);
+            tsCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCols.Image = Properties.Resources.Column_16x;
+            tsCols.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCols.Name = "tsCols";
+            tsCols.Size = new System.Drawing.Size(29, 24);
+            tsCols.Text = "Columns";
+            tsCols.Click += TsCols_Click;
             // 
             // tsBack
             // 
-            this.tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsBack.Image = global::DBADashGUI.Properties.Resources.Previous_grey_16x;
-            this.tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsBack.Name = "tsBack";
-            this.tsBack.Size = new System.Drawing.Size(29, 24);
-            this.tsBack.Text = "Back";
-            this.tsBack.Click += new System.EventHandler(this.TsBack_Click);
+            tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsBack.Image = Properties.Resources.Previous_grey_16x;
+            tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsBack.Name = "tsBack";
+            tsBack.Size = new System.Drawing.Size(29, 24);
+            tsBack.Text = "Back";
+            tsBack.Click += TsBack_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += tsTrigger_Click;
             // 
             // splitContainer1
             // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 27);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer1.Location = new System.Drawing.Point(0, 27);
+            splitContainer1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            splitContainer1.Name = "splitContainer1";
+            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.dgvSummary);
+            splitContainer1.Panel1.Controls.Add(dgvSummary);
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.dgvBackups);
-            this.splitContainer1.Panel2.Controls.Add(this.toolStrip2);
-            this.splitContainer1.Size = new System.Drawing.Size(1947, 785);
-            this.splitContainer1.SplitterDistance = 270;
-            this.splitContainer1.SplitterWidth = 5;
-            this.splitContainer1.TabIndex = 2;
+            splitContainer1.Panel2.Controls.Add(dgvBackups);
+            splitContainer1.Panel2.Controls.Add(toolStrip2);
+            splitContainer1.Size = new System.Drawing.Size(1947, 763);
+            splitContainer1.SplitterDistance = 261;
+            splitContainer1.SplitterWidth = 5;
+            splitContainer1.TabIndex = 2;
             // 
             // dgvSummary
             // 
-            this.dgvSummary.AllowUserToAddRows = false;
-            this.dgvSummary.AllowUserToDeleteRows = false;
-            this.dgvSummary.BackgroundColor = System.Drawing.Color.White;
-            this.dgvSummary.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvSummary.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvSummary.Location = new System.Drawing.Point(0, 0);
-            this.dgvSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvSummary.Name = "dgvSummary";
-            this.dgvSummary.ReadOnly = true;
-            this.dgvSummary.RowHeadersVisible = false;
-            this.dgvSummary.RowHeadersWidth = 51;
-            this.dgvSummary.RowTemplate.Height = 24;
-            this.dgvSummary.Size = new System.Drawing.Size(1947, 270);
-            this.dgvSummary.TabIndex = 0;
-            this.dgvSummary.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvSummary_CellContentClick);
-            this.dgvSummary.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvSummary_RowsAdded);
+            dgvSummary.AllowUserToAddRows = false;
+            dgvSummary.AllowUserToDeleteRows = false;
+            dgvSummary.BackgroundColor = System.Drawing.Color.White;
+            dgvSummary.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvSummary.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvSummary.Location = new System.Drawing.Point(0, 0);
+            dgvSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvSummary.Name = "dgvSummary";
+            dgvSummary.ReadOnly = true;
+            dgvSummary.RowHeadersVisible = false;
+            dgvSummary.RowHeadersWidth = 51;
+            dgvSummary.RowTemplate.Height = 24;
+            dgvSummary.Size = new System.Drawing.Size(1947, 261);
+            dgvSummary.TabIndex = 0;
+            dgvSummary.CellContentClick += DgvSummary_CellContentClick;
+            dgvSummary.RowsAdded += DgvSummary_RowsAdded;
             // 
             // toolStrip2
             // 
-            this.toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsCopyDetail,
-            this.tsExcelDetail,
-            this.statusFilterToolStrip1,
-            this.tsDetailCols});
-            this.toolStrip2.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip2.Name = "toolStrip2";
-            this.toolStrip2.Size = new System.Drawing.Size(1947, 27);
-            this.toolStrip2.TabIndex = 1;
-            this.toolStrip2.Text = "toolStrip2";
+            toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsCopyDetail, tsExcelDetail, statusFilterToolStrip1, tsDetailCols });
+            toolStrip2.Location = new System.Drawing.Point(0, 0);
+            toolStrip2.Name = "toolStrip2";
+            toolStrip2.Size = new System.Drawing.Size(1947, 27);
+            toolStrip2.TabIndex = 1;
+            toolStrip2.Text = "toolStrip2";
             // 
             // tsCopyDetail
             // 
-            this.tsCopyDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopyDetail.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopyDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopyDetail.Name = "tsCopyDetail";
-            this.tsCopyDetail.Size = new System.Drawing.Size(29, 24);
-            this.tsCopyDetail.Text = "Copy";
-            this.tsCopyDetail.Click += new System.EventHandler(this.TsCopyDetail_Click);
+            tsCopyDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopyDetail.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopyDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopyDetail.Name = "tsCopyDetail";
+            tsCopyDetail.Size = new System.Drawing.Size(29, 24);
+            tsCopyDetail.Text = "Copy";
+            tsCopyDetail.Click += TsCopyDetail_Click;
             // 
             // tsExcelDetail
             // 
-            this.tsExcelDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcelDetail.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcelDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcelDetail.Name = "tsExcelDetail";
-            this.tsExcelDetail.Size = new System.Drawing.Size(29, 24);
-            this.tsExcelDetail.Text = "Excel";
-            this.tsExcelDetail.Click += new System.EventHandler(this.TsExcelDetail_Click);
-            // 
-            // tsDetailCols
-            // 
-            this.tsDetailCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsDetailCols.Image = global::DBADashGUI.Properties.Resources.Column_16x;
-            this.tsDetailCols.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsDetailCols.Name = "tsDetailCols";
-            this.tsDetailCols.Size = new System.Drawing.Size(29, 24);
-            this.tsDetailCols.Text = "Columns";
-            this.tsDetailCols.Click += new System.EventHandler(this.TsDetailCols_Click);
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "name";
-            this.dataGridViewTextBoxColumn2.HeaderText = "Database";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "create_date_utc";
-            dataGridViewCellStyle4.Format = "yyyy-MM-dd HH:mm";
-            this.dataGridViewTextBoxColumn3.DefaultCellStyle = dataGridViewCellStyle4;
-            this.dataGridViewTextBoxColumn3.HeaderText = "Created";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 87;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "recovery_model_desc";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Recovery Model";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 127;
-            // 
-            // dataGridViewTextBoxColumn5
-            // 
-            this.dataGridViewTextBoxColumn5.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn5.DataPropertyName = "LastFull";
-            this.dataGridViewTextBoxColumn5.HeaderText = "Last Full";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn6
-            // 
-            this.dataGridViewTextBoxColumn6.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn6.DataPropertyName = "LastDiff";
-            this.dataGridViewTextBoxColumn6.HeaderText = "Last Diff";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn7
-            // 
-            this.dataGridViewTextBoxColumn7.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn7.DataPropertyName = "LastLog";
-            this.dataGridViewTextBoxColumn7.HeaderText = "Last Log";
-            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            this.dataGridViewTextBoxColumn7.ReadOnly = true;
-            this.dataGridViewTextBoxColumn7.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn8
-            // 
-            this.dataGridViewTextBoxColumn8.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn8.DataPropertyName = "LastFG";
-            this.dataGridViewTextBoxColumn8.HeaderText = "Last Filegroup Backup";
-            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            this.dataGridViewTextBoxColumn8.ReadOnly = true;
-            this.dataGridViewTextBoxColumn8.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn9
-            // 
-            this.dataGridViewTextBoxColumn9.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn9.DataPropertyName = "LastFGDiff";
-            this.dataGridViewTextBoxColumn9.HeaderText = "Last Filegroup Diff Backup";
-            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            this.dataGridViewTextBoxColumn9.ReadOnly = true;
-            this.dataGridViewTextBoxColumn9.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn10
-            // 
-            this.dataGridViewTextBoxColumn10.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn10.DataPropertyName = "LastPartial";
-            this.dataGridViewTextBoxColumn10.HeaderText = "Last Partial Backup";
-            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            this.dataGridViewTextBoxColumn10.ReadOnly = true;
-            this.dataGridViewTextBoxColumn10.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn11
-            // 
-            this.dataGridViewTextBoxColumn11.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn11.DataPropertyName = "LastPartialDiff";
-            this.dataGridViewTextBoxColumn11.HeaderText = "Last Partial Diff Backup";
-            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            this.dataGridViewTextBoxColumn11.ReadOnly = true;
-            this.dataGridViewTextBoxColumn11.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn12
-            // 
-            this.dataGridViewTextBoxColumn12.DataPropertyName = "SnapshotAge";
-            this.dataGridViewTextBoxColumn12.HeaderText = "Snapshot Age (mins)";
-            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            this.dataGridViewTextBoxColumn12.ReadOnly = true;
-            this.dataGridViewTextBoxColumn12.Width = 97;
-            // 
-            // dataGridViewTextBoxColumn13
-            // 
-            this.dataGridViewTextBoxColumn13.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn13.DataPropertyName = "FullBackupCriticalThreshold";
-            this.dataGridViewTextBoxColumn13.HeaderText = "Full Critical Threshold";
-            this.dataGridViewTextBoxColumn13.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
-            this.dataGridViewTextBoxColumn13.ReadOnly = true;
-            this.dataGridViewTextBoxColumn13.Width = 80;
-            // 
-            // dataGridViewTextBoxColumn14
-            // 
-            this.dataGridViewTextBoxColumn14.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn14.DataPropertyName = "FullBackupWarningThreshold";
-            this.dataGridViewTextBoxColumn14.HeaderText = "Full Warning Threshold";
-            this.dataGridViewTextBoxColumn14.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
-            this.dataGridViewTextBoxColumn14.ReadOnly = true;
-            this.dataGridViewTextBoxColumn14.Width = 80;
-            // 
-            // dataGridViewTextBoxColumn15
-            // 
-            this.dataGridViewTextBoxColumn15.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn15.DataPropertyName = "DiffBackupCriticalThreshold";
-            this.dataGridViewTextBoxColumn15.HeaderText = "Diff Critical Threshold";
-            this.dataGridViewTextBoxColumn15.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
-            this.dataGridViewTextBoxColumn15.ReadOnly = true;
-            this.dataGridViewTextBoxColumn15.Width = 80;
-            // 
-            // dataGridViewTextBoxColumn16
-            // 
-            this.dataGridViewTextBoxColumn16.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn16.DataPropertyName = "DiffBackupWarningThreshold";
-            this.dataGridViewTextBoxColumn16.HeaderText = "Diff Warning Threshold";
-            this.dataGridViewTextBoxColumn16.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
-            this.dataGridViewTextBoxColumn16.ReadOnly = true;
-            this.dataGridViewTextBoxColumn16.Width = 80;
-            // 
-            // dataGridViewTextBoxColumn17
-            // 
-            this.dataGridViewTextBoxColumn17.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn17.DataPropertyName = "LogBackupCriticalThreshold";
-            this.dataGridViewTextBoxColumn17.HeaderText = "Log Critical Threshold";
-            this.dataGridViewTextBoxColumn17.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
-            this.dataGridViewTextBoxColumn17.ReadOnly = true;
-            this.dataGridViewTextBoxColumn17.Width = 80;
-            // 
-            // dataGridViewTextBoxColumn18
-            // 
-            this.dataGridViewTextBoxColumn18.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.dataGridViewTextBoxColumn18.DataPropertyName = "LogBackupWarningThreshold";
-            this.dataGridViewTextBoxColumn18.HeaderText = "Log Warning Threshold";
-            this.dataGridViewTextBoxColumn18.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
-            this.dataGridViewTextBoxColumn18.ReadOnly = true;
-            this.dataGridViewTextBoxColumn18.Width = 80;
-            // 
-            // dataGridViewTextBoxColumn19
-            // 
-            this.dataGridViewTextBoxColumn19.DataPropertyName = "ThresholdsConfiguredLevel";
-            this.dataGridViewTextBoxColumn19.HeaderText = "Thresholds Configured Level";
-            this.dataGridViewTextBoxColumn19.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn19.Name = "dataGridViewTextBoxColumn19";
-            this.dataGridViewTextBoxColumn19.ReadOnly = true;
-            this.dataGridViewTextBoxColumn19.Width = 132;
-            // 
-            // dataGridViewTextBoxColumn20
-            // 
-            this.dataGridViewTextBoxColumn20.DataPropertyName = "Full Backup MB/sec";
-            dataGridViewCellStyle5.Format = "N3";
-            this.dataGridViewTextBoxColumn20.DefaultCellStyle = dataGridViewCellStyle5;
-            this.dataGridViewTextBoxColumn20.HeaderText = "Full Backup MB/sec";
-            this.dataGridViewTextBoxColumn20.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn20.Name = "dataGridViewTextBoxColumn20";
-            this.dataGridViewTextBoxColumn20.ReadOnly = true;
-            this.dataGridViewTextBoxColumn20.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn21
-            // 
-            this.dataGridViewTextBoxColumn21.DataPropertyName = "Full Backup Write MB/sec";
-            dataGridViewCellStyle6.Format = "N3";
-            this.dataGridViewTextBoxColumn21.DefaultCellStyle = dataGridViewCellStyle6;
-            this.dataGridViewTextBoxColumn21.HeaderText = "Full Backup Write MB/sec";
-            this.dataGridViewTextBoxColumn21.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn21.Name = "dataGridViewTextBoxColumn21";
-            this.dataGridViewTextBoxColumn21.ReadOnly = true;
-            this.dataGridViewTextBoxColumn21.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn22
-            // 
-            this.dataGridViewTextBoxColumn22.DataPropertyName = "Full Backup Size GB";
-            dataGridViewCellStyle7.Format = "N3";
-            this.dataGridViewTextBoxColumn22.DefaultCellStyle = dataGridViewCellStyle7;
-            this.dataGridViewTextBoxColumn22.HeaderText = "FullBackupSizeGB";
-            this.dataGridViewTextBoxColumn22.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn22.Name = "dataGridViewTextBoxColumn22";
-            this.dataGridViewTextBoxColumn22.ReadOnly = true;
-            this.dataGridViewTextBoxColumn22.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn23
-            // 
-            this.dataGridViewTextBoxColumn23.DataPropertyName = "Full Backup Size (Compressed) GB";
-            dataGridViewCellStyle8.Format = "N3";
-            this.dataGridViewTextBoxColumn23.DefaultCellStyle = dataGridViewCellStyle8;
-            this.dataGridViewTextBoxColumn23.HeaderText = "Full Backup Size (Compressed) GB";
-            this.dataGridViewTextBoxColumn23.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn23.Name = "dataGridViewTextBoxColumn23";
-            this.dataGridViewTextBoxColumn23.ReadOnly = true;
-            this.dataGridViewTextBoxColumn23.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn24
-            // 
-            this.dataGridViewTextBoxColumn24.DataPropertyName = "Full Compression Saving %";
-            dataGridViewCellStyle9.Format = "P2";
-            this.dataGridViewTextBoxColumn24.DefaultCellStyle = dataGridViewCellStyle9;
-            this.dataGridViewTextBoxColumn24.HeaderText = "Full Compression Saving %";
-            this.dataGridViewTextBoxColumn24.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn24.Name = "dataGridViewTextBoxColumn24";
-            this.dataGridViewTextBoxColumn24.ReadOnly = true;
-            this.dataGridViewTextBoxColumn24.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn25
-            // 
-            this.dataGridViewTextBoxColumn25.DataPropertyName = "Full Compression Saving %";
-            dataGridViewCellStyle10.Format = "P2";
-            this.dataGridViewTextBoxColumn25.DefaultCellStyle = dataGridViewCellStyle10;
-            this.dataGridViewTextBoxColumn25.HeaderText = "Full Compression Saving %";
-            this.dataGridViewTextBoxColumn25.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn25.Name = "dataGridViewTextBoxColumn25";
-            this.dataGridViewTextBoxColumn25.ReadOnly = true;
-            this.dataGridViewTextBoxColumn25.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn26
-            // 
-            this.dataGridViewTextBoxColumn26.DataPropertyName = "LastFullDuration";
-            this.dataGridViewTextBoxColumn26.HeaderText = "LastDiffDuration";
-            this.dataGridViewTextBoxColumn26.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn26.Name = "dataGridViewTextBoxColumn26";
-            this.dataGridViewTextBoxColumn26.ReadOnly = true;
-            this.dataGridViewTextBoxColumn26.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn27
-            // 
-            this.dataGridViewTextBoxColumn27.DataPropertyName = "Diff Backup MB/sec";
-            dataGridViewCellStyle11.Format = "N1";
-            this.dataGridViewTextBoxColumn27.DefaultCellStyle = dataGridViewCellStyle11;
-            this.dataGridViewTextBoxColumn27.HeaderText = "Diff Backup MB/sec";
-            this.dataGridViewTextBoxColumn27.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn27.Name = "dataGridViewTextBoxColumn27";
-            this.dataGridViewTextBoxColumn27.ReadOnly = true;
-            this.dataGridViewTextBoxColumn27.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn28
-            // 
-            this.dataGridViewTextBoxColumn28.DataPropertyName = "Diff Backup Write MB/sec";
-            dataGridViewCellStyle12.Format = "N1";
-            this.dataGridViewTextBoxColumn28.DefaultCellStyle = dataGridViewCellStyle12;
-            this.dataGridViewTextBoxColumn28.HeaderText = "Diff Backup Write MB/sec";
-            this.dataGridViewTextBoxColumn28.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn28.Name = "dataGridViewTextBoxColumn28";
-            this.dataGridViewTextBoxColumn28.ReadOnly = true;
-            this.dataGridViewTextBoxColumn28.Width = 125;
+            tsExcelDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcelDetail.Image = Properties.Resources.excel16x16;
+            tsExcelDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcelDetail.Name = "tsExcelDetail";
+            tsExcelDetail.Size = new System.Drawing.Size(29, 24);
+            tsExcelDetail.Text = "Excel";
+            tsExcelDetail.Click += TsExcelDetail_Click;
             // 
             // statusFilterToolStrip1
             // 
-            this.statusFilterToolStrip1.Acknowledged = true;
-            this.statusFilterToolStrip1.AcknowledgedVisible = false;
-            this.statusFilterToolStrip1.Critical = true;
-            this.statusFilterToolStrip1.CriticalVisible = true;
-            this.statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.statusFilterToolStrip1.Image = ((System.Drawing.Image)(resources.GetObject("statusFilterToolStrip1.Image")));
-            this.statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.statusFilterToolStrip1.NA = true;
-            this.statusFilterToolStrip1.Name = "statusFilterToolStrip1";
-            this.statusFilterToolStrip1.NAVisible = true;
-            this.statusFilterToolStrip1.OK = true;
-            this.statusFilterToolStrip1.OKVisible = true;
-            this.statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
-            this.statusFilterToolStrip1.Text = "ALL";
-            this.statusFilterToolStrip1.Warning = true;
-            this.statusFilterToolStrip1.WarningVisible = true;
-            this.statusFilterToolStrip1.UserChangedStatusFilter += new System.EventHandler(this.TsFilter_Click);
+            statusFilterToolStrip1.Acknowledged = false;
+            statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.Critical = true;
+            statusFilterToolStrip1.CriticalVisible = true;
+            statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            statusFilterToolStrip1.Image = (System.Drawing.Image)resources.GetObject("statusFilterToolStrip1.Image");
+            statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            statusFilterToolStrip1.NA = true;
+            statusFilterToolStrip1.Name = "statusFilterToolStrip1";
+            statusFilterToolStrip1.NAVisible = true;
+            statusFilterToolStrip1.OK = true;
+            statusFilterToolStrip1.OKVisible = true;
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
+            statusFilterToolStrip1.Text = "ALL";
+            statusFilterToolStrip1.Warning = true;
+            statusFilterToolStrip1.WarningVisible = true;
+            statusFilterToolStrip1.UserChangedStatusFilter += TsFilter_Click;
+            // 
+            // tsDetailCols
+            // 
+            tsDetailCols.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsDetailCols.Image = Properties.Resources.Column_16x;
+            tsDetailCols.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsDetailCols.Name = "tsDetailCols";
+            tsDetailCols.Size = new System.Drawing.Size(29, 24);
+            tsDetailCols.Text = "Columns";
+            tsDetailCols.Click += TsDetailCols_Click;
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            dataGridViewTextBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
+            dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.ReadOnly = true;
+            dataGridViewTextBoxColumn1.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn2.DataPropertyName = "name";
+            dataGridViewTextBoxColumn2.HeaderText = "Database";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.ReadOnly = true;
+            dataGridViewTextBoxColumn2.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            dataGridViewTextBoxColumn3.DataPropertyName = "create_date_utc";
+            dataGridViewCellStyle4.Format = "yyyy-MM-dd HH:mm";
+            dataGridViewTextBoxColumn3.DefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewTextBoxColumn3.HeaderText = "Created";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.ReadOnly = true;
+            dataGridViewTextBoxColumn3.Width = 87;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            dataGridViewTextBoxColumn4.DataPropertyName = "recovery_model_desc";
+            dataGridViewTextBoxColumn4.HeaderText = "Recovery Model";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.ReadOnly = true;
+            dataGridViewTextBoxColumn4.Width = 127;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            dataGridViewTextBoxColumn5.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn5.DataPropertyName = "LastFull";
+            dataGridViewTextBoxColumn5.HeaderText = "Last Full";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.ReadOnly = true;
+            dataGridViewTextBoxColumn5.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            dataGridViewTextBoxColumn6.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn6.DataPropertyName = "LastDiff";
+            dataGridViewTextBoxColumn6.HeaderText = "Last Diff";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.ReadOnly = true;
+            dataGridViewTextBoxColumn6.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn7
+            // 
+            dataGridViewTextBoxColumn7.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn7.DataPropertyName = "LastLog";
+            dataGridViewTextBoxColumn7.HeaderText = "Last Log";
+            dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            dataGridViewTextBoxColumn7.ReadOnly = true;
+            dataGridViewTextBoxColumn7.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn8
+            // 
+            dataGridViewTextBoxColumn8.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn8.DataPropertyName = "LastFG";
+            dataGridViewTextBoxColumn8.HeaderText = "Last Filegroup Backup";
+            dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            dataGridViewTextBoxColumn8.ReadOnly = true;
+            dataGridViewTextBoxColumn8.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn9
+            // 
+            dataGridViewTextBoxColumn9.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn9.DataPropertyName = "LastFGDiff";
+            dataGridViewTextBoxColumn9.HeaderText = "Last Filegroup Diff Backup";
+            dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            dataGridViewTextBoxColumn9.ReadOnly = true;
+            dataGridViewTextBoxColumn9.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn10
+            // 
+            dataGridViewTextBoxColumn10.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn10.DataPropertyName = "LastPartial";
+            dataGridViewTextBoxColumn10.HeaderText = "Last Partial Backup";
+            dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            dataGridViewTextBoxColumn10.ReadOnly = true;
+            dataGridViewTextBoxColumn10.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn11
+            // 
+            dataGridViewTextBoxColumn11.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn11.DataPropertyName = "LastPartialDiff";
+            dataGridViewTextBoxColumn11.HeaderText = "Last Partial Diff Backup";
+            dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            dataGridViewTextBoxColumn11.ReadOnly = true;
+            dataGridViewTextBoxColumn11.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn12
+            // 
+            dataGridViewTextBoxColumn12.DataPropertyName = "SnapshotAge";
+            dataGridViewTextBoxColumn12.HeaderText = "Snapshot Age (mins)";
+            dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            dataGridViewTextBoxColumn12.ReadOnly = true;
+            dataGridViewTextBoxColumn12.Width = 97;
+            // 
+            // dataGridViewTextBoxColumn13
+            // 
+            dataGridViewTextBoxColumn13.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn13.DataPropertyName = "FullBackupCriticalThreshold";
+            dataGridViewTextBoxColumn13.HeaderText = "Full Critical Threshold";
+            dataGridViewTextBoxColumn13.MinimumWidth = 6;
+            dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
+            dataGridViewTextBoxColumn13.ReadOnly = true;
+            dataGridViewTextBoxColumn13.Width = 80;
+            // 
+            // dataGridViewTextBoxColumn14
+            // 
+            dataGridViewTextBoxColumn14.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn14.DataPropertyName = "FullBackupWarningThreshold";
+            dataGridViewTextBoxColumn14.HeaderText = "Full Warning Threshold";
+            dataGridViewTextBoxColumn14.MinimumWidth = 6;
+            dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
+            dataGridViewTextBoxColumn14.ReadOnly = true;
+            dataGridViewTextBoxColumn14.Width = 80;
+            // 
+            // dataGridViewTextBoxColumn15
+            // 
+            dataGridViewTextBoxColumn15.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn15.DataPropertyName = "DiffBackupCriticalThreshold";
+            dataGridViewTextBoxColumn15.HeaderText = "Diff Critical Threshold";
+            dataGridViewTextBoxColumn15.MinimumWidth = 6;
+            dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
+            dataGridViewTextBoxColumn15.ReadOnly = true;
+            dataGridViewTextBoxColumn15.Width = 80;
+            // 
+            // dataGridViewTextBoxColumn16
+            // 
+            dataGridViewTextBoxColumn16.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn16.DataPropertyName = "DiffBackupWarningThreshold";
+            dataGridViewTextBoxColumn16.HeaderText = "Diff Warning Threshold";
+            dataGridViewTextBoxColumn16.MinimumWidth = 6;
+            dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
+            dataGridViewTextBoxColumn16.ReadOnly = true;
+            dataGridViewTextBoxColumn16.Width = 80;
+            // 
+            // dataGridViewTextBoxColumn17
+            // 
+            dataGridViewTextBoxColumn17.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn17.DataPropertyName = "LogBackupCriticalThreshold";
+            dataGridViewTextBoxColumn17.HeaderText = "Log Critical Threshold";
+            dataGridViewTextBoxColumn17.MinimumWidth = 6;
+            dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
+            dataGridViewTextBoxColumn17.ReadOnly = true;
+            dataGridViewTextBoxColumn17.Width = 80;
+            // 
+            // dataGridViewTextBoxColumn18
+            // 
+            dataGridViewTextBoxColumn18.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            dataGridViewTextBoxColumn18.DataPropertyName = "LogBackupWarningThreshold";
+            dataGridViewTextBoxColumn18.HeaderText = "Log Warning Threshold";
+            dataGridViewTextBoxColumn18.MinimumWidth = 6;
+            dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
+            dataGridViewTextBoxColumn18.ReadOnly = true;
+            dataGridViewTextBoxColumn18.Width = 80;
+            // 
+            // dataGridViewTextBoxColumn19
+            // 
+            dataGridViewTextBoxColumn19.DataPropertyName = "ThresholdsConfiguredLevel";
+            dataGridViewTextBoxColumn19.HeaderText = "Thresholds Configured Level";
+            dataGridViewTextBoxColumn19.MinimumWidth = 6;
+            dataGridViewTextBoxColumn19.Name = "dataGridViewTextBoxColumn19";
+            dataGridViewTextBoxColumn19.ReadOnly = true;
+            dataGridViewTextBoxColumn19.Width = 132;
+            // 
+            // dataGridViewTextBoxColumn20
+            // 
+            dataGridViewTextBoxColumn20.DataPropertyName = "Full Backup MB/sec";
+            dataGridViewCellStyle5.Format = "N3";
+            dataGridViewTextBoxColumn20.DefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewTextBoxColumn20.HeaderText = "Full Backup MB/sec";
+            dataGridViewTextBoxColumn20.MinimumWidth = 6;
+            dataGridViewTextBoxColumn20.Name = "dataGridViewTextBoxColumn20";
+            dataGridViewTextBoxColumn20.ReadOnly = true;
+            dataGridViewTextBoxColumn20.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn21
+            // 
+            dataGridViewTextBoxColumn21.DataPropertyName = "Full Backup Write MB/sec";
+            dataGridViewCellStyle6.Format = "N3";
+            dataGridViewTextBoxColumn21.DefaultCellStyle = dataGridViewCellStyle6;
+            dataGridViewTextBoxColumn21.HeaderText = "Full Backup Write MB/sec";
+            dataGridViewTextBoxColumn21.MinimumWidth = 6;
+            dataGridViewTextBoxColumn21.Name = "dataGridViewTextBoxColumn21";
+            dataGridViewTextBoxColumn21.ReadOnly = true;
+            dataGridViewTextBoxColumn21.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn22
+            // 
+            dataGridViewTextBoxColumn22.DataPropertyName = "Full Backup Size GB";
+            dataGridViewCellStyle7.Format = "N3";
+            dataGridViewTextBoxColumn22.DefaultCellStyle = dataGridViewCellStyle7;
+            dataGridViewTextBoxColumn22.HeaderText = "FullBackupSizeGB";
+            dataGridViewTextBoxColumn22.MinimumWidth = 6;
+            dataGridViewTextBoxColumn22.Name = "dataGridViewTextBoxColumn22";
+            dataGridViewTextBoxColumn22.ReadOnly = true;
+            dataGridViewTextBoxColumn22.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn23
+            // 
+            dataGridViewTextBoxColumn23.DataPropertyName = "Full Backup Size (Compressed) GB";
+            dataGridViewCellStyle8.Format = "N3";
+            dataGridViewTextBoxColumn23.DefaultCellStyle = dataGridViewCellStyle8;
+            dataGridViewTextBoxColumn23.HeaderText = "Full Backup Size (Compressed) GB";
+            dataGridViewTextBoxColumn23.MinimumWidth = 6;
+            dataGridViewTextBoxColumn23.Name = "dataGridViewTextBoxColumn23";
+            dataGridViewTextBoxColumn23.ReadOnly = true;
+            dataGridViewTextBoxColumn23.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn24
+            // 
+            dataGridViewTextBoxColumn24.DataPropertyName = "Full Compression Saving %";
+            dataGridViewCellStyle9.Format = "P2";
+            dataGridViewTextBoxColumn24.DefaultCellStyle = dataGridViewCellStyle9;
+            dataGridViewTextBoxColumn24.HeaderText = "Full Compression Saving %";
+            dataGridViewTextBoxColumn24.MinimumWidth = 6;
+            dataGridViewTextBoxColumn24.Name = "dataGridViewTextBoxColumn24";
+            dataGridViewTextBoxColumn24.ReadOnly = true;
+            dataGridViewTextBoxColumn24.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn25
+            // 
+            dataGridViewTextBoxColumn25.DataPropertyName = "Full Compression Saving %";
+            dataGridViewCellStyle10.Format = "P2";
+            dataGridViewTextBoxColumn25.DefaultCellStyle = dataGridViewCellStyle10;
+            dataGridViewTextBoxColumn25.HeaderText = "Full Compression Saving %";
+            dataGridViewTextBoxColumn25.MinimumWidth = 6;
+            dataGridViewTextBoxColumn25.Name = "dataGridViewTextBoxColumn25";
+            dataGridViewTextBoxColumn25.ReadOnly = true;
+            dataGridViewTextBoxColumn25.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn26
+            // 
+            dataGridViewTextBoxColumn26.DataPropertyName = "LastFullDuration";
+            dataGridViewTextBoxColumn26.HeaderText = "LastDiffDuration";
+            dataGridViewTextBoxColumn26.MinimumWidth = 6;
+            dataGridViewTextBoxColumn26.Name = "dataGridViewTextBoxColumn26";
+            dataGridViewTextBoxColumn26.ReadOnly = true;
+            dataGridViewTextBoxColumn26.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn27
+            // 
+            dataGridViewTextBoxColumn27.DataPropertyName = "Diff Backup MB/sec";
+            dataGridViewCellStyle11.Format = "N1";
+            dataGridViewTextBoxColumn27.DefaultCellStyle = dataGridViewCellStyle11;
+            dataGridViewTextBoxColumn27.HeaderText = "Diff Backup MB/sec";
+            dataGridViewTextBoxColumn27.MinimumWidth = 6;
+            dataGridViewTextBoxColumn27.Name = "dataGridViewTextBoxColumn27";
+            dataGridViewTextBoxColumn27.ReadOnly = true;
+            dataGridViewTextBoxColumn27.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn28
+            // 
+            dataGridViewTextBoxColumn28.DataPropertyName = "Diff Backup Write MB/sec";
+            dataGridViewCellStyle12.Format = "N1";
+            dataGridViewTextBoxColumn28.DefaultCellStyle = dataGridViewCellStyle12;
+            dataGridViewTextBoxColumn28.HeaderText = "Diff Backup Write MB/sec";
+            dataGridViewTextBoxColumn28.MinimumWidth = 6;
+            dataGridViewTextBoxColumn28.Name = "dataGridViewTextBoxColumn28";
+            dataGridViewTextBoxColumn28.ReadOnly = true;
+            dataGridViewTextBoxColumn28.Width = 125;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
+            statusStrip1.Location = new System.Drawing.Point(0, 790);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Size = new System.Drawing.Size(1947, 22);
+            statusStrip1.TabIndex = 3;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatus
+            // 
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 16);
             // 
             // BackupsControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.splitContainer1);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "BackupsControl";
-            this.Size = new System.Drawing.Size(1947, 812);
-            ((System.ComponentModel.ISupportInitialize)(this.dgvBackups)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            this.splitContainer1.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.dgvSummary)).EndInit();
-            this.toolStrip2.ResumeLayout(false);
-            this.toolStrip2.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(splitContainer1);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "BackupsControl";
+            Size = new System.Drawing.Size(1947, 812);
+            ((System.ComponentModel.ISupportInitialize)dgvBackups).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            splitContainer1.Panel1.ResumeLayout(false);
+            splitContainer1.Panel2.ResumeLayout(false);
+            splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
+            splitContainer1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)dgvSummary).EndInit();
+            toolStrip2.ResumeLayout(false);
+            toolStrip2.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -693,5 +713,8 @@
         private System.Windows.Forms.ToolStripButton tsCols;
         private System.Windows.Forms.ToolStripButton tsDetailCols;
         private StatusFilterToolStrip statusFilterToolStrip1;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }

--- a/DBADashGUI/Bak/BackupsControl.resx
+++ b/DBADashGUI/Bak/BackupsControl.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -78,4 +138,7 @@
         sdlgrh3cBIfF12GqXhrCwbTO2nDcNxpvR7NQRXnOAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>267, 17</value>
+  </metadata>
 </root>

--- a/DBADashGUI/Checks/CustomChecks.Designer.cs
+++ b/DBADashGUI/Checks/CustomChecks.Designer.cs
@@ -29,312 +29,328 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CustomChecks));
-            this.dgvCustom = new System.Windows.Forms.DataGridView();
-            this.colInstance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colTest = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.colContext = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.colStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colInfo = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colSSDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.History = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsBack = new System.Windows.Forms.ToolStripButton();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.tsFilter = new System.Windows.Forms.ToolStripDropDownButton();
-            this.testToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.contextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsClear = new System.Windows.Forms.ToolStripButton();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.statusFilterToolStrip1 = new DBADashGUI.StatusFilterToolStrip();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvCustom)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            this.SuspendLayout();
+            dgvCustom = new System.Windows.Forms.DataGridView();
+            colInstance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colTest = new System.Windows.Forms.DataGridViewLinkColumn();
+            colContext = new System.Windows.Forms.DataGridViewLinkColumn();
+            colStatus = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colInfo = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colSSDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            History = new System.Windows.Forms.DataGridViewLinkColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsBack = new System.Windows.Forms.ToolStripButton();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            statusFilterToolStrip1 = new StatusFilterToolStrip();
+            tsFilter = new System.Windows.Forms.ToolStripDropDownButton();
+            testToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            contextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsClear = new System.Windows.Forms.ToolStripButton();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)dgvCustom).BeginInit();
+            toolStrip1.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // dgvCustom
             // 
-            this.dgvCustom.AllowUserToAddRows = false;
-            this.dgvCustom.AllowUserToDeleteRows = false;
-            this.dgvCustom.BackgroundColor = System.Drawing.Color.White;
-            this.dgvCustom.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvCustom.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.colInstance,
-            this.colTest,
-            this.colContext,
-            this.colStatus,
-            this.colInfo,
-            this.colSSDate,
-            this.History});
-            this.dgvCustom.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvCustom.Location = new System.Drawing.Point(0, 27);
-            this.dgvCustom.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvCustom.Name = "dgvCustom";
-            this.dgvCustom.ReadOnly = true;
-            this.dgvCustom.RowHeadersVisible = false;
-            this.dgvCustom.RowHeadersWidth = 51;
-            this.dgvCustom.RowTemplate.Height = 24;
-            this.dgvCustom.Size = new System.Drawing.Size(801, 527);
-            this.dgvCustom.TabIndex = 0;
-            this.dgvCustom.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvCustom_CellContentClick);
-            this.dgvCustom.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvCustom_RowsAdded);
+            dgvCustom.AllowUserToAddRows = false;
+            dgvCustom.AllowUserToDeleteRows = false;
+            dgvCustom.BackgroundColor = System.Drawing.Color.White;
+            dgvCustom.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvCustom.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { colInstance, colTest, colContext, colStatus, colInfo, colSSDate, History });
+            dgvCustom.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvCustom.Location = new System.Drawing.Point(0, 27);
+            dgvCustom.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvCustom.Name = "dgvCustom";
+            dgvCustom.ReadOnly = true;
+            dgvCustom.RowHeadersVisible = false;
+            dgvCustom.RowHeadersWidth = 51;
+            dgvCustom.RowTemplate.Height = 24;
+            dgvCustom.Size = new System.Drawing.Size(801, 505);
+            dgvCustom.TabIndex = 0;
+            dgvCustom.CellContentClick += DgvCustom_CellContentClick;
+            dgvCustom.RowsAdded += DgvCustom_RowsAdded;
             // 
             // colInstance
             // 
-            this.colInstance.DataPropertyName = "InstanceDisplayName";
-            this.colInstance.HeaderText = "Instance";
-            this.colInstance.MinimumWidth = 6;
-            this.colInstance.Name = "colInstance";
-            this.colInstance.ReadOnly = true;
-            this.colInstance.Width = 90;
+            colInstance.DataPropertyName = "InstanceDisplayName";
+            colInstance.HeaderText = "Instance";
+            colInstance.MinimumWidth = 6;
+            colInstance.Name = "colInstance";
+            colInstance.ReadOnly = true;
+            colInstance.Width = 90;
             // 
             // colTest
             // 
-            this.colTest.DataPropertyName = "Test";
-            this.colTest.HeaderText = "Test";
-            this.colTest.MinimumWidth = 6;
-            this.colTest.Name = "colTest";
-            this.colTest.ReadOnly = true;
-            this.colTest.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colTest.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colTest.Width = 65;
+            colTest.DataPropertyName = "Test";
+            colTest.HeaderText = "Test";
+            colTest.MinimumWidth = 6;
+            colTest.Name = "colTest";
+            colTest.ReadOnly = true;
+            colTest.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colTest.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colTest.Width = 65;
             // 
             // colContext
             // 
-            this.colContext.DataPropertyName = "Context";
-            this.colContext.HeaderText = "Context";
-            this.colContext.MinimumWidth = 6;
-            this.colContext.Name = "colContext";
-            this.colContext.ReadOnly = true;
-            this.colContext.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colContext.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colContext.Width = 84;
+            colContext.DataPropertyName = "Context";
+            colContext.HeaderText = "Context";
+            colContext.MinimumWidth = 6;
+            colContext.Name = "colContext";
+            colContext.ReadOnly = true;
+            colContext.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colContext.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colContext.Width = 84;
             // 
             // colStatus
             // 
-            this.colStatus.DataPropertyName = "Status";
-            this.colStatus.HeaderText = "Status";
-            this.colStatus.MinimumWidth = 6;
-            this.colStatus.Name = "colStatus";
-            this.colStatus.ReadOnly = true;
-            this.colStatus.Width = 77;
+            colStatus.DataPropertyName = "Status";
+            colStatus.HeaderText = "Status";
+            colStatus.MinimumWidth = 6;
+            colStatus.Name = "colStatus";
+            colStatus.ReadOnly = true;
+            colStatus.Width = 77;
             // 
             // colInfo
             // 
-            this.colInfo.DataPropertyName = "Info";
-            this.colInfo.HeaderText = "Info";
-            this.colInfo.MinimumWidth = 6;
-            this.colInfo.Name = "colInfo";
-            this.colInfo.ReadOnly = true;
-            this.colInfo.Width = 60;
+            colInfo.DataPropertyName = "Info";
+            colInfo.HeaderText = "Info";
+            colInfo.MinimumWidth = 6;
+            colInfo.Name = "colInfo";
+            colInfo.ReadOnly = true;
+            colInfo.Width = 60;
             // 
             // colSSDate
             // 
-            this.colSSDate.DataPropertyName = "SnapshotDate";
-            this.colSSDate.HeaderText = "Snapshot Date";
-            this.colSSDate.MinimumWidth = 6;
-            this.colSSDate.Name = "colSSDate";
-            this.colSSDate.ReadOnly = true;
-            this.colSSDate.Width = 120;
+            colSSDate.DataPropertyName = "SnapshotDate";
+            colSSDate.HeaderText = "Snapshot Date";
+            colSSDate.MinimumWidth = 6;
+            colSSDate.Name = "colSSDate";
+            colSSDate.ReadOnly = true;
+            colSSDate.Width = 120;
             // 
             // History
             // 
-            this.History.HeaderText = "History";
-            this.History.MinimumWidth = 6;
-            this.History.Name = "History";
-            this.History.ReadOnly = true;
-            this.History.Text = "History";
-            this.History.UseColumnTextForLinkValue = true;
-            this.History.Width = 58;
+            History.HeaderText = "History";
+            History.MinimumWidth = 6;
+            History.Name = "History";
+            History.ReadOnly = true;
+            History.Text = "History";
+            History.UseColumnTextForLinkValue = true;
+            History.Width = 58;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsBack,
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.statusFilterToolStrip1,
-            this.tsFilter,
-            this.tsClear});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(801, 27);
-            this.toolStrip1.TabIndex = 4;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsBack, tsRefresh, tsCopy, tsExcel, statusFilterToolStrip1, tsFilter, tsClear, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(801, 27);
+            toolStrip1.TabIndex = 4;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsBack
             // 
-            this.tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsBack.Image = global::DBADashGUI.Properties.Resources.Previous_grey_16x;
-            this.tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsBack.Name = "tsBack";
-            this.tsBack.Size = new System.Drawing.Size(29, 24);
-            this.tsBack.Text = "Back";
-            this.tsBack.Visible = false;
-            this.tsBack.Click += new System.EventHandler(this.TsBack_Click);
+            tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsBack.Image = Properties.Resources.Previous_grey_16x;
+            tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsBack.Name = "tsBack";
+            tsBack.Size = new System.Drawing.Size(29, 24);
+            tsBack.Text = "Back";
+            tsBack.Visible = false;
+            tsBack.Click += TsBack_Click;
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
-            // 
-            // tsFilter
-            // 
-            this.tsFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsFilter.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.testToolStripMenuItem,
-            this.contextToolStripMenuItem});
-            this.tsFilter.Image = global::DBADashGUI.Properties.Resources.FilterDropdown_16x;
-            this.tsFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsFilter.Name = "tsFilter";
-            this.tsFilter.Size = new System.Drawing.Size(34, 24);
-            this.tsFilter.Text = "Filter";
-            // 
-            // testToolStripMenuItem
-            // 
-            this.testToolStripMenuItem.Name = "testToolStripMenuItem";
-            this.testToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            this.testToolStripMenuItem.Text = "Test";
-            // 
-            // contextToolStripMenuItem
-            // 
-            this.contextToolStripMenuItem.Name = "contextToolStripMenuItem";
-            this.contextToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
-            this.contextToolStripMenuItem.Text = "Context";
-            // 
-            // tsClear
-            // 
-            this.tsClear.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsClear.Image = global::DBADashGUI.Properties.Resources.Eraser_16x;
-            this.tsClear.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsClear.Name = "tsClear";
-            this.tsClear.Size = new System.Drawing.Size(29, 24);
-            this.tsClear.Text = "Clear Filters";
-            this.tsClear.Click += new System.EventHandler(this.TsClear_Click);
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "ConnectionID";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 90;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "Test";
-            this.dataGridViewTextBoxColumn2.HeaderText = "Test";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 65;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "Context";
-            this.dataGridViewTextBoxColumn3.HeaderText = "Context";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 84;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "Status";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Status";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 77;
-            // 
-            // dataGridViewTextBoxColumn5
-            // 
-            this.dataGridViewTextBoxColumn5.DataPropertyName = "Info";
-            this.dataGridViewTextBoxColumn5.HeaderText = "Info";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.Width = 60;
-            // 
-            // dataGridViewTextBoxColumn6
-            // 
-            this.dataGridViewTextBoxColumn6.DataPropertyName = "SnapshotDate";
-            this.dataGridViewTextBoxColumn6.HeaderText = "Snapshot Date";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.Width = 120;
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // statusFilterToolStrip1
             // 
-            this.statusFilterToolStrip1.Acknowledged = true;
-            this.statusFilterToolStrip1.AcknowledgedVisible = false;
-            this.statusFilterToolStrip1.Critical = true;
-            this.statusFilterToolStrip1.CriticalVisible = true;
-            this.statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.statusFilterToolStrip1.Image = ((System.Drawing.Image)(resources.GetObject("statusFilterToolStrip1.Image")));
-            this.statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.statusFilterToolStrip1.NA = true;
-            this.statusFilterToolStrip1.Name = "statusFilterToolStrip1";
-            this.statusFilterToolStrip1.NAVisible = true;
-            this.statusFilterToolStrip1.OK = true;
-            this.statusFilterToolStrip1.OKVisible = true;
-            this.statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
-            this.statusFilterToolStrip1.Text = "ALL";
-            this.statusFilterToolStrip1.Warning = true;
-            this.statusFilterToolStrip1.WarningVisible = true;
-            this.statusFilterToolStrip1.UserChangedStatusFilter += new System.EventHandler(this.StatusToolStripMenuItem_Click);
+            statusFilterToolStrip1.Acknowledged = false;
+            statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.Critical = true;
+            statusFilterToolStrip1.CriticalVisible = true;
+            statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            statusFilterToolStrip1.Image = (System.Drawing.Image)resources.GetObject("statusFilterToolStrip1.Image");
+            statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            statusFilterToolStrip1.NA = true;
+            statusFilterToolStrip1.Name = "statusFilterToolStrip1";
+            statusFilterToolStrip1.NAVisible = true;
+            statusFilterToolStrip1.OK = true;
+            statusFilterToolStrip1.OKVisible = true;
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
+            statusFilterToolStrip1.Text = "ALL";
+            statusFilterToolStrip1.Warning = true;
+            statusFilterToolStrip1.WarningVisible = true;
+            statusFilterToolStrip1.UserChangedStatusFilter += StatusToolStripMenuItem_Click;
+            // 
+            // tsFilter
+            // 
+            tsFilter.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsFilter.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { testToolStripMenuItem, contextToolStripMenuItem });
+            tsFilter.Image = Properties.Resources.FilterDropdown_16x;
+            tsFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsFilter.Name = "tsFilter";
+            tsFilter.Size = new System.Drawing.Size(34, 24);
+            tsFilter.Text = "Filter";
+            // 
+            // testToolStripMenuItem
+            // 
+            testToolStripMenuItem.Name = "testToolStripMenuItem";
+            testToolStripMenuItem.Size = new System.Drawing.Size(143, 26);
+            testToolStripMenuItem.Text = "Test";
+            // 
+            // contextToolStripMenuItem
+            // 
+            contextToolStripMenuItem.Name = "contextToolStripMenuItem";
+            contextToolStripMenuItem.Size = new System.Drawing.Size(143, 26);
+            contextToolStripMenuItem.Text = "Context";
+            // 
+            // tsClear
+            // 
+            tsClear.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsClear.Image = Properties.Resources.Eraser_16x;
+            tsClear.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsClear.Name = "tsClear";
+            tsClear.Size = new System.Drawing.Size(29, 24);
+            tsClear.Text = "Clear Filters";
+            tsClear.Click += TsClear_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += TsTrigger_Click;
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            dataGridViewTextBoxColumn1.DataPropertyName = "ConnectionID";
+            dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.ReadOnly = true;
+            dataGridViewTextBoxColumn1.Width = 90;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            dataGridViewTextBoxColumn2.DataPropertyName = "Test";
+            dataGridViewTextBoxColumn2.HeaderText = "Test";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.ReadOnly = true;
+            dataGridViewTextBoxColumn2.Width = 65;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            dataGridViewTextBoxColumn3.DataPropertyName = "Context";
+            dataGridViewTextBoxColumn3.HeaderText = "Context";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.ReadOnly = true;
+            dataGridViewTextBoxColumn3.Width = 84;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            dataGridViewTextBoxColumn4.DataPropertyName = "Status";
+            dataGridViewTextBoxColumn4.HeaderText = "Status";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.ReadOnly = true;
+            dataGridViewTextBoxColumn4.Width = 77;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            dataGridViewTextBoxColumn5.DataPropertyName = "Info";
+            dataGridViewTextBoxColumn5.HeaderText = "Info";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.ReadOnly = true;
+            dataGridViewTextBoxColumn5.Width = 60;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            dataGridViewTextBoxColumn6.DataPropertyName = "SnapshotDate";
+            dataGridViewTextBoxColumn6.HeaderText = "Snapshot Date";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.ReadOnly = true;
+            dataGridViewTextBoxColumn6.Width = 120;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
+            statusStrip1.Location = new System.Drawing.Point(0, 532);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Size = new System.Drawing.Size(801, 22);
+            statusStrip1.TabIndex = 5;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatus
+            // 
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 16);
             // 
             // CustomChecks
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.dgvCustom);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "CustomChecks";
-            this.Size = new System.Drawing.Size(801, 554);
-            this.Load += new System.EventHandler(this.CustomChecks_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.dgvCustom)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(dgvCustom);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "CustomChecks";
+            Size = new System.Drawing.Size(801, 554);
+            Load += CustomChecks_Load;
+            ((System.ComponentModel.ISupportInitialize)dgvCustom).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -363,5 +379,8 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colSSDate;
         private System.Windows.Forms.DataGridViewLinkColumn History;
         private StatusFilterToolStrip statusFilterToolStrip1;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }

--- a/DBADashGUI/Checks/CustomChecks.resx
+++ b/DBADashGUI/Checks/CustomChecks.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -96,4 +156,7 @@
         sdlgrh3cBIfF12GqXhrCwbTO2nDcNxpvR7NQRXnOAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>143, 17</value>
+  </metadata>
 </root>

--- a/DBADashGUI/CollectionDates/CollectionDates.cs
+++ b/DBADashGUI/CollectionDates/CollectionDates.cs
@@ -165,15 +165,7 @@ namespace DBADashGUI.CollectionDates
 
         public void SetStatus(string message, string tooltip, Color color)
         {
-            this.Invoke(() =>
-            {
-                lblStatus.Visible = true;
-                lblStatus.Text = message;
-                lblStatus.ToolTipText = tooltip;
-                lblStatus.IsLink = !string.IsNullOrEmpty(tooltip);
-                lblStatus.ForeColor = color;
-                lblStatus.LinkColor = color;
-            });
+            lblStatus.InvokeSetStatus(message,tooltip, color);
         }
 
         private void Dgv_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)

--- a/DBADashGUI/CommonData.cs
+++ b/DBADashGUI/CommonData.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Runtime.Caching;
+using DBADash;
 
 namespace DBADashGUI
 {
@@ -265,6 +266,15 @@ namespace DBADashGUI
             cache.Add(key, metricDrives, policy);
 
             return metricDrives;
+        }
+
+        public static DBADashAgent GetDBADashAgent(int agentID)
+        {
+            var cacheKey = "DBADashAgent_" + agentID;    
+            if (cache.Get(cacheKey) is DBADashAgent agent) return agent; 
+            agent =  DBADashAgent.GetDBADashAgent(Common.ConnectionString,agentID);
+            cache.Add(cacheKey, agent, DateTimeOffset.Now.AddMinutes(10));
+            return agent;
         }
 
         public static void ClearCache()

--- a/DBADashGUI/DBADashContext.cs
+++ b/DBADashGUI/DBADashContext.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using DBADash;
 using DBADashGUI.CustomReports;
 
 namespace DBADashGUI
@@ -29,9 +31,58 @@ namespace DBADashGUI
 
         public CustomReport Report { get; set; }
 
+        private int? _importAgentID;
+        private int? _collectAgentID;
+
+        public int? ImportAgentID
+        {
+            get
+            {
+                if(_importAgentID != null || InstanceID <=0) return _importAgentID;
+                GetInstanceAgentInfo();
+                return _importAgentID;
+            }
+        }
+
+        public int? CollectAgentID
+        {
+            get
+            {
+                if(_collectAgentID != null || InstanceID<=0) return _collectAgentID;
+                GetInstanceAgentInfo();
+                return _collectAgentID;
+            }
+        }
+
+        private bool? _canMessage;
+
+        private void GetInstanceAgentInfo()
+        {
+            if(InstanceID<=0) return;
+            var row =  CommonData.Instances.Select($"InstanceID={InstanceID}").FirstOrDefault();
+            if (row == null) return;
+            _collectAgentID = (int)row["CollectAgentID"];
+            _importAgentID = (int)row["ImportAgentID"];
+        }
+
+        public bool CanMessage
+        {
+            get
+            {
+                if (_canMessage != null) return (bool)_canMessage;
+                _canMessage= DBADashUser.AllowMessaging && ImportAgent is { MessagingEnabled: true } && CollectAgent is {MessagingEnabled:true};
+                return (bool)_canMessage;
+            }
+        }
+
+        public DBADashAgent ImportAgent => ImportAgentID == null ? null : CommonData.GetDBADashAgent((int)ImportAgentID);
+
+        public DBADashAgent CollectAgent => CollectAgentID == null ? null : CommonData.GetDBADashAgent((int)CollectAgentID);
+
         public object Clone()
         {
             var clone = (DBADashContext)MemberwiseClone();
+            clone._canMessage = null;
             return clone;
         }
     }

--- a/DBADashGUI/DBFiles/DBFilesControl.Designer.cs
+++ b/DBADashGUI/DBFiles/DBFilesControl.Designer.cs
@@ -61,1029 +61,995 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle30 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle31 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle32 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.dgvFiles = new System.Windows.Forms.DataGridView();
-            this.Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colType = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_PhysicalName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_FileSizeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_FileUsedMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_FileFreeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_FilePctFree = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_Growth = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_GrowthPct = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileLevel_MaxSizeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileGroup = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SizeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupUsedMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupFreeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupPctFree = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupMaxSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupPctMaxSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupUsedPctMaxSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.NumberOfFiles = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilegroupAutogrow = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ExcludedReason = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.MaxSizeExcludedReason = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ReadOnly = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DBReadOnly = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Standby = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.State = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ConfiguredLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FileSnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.History = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.Configure = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.statusFilterToolStrip1 = new DBADashGUI.StatusFilterToolStrip();
-            this.tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
-            this.configureDatabaseThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsLevel = new System.Windows.Forms.ToolStripDropDownButton();
-            this.tsFilegroup = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsFile = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsType = new System.Windows.Forms.ToolStripDropDownButton();
-            this.rOWSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lOGToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fILESTREAMToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fULLTEXTToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn19 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn20 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn21 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn22 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn23 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn24 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn25 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn26 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn27 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn28 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn29 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn30 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-            this.lblInfo = new System.Windows.Forms.ToolStripStatusLabel();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvFiles)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            this.statusStrip1.SuspendLayout();
-            this.SuspendLayout();
+            dgvFiles = new System.Windows.Forms.DataGridView();
+            Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colType = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_PhysicalName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_FileSizeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_FileUsedMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_FileFreeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_FilePctFree = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_Growth = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_GrowthPct = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileLevel_MaxSizeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileGroup = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            SizeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupUsedMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupFreeMB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupPctFree = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupMaxSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupPctMaxSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupUsedPctMaxSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            NumberOfFiles = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FilegroupAutogrow = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ExcludedReason = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            MaxSizeExcludedReason = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ReadOnly = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            DBReadOnly = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Standby = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            State = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ConfiguredLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            FileSnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            History = new System.Windows.Forms.DataGridViewLinkColumn();
+            Configure = new System.Windows.Forms.DataGridViewLinkColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            statusFilterToolStrip1 = new StatusFilterToolStrip();
+            tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
+            configureDatabaseThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsLevel = new System.Windows.Forms.ToolStripDropDownButton();
+            tsFilegroup = new System.Windows.Forms.ToolStripMenuItem();
+            tsFile = new System.Windows.Forms.ToolStripMenuItem();
+            tsType = new System.Windows.Forms.ToolStripDropDownButton();
+            rOWSToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            lOGToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            fILESTREAMToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            fULLTEXTToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn15 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn16 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn17 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn18 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn19 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn20 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn21 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn22 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn23 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn24 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn25 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn26 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn27 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn28 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn29 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn30 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblInfo = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)dgvFiles).BeginInit();
+            toolStrip1.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // dgvFiles
             // 
-            this.dgvFiles.AllowUserToAddRows = false;
-            this.dgvFiles.AllowUserToDeleteRows = false;
-            this.dgvFiles.BackgroundColor = System.Drawing.Color.White;
-            this.dgvFiles.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
+            dgvFiles.AllowUserToAddRows = false;
+            dgvFiles.AllowUserToDeleteRows = false;
+            dgvFiles.BackgroundColor = System.Drawing.Color.White;
+            dgvFiles.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvFiles.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.dgvFiles.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvFiles.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Instance,
-            this.Database,
-            this.FileLevel_FileName,
-            this.colType,
-            this.FileLevel_PhysicalName,
-            this.FileLevel_FileSizeMB,
-            this.FileLevel_FileUsedMB,
-            this.FileLevel_FileFreeMB,
-            this.FileLevel_FilePctFree,
-            this.FileLevel_Growth,
-            this.FileLevel_GrowthPct,
-            this.FileLevel_MaxSizeMB,
-            this.FileGroup,
-            this.SizeMB,
-            this.FilegroupUsedMB,
-            this.FilegroupFreeMB,
-            this.FilegroupPctFree,
-            this.FilegroupMaxSize,
-            this.FilegroupPctMaxSize,
-            this.FilegroupUsedPctMaxSize,
-            this.NumberOfFiles,
-            this.FilegroupAutogrow,
-            this.ExcludedReason,
-            this.MaxSizeExcludedReason,
-            this.ReadOnly,
-            this.DBReadOnly,
-            this.Standby,
-            this.State,
-            this.ConfiguredLevel,
-            this.FileSnapshotAge,
-            this.History,
-            this.Configure});
+            dgvFiles.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dgvFiles.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvFiles.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { Instance, Database, FileLevel_FileName, colType, FileLevel_PhysicalName, FileLevel_FileSizeMB, FileLevel_FileUsedMB, FileLevel_FileFreeMB, FileLevel_FilePctFree, FileLevel_Growth, FileLevel_GrowthPct, FileLevel_MaxSizeMB, FileGroup, SizeMB, FilegroupUsedMB, FilegroupFreeMB, FilegroupPctFree, FilegroupMaxSize, FilegroupPctMaxSize, FilegroupUsedPctMaxSize, NumberOfFiles, FilegroupAutogrow, ExcludedReason, MaxSizeExcludedReason, ReadOnly, DBReadOnly, Standby, State, ConfiguredLevel, FileSnapshotAge, History, Configure });
             dataGridViewCellStyle15.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle15.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle15.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle15.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle15.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle15.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle15.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle15.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvFiles.DefaultCellStyle = dataGridViewCellStyle15;
-            this.dgvFiles.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvFiles.Location = new System.Drawing.Point(0, 27);
-            this.dgvFiles.Name = "dgvFiles";
-            this.dgvFiles.ReadOnly = true;
+            dgvFiles.DefaultCellStyle = dataGridViewCellStyle15;
+            dgvFiles.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvFiles.Location = new System.Drawing.Point(0, 27);
+            dgvFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvFiles.Name = "dgvFiles";
+            dgvFiles.ReadOnly = true;
             dataGridViewCellStyle16.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle16.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle16.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle16.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle16.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle16.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle16.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle16.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvFiles.RowHeadersDefaultCellStyle = dataGridViewCellStyle16;
-            this.dgvFiles.RowHeadersVisible = false;
-            this.dgvFiles.RowHeadersWidth = 51;
-            this.dgvFiles.RowTemplate.Height = 24;
-            this.dgvFiles.Size = new System.Drawing.Size(1414, 219);
-            this.dgvFiles.TabIndex = 0;
-            this.dgvFiles.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvFiles_CellContentClick);
-            this.dgvFiles.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvFiles_RowsAdded);
+            dgvFiles.RowHeadersDefaultCellStyle = dataGridViewCellStyle16;
+            dgvFiles.RowHeadersVisible = false;
+            dgvFiles.RowHeadersWidth = 51;
+            dgvFiles.RowTemplate.Height = 24;
+            dgvFiles.Size = new System.Drawing.Size(1616, 308);
+            dgvFiles.TabIndex = 0;
+            dgvFiles.CellContentClick += DgvFiles_CellContentClick;
+            dgvFiles.RowsAdded += DgvFiles_RowsAdded;
             // 
             // Instance
             // 
-            this.Instance.DataPropertyName = "InstanceDisplayName";
-            this.Instance.HeaderText = "Instance";
-            this.Instance.MinimumWidth = 6;
-            this.Instance.Name = "Instance";
-            this.Instance.ReadOnly = true;
-            this.Instance.Width = 90;
+            Instance.DataPropertyName = "InstanceDisplayName";
+            Instance.HeaderText = "Instance";
+            Instance.MinimumWidth = 6;
+            Instance.Name = "Instance";
+            Instance.ReadOnly = true;
+            Instance.Width = 90;
             // 
             // Database
             // 
-            this.Database.DataPropertyName = "name";
-            this.Database.HeaderText = "Database";
-            this.Database.MinimumWidth = 6;
-            this.Database.Name = "Database";
-            this.Database.ReadOnly = true;
-            this.Database.Width = 98;
+            Database.DataPropertyName = "name";
+            Database.HeaderText = "Database";
+            Database.MinimumWidth = 6;
+            Database.Name = "Database";
+            Database.ReadOnly = true;
+            Database.Width = 98;
             // 
             // FileLevel_FileName
             // 
-            this.FileLevel_FileName.DataPropertyName = "file_name";
-            this.FileLevel_FileName.HeaderText = "File Name";
-            this.FileLevel_FileName.MinimumWidth = 6;
-            this.FileLevel_FileName.Name = "FileLevel_FileName";
-            this.FileLevel_FileName.ReadOnly = true;
-            this.FileLevel_FileName.Visible = false;
-            this.FileLevel_FileName.Width = 125;
+            FileLevel_FileName.DataPropertyName = "file_name";
+            FileLevel_FileName.HeaderText = "File Name";
+            FileLevel_FileName.MinimumWidth = 6;
+            FileLevel_FileName.Name = "FileLevel_FileName";
+            FileLevel_FileName.ReadOnly = true;
+            FileLevel_FileName.Visible = false;
+            FileLevel_FileName.Width = 125;
             // 
             // colType
             // 
-            this.colType.DataPropertyName = "type_desc";
-            this.colType.HeaderText = "Type";
-            this.colType.MinimumWidth = 6;
-            this.colType.Name = "colType";
-            this.colType.ReadOnly = true;
-            this.colType.Width = 69;
+            colType.DataPropertyName = "type_desc";
+            colType.HeaderText = "Type";
+            colType.MinimumWidth = 6;
+            colType.Name = "colType";
+            colType.ReadOnly = true;
+            colType.Width = 69;
             // 
             // FileLevel_PhysicalName
             // 
-            this.FileLevel_PhysicalName.DataPropertyName = "physical_name";
-            this.FileLevel_PhysicalName.HeaderText = "Physical Name";
-            this.FileLevel_PhysicalName.MinimumWidth = 6;
-            this.FileLevel_PhysicalName.Name = "FileLevel_PhysicalName";
-            this.FileLevel_PhysicalName.ReadOnly = true;
-            this.FileLevel_PhysicalName.Visible = false;
-            this.FileLevel_PhysicalName.Width = 130;
+            FileLevel_PhysicalName.DataPropertyName = "physical_name";
+            FileLevel_PhysicalName.HeaderText = "Physical Name";
+            FileLevel_PhysicalName.MinimumWidth = 6;
+            FileLevel_PhysicalName.Name = "FileLevel_PhysicalName";
+            FileLevel_PhysicalName.ReadOnly = true;
+            FileLevel_PhysicalName.Visible = false;
+            FileLevel_PhysicalName.Width = 130;
             // 
             // FileLevel_FileSizeMB
             // 
-            this.FileLevel_FileSizeMB.DataPropertyName = "FileSizeMB";
+            FileLevel_FileSizeMB.DataPropertyName = "FileSizeMB";
             dataGridViewCellStyle2.Format = "N1";
-            this.FileLevel_FileSizeMB.DefaultCellStyle = dataGridViewCellStyle2;
-            this.FileLevel_FileSizeMB.HeaderText = "File Size (MB)";
-            this.FileLevel_FileSizeMB.MinimumWidth = 6;
-            this.FileLevel_FileSizeMB.Name = "FileLevel_FileSizeMB";
-            this.FileLevel_FileSizeMB.ReadOnly = true;
-            this.FileLevel_FileSizeMB.Visible = false;
-            this.FileLevel_FileSizeMB.Width = 124;
+            FileLevel_FileSizeMB.DefaultCellStyle = dataGridViewCellStyle2;
+            FileLevel_FileSizeMB.HeaderText = "File Size (MB)";
+            FileLevel_FileSizeMB.MinimumWidth = 6;
+            FileLevel_FileSizeMB.Name = "FileLevel_FileSizeMB";
+            FileLevel_FileSizeMB.ReadOnly = true;
+            FileLevel_FileSizeMB.Visible = false;
+            FileLevel_FileSizeMB.Width = 124;
             // 
             // FileLevel_FileUsedMB
             // 
-            this.FileLevel_FileUsedMB.DataPropertyName = "FileUsedMB";
+            FileLevel_FileUsedMB.DataPropertyName = "FileUsedMB";
             dataGridViewCellStyle3.Format = "N1";
-            this.FileLevel_FileUsedMB.DefaultCellStyle = dataGridViewCellStyle3;
-            this.FileLevel_FileUsedMB.HeaderText = "File Used (MB)";
-            this.FileLevel_FileUsedMB.MinimumWidth = 6;
-            this.FileLevel_FileUsedMB.Name = "FileLevel_FileUsedMB";
-            this.FileLevel_FileUsedMB.ReadOnly = true;
-            this.FileLevel_FileUsedMB.Visible = false;
-            this.FileLevel_FileUsedMB.Width = 130;
+            FileLevel_FileUsedMB.DefaultCellStyle = dataGridViewCellStyle3;
+            FileLevel_FileUsedMB.HeaderText = "File Used (MB)";
+            FileLevel_FileUsedMB.MinimumWidth = 6;
+            FileLevel_FileUsedMB.Name = "FileLevel_FileUsedMB";
+            FileLevel_FileUsedMB.ReadOnly = true;
+            FileLevel_FileUsedMB.Visible = false;
+            FileLevel_FileUsedMB.Width = 130;
             // 
             // FileLevel_FileFreeMB
             // 
-            this.FileLevel_FileFreeMB.DataPropertyName = "FileFreeMB";
+            FileLevel_FileFreeMB.DataPropertyName = "FileFreeMB";
             dataGridViewCellStyle4.Format = "N1";
-            this.FileLevel_FileFreeMB.DefaultCellStyle = dataGridViewCellStyle4;
-            this.FileLevel_FileFreeMB.HeaderText = "File Free (MB)";
-            this.FileLevel_FileFreeMB.MinimumWidth = 6;
-            this.FileLevel_FileFreeMB.Name = "FileLevel_FileFreeMB";
-            this.FileLevel_FileFreeMB.ReadOnly = true;
-            this.FileLevel_FileFreeMB.Visible = false;
-            this.FileLevel_FileFreeMB.Width = 126;
+            FileLevel_FileFreeMB.DefaultCellStyle = dataGridViewCellStyle4;
+            FileLevel_FileFreeMB.HeaderText = "File Free (MB)";
+            FileLevel_FileFreeMB.MinimumWidth = 6;
+            FileLevel_FileFreeMB.Name = "FileLevel_FileFreeMB";
+            FileLevel_FileFreeMB.ReadOnly = true;
+            FileLevel_FileFreeMB.Visible = false;
+            FileLevel_FileFreeMB.Width = 126;
             // 
             // FileLevel_FilePctFree
             // 
-            this.FileLevel_FilePctFree.DataPropertyName = "FilePctFree";
+            FileLevel_FilePctFree.DataPropertyName = "FilePctFree";
             dataGridViewCellStyle5.Format = "P1";
-            this.FileLevel_FilePctFree.DefaultCellStyle = dataGridViewCellStyle5;
-            this.FileLevel_FilePctFree.HeaderText = "File Free %";
-            this.FileLevel_FilePctFree.MinimumWidth = 6;
-            this.FileLevel_FilePctFree.Name = "FileLevel_FilePctFree";
-            this.FileLevel_FilePctFree.ReadOnly = true;
-            this.FileLevel_FilePctFree.Visible = false;
-            this.FileLevel_FilePctFree.Width = 108;
+            FileLevel_FilePctFree.DefaultCellStyle = dataGridViewCellStyle5;
+            FileLevel_FilePctFree.HeaderText = "File Free %";
+            FileLevel_FilePctFree.MinimumWidth = 6;
+            FileLevel_FilePctFree.Name = "FileLevel_FilePctFree";
+            FileLevel_FilePctFree.ReadOnly = true;
+            FileLevel_FilePctFree.Visible = false;
+            FileLevel_FilePctFree.Width = 108;
             // 
             // FileLevel_Growth
             // 
-            this.FileLevel_Growth.DataPropertyName = "GrowthMB";
+            FileLevel_Growth.DataPropertyName = "GrowthMB";
             dataGridViewCellStyle6.Format = "#,##0.#";
-            this.FileLevel_Growth.DefaultCellStyle = dataGridViewCellStyle6;
-            this.FileLevel_Growth.HeaderText = "Growth (MB)";
-            this.FileLevel_Growth.MinimumWidth = 6;
-            this.FileLevel_Growth.Name = "FileLevel_Growth";
-            this.FileLevel_Growth.ReadOnly = true;
-            this.FileLevel_Growth.Visible = false;
-            this.FileLevel_Growth.Width = 116;
+            FileLevel_Growth.DefaultCellStyle = dataGridViewCellStyle6;
+            FileLevel_Growth.HeaderText = "Growth (MB)";
+            FileLevel_Growth.MinimumWidth = 6;
+            FileLevel_Growth.Name = "FileLevel_Growth";
+            FileLevel_Growth.ReadOnly = true;
+            FileLevel_Growth.Visible = false;
+            FileLevel_Growth.Width = 116;
             // 
             // FileLevel_GrowthPct
             // 
-            this.FileLevel_GrowthPct.DataPropertyName = "GrowthPct";
-            this.FileLevel_GrowthPct.HeaderText = "Growth %";
-            this.FileLevel_GrowthPct.MinimumWidth = 6;
-            this.FileLevel_GrowthPct.Name = "FileLevel_GrowthPct";
-            this.FileLevel_GrowthPct.ReadOnly = true;
-            this.FileLevel_GrowthPct.Visible = false;
-            this.FileLevel_GrowthPct.Width = 98;
+            FileLevel_GrowthPct.DataPropertyName = "GrowthPct";
+            FileLevel_GrowthPct.HeaderText = "Growth %";
+            FileLevel_GrowthPct.MinimumWidth = 6;
+            FileLevel_GrowthPct.Name = "FileLevel_GrowthPct";
+            FileLevel_GrowthPct.ReadOnly = true;
+            FileLevel_GrowthPct.Visible = false;
+            FileLevel_GrowthPct.Width = 98;
             // 
             // FileLevel_MaxSizeMB
             // 
-            this.FileLevel_MaxSizeMB.DataPropertyName = "MaxSizeMB";
+            FileLevel_MaxSizeMB.DataPropertyName = "MaxSizeMB";
             dataGridViewCellStyle7.Format = "#,##0.#";
-            this.FileLevel_MaxSizeMB.DefaultCellStyle = dataGridViewCellStyle7;
-            this.FileLevel_MaxSizeMB.HeaderText = "Max Size (MB)";
-            this.FileLevel_MaxSizeMB.MinimumWidth = 6;
-            this.FileLevel_MaxSizeMB.Name = "FileLevel_MaxSizeMB";
-            this.FileLevel_MaxSizeMB.ReadOnly = true;
-            this.FileLevel_MaxSizeMB.Visible = false;
-            this.FileLevel_MaxSizeMB.Width = 127;
+            FileLevel_MaxSizeMB.DefaultCellStyle = dataGridViewCellStyle7;
+            FileLevel_MaxSizeMB.HeaderText = "Max Size (MB)";
+            FileLevel_MaxSizeMB.MinimumWidth = 6;
+            FileLevel_MaxSizeMB.Name = "FileLevel_MaxSizeMB";
+            FileLevel_MaxSizeMB.ReadOnly = true;
+            FileLevel_MaxSizeMB.Visible = false;
+            FileLevel_MaxSizeMB.Width = 127;
             // 
             // FileGroup
             // 
-            this.FileGroup.DataPropertyName = "filegroup_name";
-            this.FileGroup.HeaderText = "Filegroup";
-            this.FileGroup.MinimumWidth = 6;
-            this.FileGroup.Name = "FileGroup";
-            this.FileGroup.ReadOnly = true;
-            this.FileGroup.Width = 96;
+            FileGroup.DataPropertyName = "filegroup_name";
+            FileGroup.HeaderText = "Filegroup";
+            FileGroup.MinimumWidth = 6;
+            FileGroup.Name = "FileGroup";
+            FileGroup.ReadOnly = true;
+            FileGroup.Width = 96;
             // 
             // SizeMB
             // 
-            this.SizeMB.DataPropertyName = "FilegroupSizeMB";
+            SizeMB.DataPropertyName = "FilegroupSizeMB";
             dataGridViewCellStyle8.Format = "N1";
-            this.SizeMB.DefaultCellStyle = dataGridViewCellStyle8;
-            this.SizeMB.HeaderText = "Filegroup Size (MB)";
-            this.SizeMB.MinimumWidth = 6;
-            this.SizeMB.Name = "SizeMB";
-            this.SizeMB.ReadOnly = true;
-            this.SizeMB.Width = 120;
+            SizeMB.DefaultCellStyle = dataGridViewCellStyle8;
+            SizeMB.HeaderText = "Filegroup Size (MB)";
+            SizeMB.MinimumWidth = 6;
+            SizeMB.Name = "SizeMB";
+            SizeMB.ReadOnly = true;
+            SizeMB.Width = 120;
             // 
             // FilegroupUsedMB
             // 
-            this.FilegroupUsedMB.DataPropertyName = "FilegroupUsedMB";
+            FilegroupUsedMB.DataPropertyName = "FilegroupUsedMB";
             dataGridViewCellStyle9.Format = "N1";
             dataGridViewCellStyle9.NullValue = null;
-            this.FilegroupUsedMB.DefaultCellStyle = dataGridViewCellStyle9;
-            this.FilegroupUsedMB.HeaderText = "Filegroup Used (MB)";
-            this.FilegroupUsedMB.MinimumWidth = 6;
-            this.FilegroupUsedMB.Name = "FilegroupUsedMB";
-            this.FilegroupUsedMB.ReadOnly = true;
-            this.FilegroupUsedMB.Width = 126;
+            FilegroupUsedMB.DefaultCellStyle = dataGridViewCellStyle9;
+            FilegroupUsedMB.HeaderText = "Filegroup Used (MB)";
+            FilegroupUsedMB.MinimumWidth = 6;
+            FilegroupUsedMB.Name = "FilegroupUsedMB";
+            FilegroupUsedMB.ReadOnly = true;
+            FilegroupUsedMB.Width = 126;
             // 
             // FilegroupFreeMB
             // 
-            this.FilegroupFreeMB.DataPropertyName = "FilegroupFreeMB";
+            FilegroupFreeMB.DataPropertyName = "FilegroupFreeMB";
             dataGridViewCellStyle10.Format = "N1";
-            this.FilegroupFreeMB.DefaultCellStyle = dataGridViewCellStyle10;
-            this.FilegroupFreeMB.HeaderText = "Filegroup Free (MB)";
-            this.FilegroupFreeMB.MinimumWidth = 6;
-            this.FilegroupFreeMB.Name = "FilegroupFreeMB";
-            this.FilegroupFreeMB.ReadOnly = true;
-            this.FilegroupFreeMB.Width = 122;
+            FilegroupFreeMB.DefaultCellStyle = dataGridViewCellStyle10;
+            FilegroupFreeMB.HeaderText = "Filegroup Free (MB)";
+            FilegroupFreeMB.MinimumWidth = 6;
+            FilegroupFreeMB.Name = "FilegroupFreeMB";
+            FilegroupFreeMB.ReadOnly = true;
+            FilegroupFreeMB.Width = 122;
             // 
             // FilegroupPctFree
             // 
-            this.FilegroupPctFree.DataPropertyName = "FilegroupPctFree";
+            FilegroupPctFree.DataPropertyName = "FilegroupPctFree";
             dataGridViewCellStyle11.Format = "P1";
             dataGridViewCellStyle11.NullValue = null;
-            this.FilegroupPctFree.DefaultCellStyle = dataGridViewCellStyle11;
-            this.FilegroupPctFree.HeaderText = "Filegroup Free %";
-            this.FilegroupPctFree.MinimumWidth = 6;
-            this.FilegroupPctFree.Name = "FilegroupPctFree";
-            this.FilegroupPctFree.ReadOnly = true;
-            this.FilegroupPctFree.Width = 122;
+            FilegroupPctFree.DefaultCellStyle = dataGridViewCellStyle11;
+            FilegroupPctFree.HeaderText = "Filegroup Free %";
+            FilegroupPctFree.MinimumWidth = 6;
+            FilegroupPctFree.Name = "FilegroupPctFree";
+            FilegroupPctFree.ReadOnly = true;
+            FilegroupPctFree.Width = 122;
             // 
             // FilegroupMaxSize
             // 
-            this.FilegroupMaxSize.DataPropertyName = "FilegroupMaxSizeMB";
+            FilegroupMaxSize.DataPropertyName = "FilegroupMaxSizeMB";
             dataGridViewCellStyle12.Format = "N0";
-            this.FilegroupMaxSize.DefaultCellStyle = dataGridViewCellStyle12;
-            this.FilegroupMaxSize.HeaderText = "Filegroup Max Size (MB)";
-            this.FilegroupMaxSize.MinimumWidth = 6;
-            this.FilegroupMaxSize.Name = "FilegroupMaxSize";
-            this.FilegroupMaxSize.ReadOnly = true;
-            this.FilegroupMaxSize.Width = 146;
+            FilegroupMaxSize.DefaultCellStyle = dataGridViewCellStyle12;
+            FilegroupMaxSize.HeaderText = "Filegroup Max Size (MB)";
+            FilegroupMaxSize.MinimumWidth = 6;
+            FilegroupMaxSize.Name = "FilegroupMaxSize";
+            FilegroupMaxSize.ReadOnly = true;
+            FilegroupMaxSize.Width = 146;
             // 
             // FilegroupPctMaxSize
             // 
-            this.FilegroupPctMaxSize.DataPropertyName = "FilegroupPctOfMaxSize";
+            FilegroupPctMaxSize.DataPropertyName = "FilegroupPctOfMaxSize";
             dataGridViewCellStyle13.Format = "P1";
-            this.FilegroupPctMaxSize.DefaultCellStyle = dataGridViewCellStyle13;
-            this.FilegroupPctMaxSize.HeaderText = "Filegroup % Of Max Size";
-            this.FilegroupPctMaxSize.MinimumWidth = 6;
-            this.FilegroupPctMaxSize.Name = "FilegroupPctMaxSize";
-            this.FilegroupPctMaxSize.ReadOnly = true;
-            this.FilegroupPctMaxSize.Width = 124;
+            FilegroupPctMaxSize.DefaultCellStyle = dataGridViewCellStyle13;
+            FilegroupPctMaxSize.HeaderText = "Filegroup % Of Max Size";
+            FilegroupPctMaxSize.MinimumWidth = 6;
+            FilegroupPctMaxSize.Name = "FilegroupPctMaxSize";
+            FilegroupPctMaxSize.ReadOnly = true;
+            FilegroupPctMaxSize.Width = 124;
             // 
             // FilegroupUsedPctMaxSize
             // 
-            this.FilegroupUsedPctMaxSize.DataPropertyName = "FilegroupUsedPctOfMaxSize";
+            FilegroupUsedPctMaxSize.DataPropertyName = "FilegroupUsedPctOfMaxSize";
             dataGridViewCellStyle14.Format = "P1";
-            this.FilegroupUsedPctMaxSize.DefaultCellStyle = dataGridViewCellStyle14;
-            this.FilegroupUsedPctMaxSize.HeaderText = "Filegroup Used % Max Size";
-            this.FilegroupUsedPctMaxSize.MinimumWidth = 6;
-            this.FilegroupUsedPctMaxSize.Name = "FilegroupUsedPctMaxSize";
-            this.FilegroupUsedPctMaxSize.ReadOnly = true;
-            this.FilegroupUsedPctMaxSize.Width = 140;
+            FilegroupUsedPctMaxSize.DefaultCellStyle = dataGridViewCellStyle14;
+            FilegroupUsedPctMaxSize.HeaderText = "Filegroup Used % Max Size";
+            FilegroupUsedPctMaxSize.MinimumWidth = 6;
+            FilegroupUsedPctMaxSize.Name = "FilegroupUsedPctMaxSize";
+            FilegroupUsedPctMaxSize.ReadOnly = true;
+            FilegroupUsedPctMaxSize.Width = 140;
             // 
             // NumberOfFiles
             // 
-            this.NumberOfFiles.DataPropertyName = "FilegroupNumberOfFiles";
-            this.NumberOfFiles.HeaderText = "Filegroup Number of Files";
-            this.NumberOfFiles.MinimumWidth = 6;
-            this.NumberOfFiles.Name = "NumberOfFiles";
-            this.NumberOfFiles.ReadOnly = true;
-            this.NumberOfFiles.Width = 141;
+            NumberOfFiles.DataPropertyName = "FilegroupNumberOfFiles";
+            NumberOfFiles.HeaderText = "Filegroup Number of Files";
+            NumberOfFiles.MinimumWidth = 6;
+            NumberOfFiles.Name = "NumberOfFiles";
+            NumberOfFiles.ReadOnly = true;
+            NumberOfFiles.Width = 141;
             // 
             // FilegroupAutogrow
             // 
-            this.FilegroupAutogrow.DataPropertyName = "FilegroupAutogrowFileCount";
-            this.FilegroupAutogrow.HeaderText = "Filegroup Autogrow File Count";
-            this.FilegroupAutogrow.MinimumWidth = 6;
-            this.FilegroupAutogrow.Name = "FilegroupAutogrow";
-            this.FilegroupAutogrow.ReadOnly = true;
-            this.FilegroupAutogrow.Width = 172;
+            FilegroupAutogrow.DataPropertyName = "FilegroupAutogrowFileCount";
+            FilegroupAutogrow.HeaderText = "Filegroup Autogrow File Count";
+            FilegroupAutogrow.MinimumWidth = 6;
+            FilegroupAutogrow.Name = "FilegroupAutogrow";
+            FilegroupAutogrow.ReadOnly = true;
+            FilegroupAutogrow.Width = 172;
             // 
             // ExcludedReason
             // 
-            this.ExcludedReason.DataPropertyName = "ExcludedReason";
-            this.ExcludedReason.HeaderText = "Excluded Reason";
-            this.ExcludedReason.MinimumWidth = 6;
-            this.ExcludedReason.Name = "ExcludedReason";
-            this.ExcludedReason.ReadOnly = true;
-            this.ExcludedReason.Width = 135;
+            ExcludedReason.DataPropertyName = "ExcludedReason";
+            ExcludedReason.HeaderText = "Excluded Reason";
+            ExcludedReason.MinimumWidth = 6;
+            ExcludedReason.Name = "ExcludedReason";
+            ExcludedReason.ReadOnly = true;
+            ExcludedReason.Width = 135;
             // 
             // MaxSizeExcludedReason
             // 
-            this.MaxSizeExcludedReason.DataPropertyName = "MaxSizeExcludedReason";
-            this.MaxSizeExcludedReason.HeaderText = "Max Size Excluded Reason";
-            this.MaxSizeExcludedReason.MinimumWidth = 6;
-            this.MaxSizeExcludedReason.Name = "MaxSizeExcludedReason";
-            this.MaxSizeExcludedReason.ReadOnly = true;
-            this.MaxSizeExcludedReason.Width = 189;
+            MaxSizeExcludedReason.DataPropertyName = "MaxSizeExcludedReason";
+            MaxSizeExcludedReason.HeaderText = "Max Size Excluded Reason";
+            MaxSizeExcludedReason.MinimumWidth = 6;
+            MaxSizeExcludedReason.Name = "MaxSizeExcludedReason";
+            MaxSizeExcludedReason.ReadOnly = true;
+            MaxSizeExcludedReason.Width = 189;
             // 
             // ReadOnly
             // 
-            this.ReadOnly.DataPropertyName = "is_read_only";
-            this.ReadOnly.HeaderText = "Read Only";
-            this.ReadOnly.MinimumWidth = 6;
-            this.ReadOnly.Name = "ReadOnly";
-            this.ReadOnly.ReadOnly = true;
-            this.ReadOnly.Width = 96;
+            ReadOnly.DataPropertyName = "is_read_only";
+            ReadOnly.HeaderText = "Read Only";
+            ReadOnly.MinimumWidth = 6;
+            ReadOnly.Name = "ReadOnly";
+            ReadOnly.ReadOnly = true;
+            ReadOnly.Width = 96;
             // 
             // DBReadOnly
             // 
-            this.DBReadOnly.DataPropertyName = "is_db_read_only";
-            this.DBReadOnly.HeaderText = "DB ReadOnly";
-            this.DBReadOnly.MinimumWidth = 6;
-            this.DBReadOnly.Name = "DBReadOnly";
-            this.DBReadOnly.ReadOnly = true;
-            this.DBReadOnly.Width = 113;
+            DBReadOnly.DataPropertyName = "is_db_read_only";
+            DBReadOnly.HeaderText = "DB ReadOnly";
+            DBReadOnly.MinimumWidth = 6;
+            DBReadOnly.Name = "DBReadOnly";
+            DBReadOnly.ReadOnly = true;
+            DBReadOnly.Width = 113;
             // 
             // Standby
             // 
-            this.Standby.DataPropertyName = "is_in_standby";
-            this.Standby.HeaderText = "Standby";
-            this.Standby.MinimumWidth = 6;
-            this.Standby.Name = "Standby";
-            this.Standby.ReadOnly = true;
-            this.Standby.Width = 89;
+            Standby.DataPropertyName = "is_in_standby";
+            Standby.HeaderText = "Standby";
+            Standby.MinimumWidth = 6;
+            Standby.Name = "Standby";
+            Standby.ReadOnly = true;
+            Standby.Width = 89;
             // 
             // State
             // 
-            this.State.DataPropertyName = "state_desc";
-            this.State.HeaderText = "State";
-            this.State.MinimumWidth = 6;
-            this.State.Name = "State";
-            this.State.ReadOnly = true;
-            this.State.Width = 70;
+            State.DataPropertyName = "state_desc";
+            State.HeaderText = "State";
+            State.MinimumWidth = 6;
+            State.Name = "State";
+            State.ReadOnly = true;
+            State.Width = 70;
             // 
             // ConfiguredLevel
             // 
-            this.ConfiguredLevel.DataPropertyName = "ConfiguredLevel";
-            this.ConfiguredLevel.HeaderText = "Configured Level";
-            this.ConfiguredLevel.MinimumWidth = 6;
-            this.ConfiguredLevel.Name = "ConfiguredLevel";
-            this.ConfiguredLevel.ReadOnly = true;
-            this.ConfiguredLevel.Width = 132;
+            ConfiguredLevel.DataPropertyName = "ConfiguredLevel";
+            ConfiguredLevel.HeaderText = "Configured Level";
+            ConfiguredLevel.MinimumWidth = 6;
+            ConfiguredLevel.Name = "ConfiguredLevel";
+            ConfiguredLevel.ReadOnly = true;
+            ConfiguredLevel.Width = 132;
             // 
             // FileSnapshotAge
             // 
-            this.FileSnapshotAge.DataPropertyName = "FileSnapshotAge";
-            this.FileSnapshotAge.HeaderText = "File Snapshot Age";
-            this.FileSnapshotAge.MinimumWidth = 6;
-            this.FileSnapshotAge.Name = "FileSnapshotAge";
-            this.FileSnapshotAge.ReadOnly = true;
-            this.FileSnapshotAge.Width = 139;
+            FileSnapshotAge.DataPropertyName = "FileSnapshotAge";
+            FileSnapshotAge.HeaderText = "File Snapshot Age";
+            FileSnapshotAge.MinimumWidth = 6;
+            FileSnapshotAge.Name = "FileSnapshotAge";
+            FileSnapshotAge.ReadOnly = true;
+            FileSnapshotAge.Width = 139;
             // 
             // History
             // 
-            this.History.HeaderText = "History";
-            this.History.MinimumWidth = 6;
-            this.History.Name = "History";
-            this.History.ReadOnly = true;
-            this.History.Text = "History";
-            this.History.UseColumnTextForLinkValue = true;
-            this.History.Width = 58;
+            History.HeaderText = "History";
+            History.MinimumWidth = 6;
+            History.Name = "History";
+            History.ReadOnly = true;
+            History.Text = "History";
+            History.UseColumnTextForLinkValue = true;
+            History.Width = 58;
             // 
             // Configure
             // 
-            this.Configure.HeaderText = "Configure";
-            this.Configure.MinimumWidth = 6;
-            this.Configure.Name = "Configure";
-            this.Configure.ReadOnly = true;
-            this.Configure.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.Configure.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Configure.Text = "Configure";
-            this.Configure.UseColumnTextForLinkValue = true;
-            this.Configure.Width = 98;
+            Configure.HeaderText = "Configure";
+            Configure.MinimumWidth = 6;
+            Configure.Name = "Configure";
+            Configure.ReadOnly = true;
+            Configure.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            Configure.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            Configure.Text = "Configure";
+            Configure.UseColumnTextForLinkValue = true;
+            Configure.Width = 98;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.statusFilterToolStrip1,
-            this.tsConfigure,
-            this.tsLevel,
-            this.tsType});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1414, 27);
-            this.toolStrip1.TabIndex = 3;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, statusFilterToolStrip1, tsConfigure, tsLevel, tsType, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(1616, 27);
+            toolStrip1.TabIndex = 3;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(24, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(24, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(24, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // statusFilterToolStrip1
             // 
-            this.statusFilterToolStrip1.Acknowledged = false;
-            this.statusFilterToolStrip1.AcknowledgedVisible = false;
-            this.statusFilterToolStrip1.Critical = true;
-            this.statusFilterToolStrip1.CriticalVisible = true;
-            this.statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.statusFilterToolStrip1.Image = ((System.Drawing.Image)(resources.GetObject("statusFilterToolStrip1.Image")));
-            this.statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.statusFilterToolStrip1.NA = true;
-            this.statusFilterToolStrip1.Name = "statusFilterToolStrip1";
-            this.statusFilterToolStrip1.NAVisible = true;
-            this.statusFilterToolStrip1.OK = true;
-            this.statusFilterToolStrip1.OKVisible = true;
-            this.statusFilterToolStrip1.Size = new System.Drawing.Size(60, 24);
-            this.statusFilterToolStrip1.Text = "ALL";
-            this.statusFilterToolStrip1.Warning = true;
-            this.statusFilterToolStrip1.WarningVisible = true;
-            this.statusFilterToolStrip1.UserChangedStatusFilter += new System.EventHandler(this.Status_Selected);
+            statusFilterToolStrip1.Acknowledged = false;
+            statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.Critical = true;
+            statusFilterToolStrip1.CriticalVisible = true;
+            statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            statusFilterToolStrip1.Image = (System.Drawing.Image)resources.GetObject("statusFilterToolStrip1.Image");
+            statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            statusFilterToolStrip1.NA = true;
+            statusFilterToolStrip1.Name = "statusFilterToolStrip1";
+            statusFilterToolStrip1.NAVisible = true;
+            statusFilterToolStrip1.OK = true;
+            statusFilterToolStrip1.OKVisible = true;
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
+            statusFilterToolStrip1.Text = "ALL";
+            statusFilterToolStrip1.Warning = true;
+            statusFilterToolStrip1.WarningVisible = true;
+            statusFilterToolStrip1.UserChangedStatusFilter += Status_Selected;
             // 
             // tsConfigure
             // 
-            this.tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.configureDatabaseThresholdsToolStripMenuItem,
-            this.configureInstanceThresholdsToolStripMenuItem,
-            this.configureRootThresholdsToolStripMenuItem});
-            this.tsConfigure.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
-            this.tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsConfigure.Name = "tsConfigure";
-            this.tsConfigure.Size = new System.Drawing.Size(33, 24);
-            this.tsConfigure.Text = "Configure";
+            tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { configureDatabaseThresholdsToolStripMenuItem, configureInstanceThresholdsToolStripMenuItem, configureRootThresholdsToolStripMenuItem });
+            tsConfigure.Image = Properties.Resources.SettingsOutline_16x;
+            tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsConfigure.Name = "tsConfigure";
+            tsConfigure.Size = new System.Drawing.Size(34, 24);
+            tsConfigure.Text = "Configure";
             // 
             // configureDatabaseThresholdsToolStripMenuItem
             // 
-            this.configureDatabaseThresholdsToolStripMenuItem.Name = "configureDatabaseThresholdsToolStripMenuItem";
-            this.configureDatabaseThresholdsToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
-            this.configureDatabaseThresholdsToolStripMenuItem.Text = "Configure Database Thresholds";
-            this.configureDatabaseThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureDatabaseThresholdsToolStripMenuItem_Click);
+            configureDatabaseThresholdsToolStripMenuItem.Name = "configureDatabaseThresholdsToolStripMenuItem";
+            configureDatabaseThresholdsToolStripMenuItem.Size = new System.Drawing.Size(299, 26);
+            configureDatabaseThresholdsToolStripMenuItem.Text = "Configure Database Thresholds";
+            configureDatabaseThresholdsToolStripMenuItem.Click += ConfigureDatabaseThresholdsToolStripMenuItem_Click;
             // 
             // configureInstanceThresholdsToolStripMenuItem
             // 
-            this.configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
-            this.configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
-            this.configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
-            this.configureInstanceThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureInstanceThresholdsToolStripMenuItem_Click);
+            configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
+            configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(299, 26);
+            configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
+            configureInstanceThresholdsToolStripMenuItem.Click += ConfigureInstanceThresholdsToolStripMenuItem_Click;
             // 
             // configureRootThresholdsToolStripMenuItem
             // 
-            this.configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
-            this.configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(238, 22);
-            this.configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
-            this.configureRootThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureRootThresholdsToolStripMenuItem_Click);
+            configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
+            configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(299, 26);
+            configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
+            configureRootThresholdsToolStripMenuItem.Click += ConfigureRootThresholdsToolStripMenuItem_Click;
             // 
             // tsLevel
             // 
-            this.tsLevel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tsLevel.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsFilegroup,
-            this.tsFile});
-            this.tsLevel.Image = ((System.Drawing.Image)(resources.GetObject("tsLevel.Image")));
-            this.tsLevel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsLevel.Name = "tsLevel";
-            this.tsLevel.Size = new System.Drawing.Size(47, 24);
-            this.tsLevel.Text = "Level";
+            tsLevel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            tsLevel.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { tsFilegroup, tsFile });
+            tsLevel.Image = (System.Drawing.Image)resources.GetObject("tsLevel.Image");
+            tsLevel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsLevel.Name = "tsLevel";
+            tsLevel.Size = new System.Drawing.Size(57, 24);
+            tsLevel.Text = "Level";
             // 
             // tsFilegroup
             // 
-            this.tsFilegroup.Checked = true;
-            this.tsFilegroup.CheckOnClick = true;
-            this.tsFilegroup.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.tsFilegroup.Name = "tsFilegroup";
-            this.tsFilegroup.Size = new System.Drawing.Size(124, 22);
-            this.tsFilegroup.Text = "Filegroup";
-            this.tsFilegroup.Click += new System.EventHandler(this.TsFilegroup_Click);
+            tsFilegroup.Checked = true;
+            tsFilegroup.CheckOnClick = true;
+            tsFilegroup.CheckState = System.Windows.Forms.CheckState.Checked;
+            tsFilegroup.Name = "tsFilegroup";
+            tsFilegroup.Size = new System.Drawing.Size(155, 26);
+            tsFilegroup.Text = "Filegroup";
+            tsFilegroup.Click += TsFilegroup_Click;
             // 
             // tsFile
             // 
-            this.tsFile.Name = "tsFile";
-            this.tsFile.Size = new System.Drawing.Size(124, 22);
-            this.tsFile.Text = "File";
-            this.tsFile.Click += new System.EventHandler(this.TsFile_Click);
+            tsFile.Name = "tsFile";
+            tsFile.Size = new System.Drawing.Size(155, 26);
+            tsFile.Text = "File";
+            tsFile.Click += TsFile_Click;
             // 
             // tsType
             // 
-            this.tsType.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.tsType.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.rOWSToolStripMenuItem,
-            this.lOGToolStripMenuItem,
-            this.fILESTREAMToolStripMenuItem,
-            this.fULLTEXTToolStripMenuItem});
-            this.tsType.Image = ((System.Drawing.Image)(resources.GetObject("tsType.Image")));
-            this.tsType.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsType.Name = "tsType";
-            this.tsType.Size = new System.Drawing.Size(44, 24);
-            this.tsType.Text = "Type";
+            tsType.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            tsType.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { rOWSToolStripMenuItem, lOGToolStripMenuItem, fILESTREAMToolStripMenuItem, fULLTEXTToolStripMenuItem });
+            tsType.Image = (System.Drawing.Image)resources.GetObject("tsType.Image");
+            tsType.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsType.Name = "tsType";
+            tsType.Size = new System.Drawing.Size(54, 24);
+            tsType.Text = "Type";
             // 
             // rOWSToolStripMenuItem
             // 
-            this.rOWSToolStripMenuItem.Checked = true;
-            this.rOWSToolStripMenuItem.CheckOnClick = true;
-            this.rOWSToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.rOWSToolStripMenuItem.Name = "rOWSToolStripMenuItem";
-            this.rOWSToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.rOWSToolStripMenuItem.Tag = "0";
-            this.rOWSToolStripMenuItem.Text = "ROWS";
-            this.rOWSToolStripMenuItem.CheckedChanged += new System.EventHandler(this.TsTypes_Click);
+            rOWSToolStripMenuItem.Checked = true;
+            rOWSToolStripMenuItem.CheckOnClick = true;
+            rOWSToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            rOWSToolStripMenuItem.Name = "rOWSToolStripMenuItem";
+            rOWSToolStripMenuItem.Size = new System.Drawing.Size(174, 26);
+            rOWSToolStripMenuItem.Tag = "0";
+            rOWSToolStripMenuItem.Text = "ROWS";
+            rOWSToolStripMenuItem.CheckedChanged += TsTypes_Click;
             // 
             // lOGToolStripMenuItem
             // 
-            this.lOGToolStripMenuItem.Checked = true;
-            this.lOGToolStripMenuItem.CheckOnClick = true;
-            this.lOGToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.lOGToolStripMenuItem.Name = "lOGToolStripMenuItem";
-            this.lOGToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.lOGToolStripMenuItem.Tag = "1";
-            this.lOGToolStripMenuItem.Text = "LOG";
-            this.lOGToolStripMenuItem.CheckedChanged += new System.EventHandler(this.TsTypes_Click);
+            lOGToolStripMenuItem.Checked = true;
+            lOGToolStripMenuItem.CheckOnClick = true;
+            lOGToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            lOGToolStripMenuItem.Name = "lOGToolStripMenuItem";
+            lOGToolStripMenuItem.Size = new System.Drawing.Size(174, 26);
+            lOGToolStripMenuItem.Tag = "1";
+            lOGToolStripMenuItem.Text = "LOG";
+            lOGToolStripMenuItem.CheckedChanged += TsTypes_Click;
             // 
             // fILESTREAMToolStripMenuItem
             // 
-            this.fILESTREAMToolStripMenuItem.Checked = true;
-            this.fILESTREAMToolStripMenuItem.CheckOnClick = true;
-            this.fILESTREAMToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.fILESTREAMToolStripMenuItem.Name = "fILESTREAMToolStripMenuItem";
-            this.fILESTREAMToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.fILESTREAMToolStripMenuItem.Tag = "2";
-            this.fILESTREAMToolStripMenuItem.Text = "FILESTREAM";
-            this.fILESTREAMToolStripMenuItem.CheckedChanged += new System.EventHandler(this.TsTypes_Click);
+            fILESTREAMToolStripMenuItem.Checked = true;
+            fILESTREAMToolStripMenuItem.CheckOnClick = true;
+            fILESTREAMToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            fILESTREAMToolStripMenuItem.Name = "fILESTREAMToolStripMenuItem";
+            fILESTREAMToolStripMenuItem.Size = new System.Drawing.Size(174, 26);
+            fILESTREAMToolStripMenuItem.Tag = "2";
+            fILESTREAMToolStripMenuItem.Text = "FILESTREAM";
+            fILESTREAMToolStripMenuItem.CheckedChanged += TsTypes_Click;
             // 
             // fULLTEXTToolStripMenuItem
             // 
-            this.fULLTEXTToolStripMenuItem.Checked = true;
-            this.fULLTEXTToolStripMenuItem.CheckOnClick = true;
-            this.fULLTEXTToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.fULLTEXTToolStripMenuItem.Name = "fULLTEXTToolStripMenuItem";
-            this.fULLTEXTToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.fULLTEXTToolStripMenuItem.Tag = "4";
-            this.fULLTEXTToolStripMenuItem.Text = "FULLTEXT";
-            this.fULLTEXTToolStripMenuItem.CheckedChanged += new System.EventHandler(this.TsTypes_Click);
+            fULLTEXTToolStripMenuItem.Checked = true;
+            fULLTEXTToolStripMenuItem.CheckOnClick = true;
+            fULLTEXTToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            fULLTEXTToolStripMenuItem.Name = "fULLTEXTToolStripMenuItem";
+            fULLTEXTToolStripMenuItem.Size = new System.Drawing.Size(174, 26);
+            fULLTEXTToolStripMenuItem.Tag = "4";
+            fULLTEXTToolStripMenuItem.Text = "FULLTEXT";
+            fULLTEXTToolStripMenuItem.CheckedChanged += TsTypes_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += TsTrigger_Click;
             // 
             // dataGridViewTextBoxColumn1
             // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 90;
+            dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
+            dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.ReadOnly = true;
+            dataGridViewTextBoxColumn1.Width = 90;
             // 
             // dataGridViewTextBoxColumn2
             // 
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "name";
-            this.dataGridViewTextBoxColumn2.HeaderText = "Database";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 98;
+            dataGridViewTextBoxColumn2.DataPropertyName = "name";
+            dataGridViewTextBoxColumn2.HeaderText = "Database";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.ReadOnly = true;
+            dataGridViewTextBoxColumn2.Width = 98;
             // 
             // dataGridViewTextBoxColumn3
             // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "file_name";
-            this.dataGridViewTextBoxColumn3.HeaderText = "File Name";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Visible = false;
-            this.dataGridViewTextBoxColumn3.Width = 125;
+            dataGridViewTextBoxColumn3.DataPropertyName = "file_name";
+            dataGridViewTextBoxColumn3.HeaderText = "File Name";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.ReadOnly = true;
+            dataGridViewTextBoxColumn3.Visible = false;
+            dataGridViewTextBoxColumn3.Width = 125;
             // 
             // dataGridViewTextBoxColumn4
             // 
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "physical_name";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Physical Name";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Visible = false;
-            this.dataGridViewTextBoxColumn4.Width = 130;
+            dataGridViewTextBoxColumn4.DataPropertyName = "physical_name";
+            dataGridViewTextBoxColumn4.HeaderText = "Physical Name";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.ReadOnly = true;
+            dataGridViewTextBoxColumn4.Visible = false;
+            dataGridViewTextBoxColumn4.Width = 130;
             // 
             // dataGridViewTextBoxColumn5
             // 
-            this.dataGridViewTextBoxColumn5.DataPropertyName = "FileSizeMB";
+            dataGridViewTextBoxColumn5.DataPropertyName = "FileSizeMB";
             dataGridViewCellStyle17.Format = "N1";
-            this.dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle17;
-            this.dataGridViewTextBoxColumn5.HeaderText = "File Size (MB)";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.Visible = false;
-            this.dataGridViewTextBoxColumn5.Width = 124;
+            dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle17;
+            dataGridViewTextBoxColumn5.HeaderText = "File Size (MB)";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.ReadOnly = true;
+            dataGridViewTextBoxColumn5.Visible = false;
+            dataGridViewTextBoxColumn5.Width = 124;
             // 
             // dataGridViewTextBoxColumn6
             // 
-            this.dataGridViewTextBoxColumn6.DataPropertyName = "FileUsedMB";
+            dataGridViewTextBoxColumn6.DataPropertyName = "FileUsedMB";
             dataGridViewCellStyle18.Format = "N1";
-            this.dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle18;
-            this.dataGridViewTextBoxColumn6.HeaderText = "File Used (MB)";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.Visible = false;
-            this.dataGridViewTextBoxColumn6.Width = 130;
+            dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle18;
+            dataGridViewTextBoxColumn6.HeaderText = "File Used (MB)";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.ReadOnly = true;
+            dataGridViewTextBoxColumn6.Visible = false;
+            dataGridViewTextBoxColumn6.Width = 130;
             // 
             // dataGridViewTextBoxColumn7
             // 
-            this.dataGridViewTextBoxColumn7.DataPropertyName = "FileFreeMB";
+            dataGridViewTextBoxColumn7.DataPropertyName = "FileFreeMB";
             dataGridViewCellStyle19.Format = "N1";
-            this.dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle19;
-            this.dataGridViewTextBoxColumn7.HeaderText = "File Free (MB)";
-            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            this.dataGridViewTextBoxColumn7.ReadOnly = true;
-            this.dataGridViewTextBoxColumn7.Visible = false;
-            this.dataGridViewTextBoxColumn7.Width = 126;
+            dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle19;
+            dataGridViewTextBoxColumn7.HeaderText = "File Free (MB)";
+            dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            dataGridViewTextBoxColumn7.ReadOnly = true;
+            dataGridViewTextBoxColumn7.Visible = false;
+            dataGridViewTextBoxColumn7.Width = 126;
             // 
             // dataGridViewTextBoxColumn8
             // 
-            this.dataGridViewTextBoxColumn8.DataPropertyName = "FilePctFree";
+            dataGridViewTextBoxColumn8.DataPropertyName = "FilePctFree";
             dataGridViewCellStyle20.Format = "P1";
-            this.dataGridViewTextBoxColumn8.DefaultCellStyle = dataGridViewCellStyle20;
-            this.dataGridViewTextBoxColumn8.HeaderText = "File Free %";
-            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            this.dataGridViewTextBoxColumn8.ReadOnly = true;
-            this.dataGridViewTextBoxColumn8.Visible = false;
-            this.dataGridViewTextBoxColumn8.Width = 108;
+            dataGridViewTextBoxColumn8.DefaultCellStyle = dataGridViewCellStyle20;
+            dataGridViewTextBoxColumn8.HeaderText = "File Free %";
+            dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            dataGridViewTextBoxColumn8.ReadOnly = true;
+            dataGridViewTextBoxColumn8.Visible = false;
+            dataGridViewTextBoxColumn8.Width = 108;
             // 
             // dataGridViewTextBoxColumn9
             // 
-            this.dataGridViewTextBoxColumn9.DataPropertyName = "GrowthMB";
+            dataGridViewTextBoxColumn9.DataPropertyName = "GrowthMB";
             dataGridViewCellStyle21.Format = "#,##0.#";
-            this.dataGridViewTextBoxColumn9.DefaultCellStyle = dataGridViewCellStyle21;
-            this.dataGridViewTextBoxColumn9.HeaderText = "Growth (MB)";
-            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            this.dataGridViewTextBoxColumn9.ReadOnly = true;
-            this.dataGridViewTextBoxColumn9.Visible = false;
-            this.dataGridViewTextBoxColumn9.Width = 107;
+            dataGridViewTextBoxColumn9.DefaultCellStyle = dataGridViewCellStyle21;
+            dataGridViewTextBoxColumn9.HeaderText = "Growth (MB)";
+            dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            dataGridViewTextBoxColumn9.ReadOnly = true;
+            dataGridViewTextBoxColumn9.Visible = false;
+            dataGridViewTextBoxColumn9.Width = 107;
             // 
             // dataGridViewTextBoxColumn10
             // 
-            this.dataGridViewTextBoxColumn10.DataPropertyName = "MaxSizeMB";
+            dataGridViewTextBoxColumn10.DataPropertyName = "MaxSizeMB";
             dataGridViewCellStyle22.Format = "#,##0.#";
-            this.dataGridViewTextBoxColumn10.DefaultCellStyle = dataGridViewCellStyle22;
-            this.dataGridViewTextBoxColumn10.HeaderText = "Max Size (MB)";
-            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            this.dataGridViewTextBoxColumn10.ReadOnly = true;
-            this.dataGridViewTextBoxColumn10.Visible = false;
-            this.dataGridViewTextBoxColumn10.Width = 117;
+            dataGridViewTextBoxColumn10.DefaultCellStyle = dataGridViewCellStyle22;
+            dataGridViewTextBoxColumn10.HeaderText = "Max Size (MB)";
+            dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            dataGridViewTextBoxColumn10.ReadOnly = true;
+            dataGridViewTextBoxColumn10.Visible = false;
+            dataGridViewTextBoxColumn10.Width = 117;
             // 
             // dataGridViewTextBoxColumn11
             // 
-            this.dataGridViewTextBoxColumn11.DataPropertyName = "filegroup_name";
+            dataGridViewTextBoxColumn11.DataPropertyName = "filegroup_name";
             dataGridViewCellStyle23.Format = "#,##0.#";
-            this.dataGridViewTextBoxColumn11.DefaultCellStyle = dataGridViewCellStyle23;
-            this.dataGridViewTextBoxColumn11.HeaderText = "Filegroup";
-            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            this.dataGridViewTextBoxColumn11.ReadOnly = true;
-            this.dataGridViewTextBoxColumn11.Visible = false;
-            this.dataGridViewTextBoxColumn11.Width = 96;
+            dataGridViewTextBoxColumn11.DefaultCellStyle = dataGridViewCellStyle23;
+            dataGridViewTextBoxColumn11.HeaderText = "Filegroup";
+            dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            dataGridViewTextBoxColumn11.ReadOnly = true;
+            dataGridViewTextBoxColumn11.Visible = false;
+            dataGridViewTextBoxColumn11.Width = 96;
             // 
             // dataGridViewTextBoxColumn12
             // 
-            this.dataGridViewTextBoxColumn12.DataPropertyName = "FilegroupSizeMB";
+            dataGridViewTextBoxColumn12.DataPropertyName = "FilegroupSizeMB";
             dataGridViewCellStyle24.Format = "N1";
-            this.dataGridViewTextBoxColumn12.DefaultCellStyle = dataGridViewCellStyle24;
-            this.dataGridViewTextBoxColumn12.HeaderText = "Filegroup Size (MB)";
-            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            this.dataGridViewTextBoxColumn12.ReadOnly = true;
-            this.dataGridViewTextBoxColumn12.Visible = false;
-            this.dataGridViewTextBoxColumn12.Width = 120;
+            dataGridViewTextBoxColumn12.DefaultCellStyle = dataGridViewCellStyle24;
+            dataGridViewTextBoxColumn12.HeaderText = "Filegroup Size (MB)";
+            dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            dataGridViewTextBoxColumn12.ReadOnly = true;
+            dataGridViewTextBoxColumn12.Visible = false;
+            dataGridViewTextBoxColumn12.Width = 120;
             // 
             // dataGridViewTextBoxColumn13
             // 
-            this.dataGridViewTextBoxColumn13.DataPropertyName = "FilegroupUsedMB";
+            dataGridViewTextBoxColumn13.DataPropertyName = "FilegroupUsedMB";
             dataGridViewCellStyle25.Format = "N1";
             dataGridViewCellStyle25.NullValue = null;
-            this.dataGridViewTextBoxColumn13.DefaultCellStyle = dataGridViewCellStyle25;
-            this.dataGridViewTextBoxColumn13.HeaderText = "Filegroup Used (MB)";
-            this.dataGridViewTextBoxColumn13.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
-            this.dataGridViewTextBoxColumn13.ReadOnly = true;
-            this.dataGridViewTextBoxColumn13.Width = 126;
+            dataGridViewTextBoxColumn13.DefaultCellStyle = dataGridViewCellStyle25;
+            dataGridViewTextBoxColumn13.HeaderText = "Filegroup Used (MB)";
+            dataGridViewTextBoxColumn13.MinimumWidth = 6;
+            dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
+            dataGridViewTextBoxColumn13.ReadOnly = true;
+            dataGridViewTextBoxColumn13.Width = 126;
             // 
             // dataGridViewTextBoxColumn14
             // 
-            this.dataGridViewTextBoxColumn14.DataPropertyName = "FilegroupFreeMB";
+            dataGridViewTextBoxColumn14.DataPropertyName = "FilegroupFreeMB";
             dataGridViewCellStyle26.Format = "N1";
-            this.dataGridViewTextBoxColumn14.DefaultCellStyle = dataGridViewCellStyle26;
-            this.dataGridViewTextBoxColumn14.HeaderText = "Filegroup Free (MB)";
-            this.dataGridViewTextBoxColumn14.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
-            this.dataGridViewTextBoxColumn14.ReadOnly = true;
-            this.dataGridViewTextBoxColumn14.Width = 122;
+            dataGridViewTextBoxColumn14.DefaultCellStyle = dataGridViewCellStyle26;
+            dataGridViewTextBoxColumn14.HeaderText = "Filegroup Free (MB)";
+            dataGridViewTextBoxColumn14.MinimumWidth = 6;
+            dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
+            dataGridViewTextBoxColumn14.ReadOnly = true;
+            dataGridViewTextBoxColumn14.Width = 122;
             // 
             // dataGridViewTextBoxColumn15
             // 
-            this.dataGridViewTextBoxColumn15.DataPropertyName = "FilegroupPctFree";
+            dataGridViewTextBoxColumn15.DataPropertyName = "FilegroupPctFree";
             dataGridViewCellStyle27.Format = "P1";
             dataGridViewCellStyle27.NullValue = null;
-            this.dataGridViewTextBoxColumn15.DefaultCellStyle = dataGridViewCellStyle27;
-            this.dataGridViewTextBoxColumn15.HeaderText = "Filegroup Free %";
-            this.dataGridViewTextBoxColumn15.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
-            this.dataGridViewTextBoxColumn15.ReadOnly = true;
-            this.dataGridViewTextBoxColumn15.Width = 122;
+            dataGridViewTextBoxColumn15.DefaultCellStyle = dataGridViewCellStyle27;
+            dataGridViewTextBoxColumn15.HeaderText = "Filegroup Free %";
+            dataGridViewTextBoxColumn15.MinimumWidth = 6;
+            dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
+            dataGridViewTextBoxColumn15.ReadOnly = true;
+            dataGridViewTextBoxColumn15.Width = 122;
             // 
             // dataGridViewTextBoxColumn16
             // 
-            this.dataGridViewTextBoxColumn16.DataPropertyName = "FilegroupNumberOfFiles";
+            dataGridViewTextBoxColumn16.DataPropertyName = "FilegroupNumberOfFiles";
             dataGridViewCellStyle28.Format = "P1";
             dataGridViewCellStyle28.NullValue = null;
-            this.dataGridViewTextBoxColumn16.DefaultCellStyle = dataGridViewCellStyle28;
-            this.dataGridViewTextBoxColumn16.HeaderText = "Filegroup Number of Files";
-            this.dataGridViewTextBoxColumn16.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
-            this.dataGridViewTextBoxColumn16.ReadOnly = true;
-            this.dataGridViewTextBoxColumn16.Width = 141;
+            dataGridViewTextBoxColumn16.DefaultCellStyle = dataGridViewCellStyle28;
+            dataGridViewTextBoxColumn16.HeaderText = "Filegroup Number of Files";
+            dataGridViewTextBoxColumn16.MinimumWidth = 6;
+            dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
+            dataGridViewTextBoxColumn16.ReadOnly = true;
+            dataGridViewTextBoxColumn16.Width = 141;
             // 
             // dataGridViewTextBoxColumn17
             // 
-            this.dataGridViewTextBoxColumn17.DataPropertyName = "ExcludedReason";
+            dataGridViewTextBoxColumn17.DataPropertyName = "ExcludedReason";
             dataGridViewCellStyle29.Format = "N0";
-            this.dataGridViewTextBoxColumn17.DefaultCellStyle = dataGridViewCellStyle29;
-            this.dataGridViewTextBoxColumn17.HeaderText = "Excluded Reason";
-            this.dataGridViewTextBoxColumn17.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
-            this.dataGridViewTextBoxColumn17.ReadOnly = true;
-            this.dataGridViewTextBoxColumn17.Width = 135;
+            dataGridViewTextBoxColumn17.DefaultCellStyle = dataGridViewCellStyle29;
+            dataGridViewTextBoxColumn17.HeaderText = "Excluded Reason";
+            dataGridViewTextBoxColumn17.MinimumWidth = 6;
+            dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
+            dataGridViewTextBoxColumn17.ReadOnly = true;
+            dataGridViewTextBoxColumn17.Width = 135;
             // 
             // dataGridViewTextBoxColumn18
             // 
-            this.dataGridViewTextBoxColumn18.DataPropertyName = "is_read_only";
+            dataGridViewTextBoxColumn18.DataPropertyName = "is_read_only";
             dataGridViewCellStyle30.Format = "P1";
-            this.dataGridViewTextBoxColumn18.DefaultCellStyle = dataGridViewCellStyle30;
-            this.dataGridViewTextBoxColumn18.HeaderText = "Read Only";
-            this.dataGridViewTextBoxColumn18.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
-            this.dataGridViewTextBoxColumn18.ReadOnly = true;
-            this.dataGridViewTextBoxColumn18.Width = 96;
+            dataGridViewTextBoxColumn18.DefaultCellStyle = dataGridViewCellStyle30;
+            dataGridViewTextBoxColumn18.HeaderText = "Read Only";
+            dataGridViewTextBoxColumn18.MinimumWidth = 6;
+            dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
+            dataGridViewTextBoxColumn18.ReadOnly = true;
+            dataGridViewTextBoxColumn18.Width = 96;
             // 
             // dataGridViewTextBoxColumn19
             // 
-            this.dataGridViewTextBoxColumn19.DataPropertyName = "is_db_read_only";
+            dataGridViewTextBoxColumn19.DataPropertyName = "is_db_read_only";
             dataGridViewCellStyle31.Format = "P1";
-            this.dataGridViewTextBoxColumn19.DefaultCellStyle = dataGridViewCellStyle31;
-            this.dataGridViewTextBoxColumn19.HeaderText = "DB ReadOnly";
-            this.dataGridViewTextBoxColumn19.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn19.Name = "dataGridViewTextBoxColumn19";
-            this.dataGridViewTextBoxColumn19.ReadOnly = true;
-            this.dataGridViewTextBoxColumn19.Width = 113;
+            dataGridViewTextBoxColumn19.DefaultCellStyle = dataGridViewCellStyle31;
+            dataGridViewTextBoxColumn19.HeaderText = "DB ReadOnly";
+            dataGridViewTextBoxColumn19.MinimumWidth = 6;
+            dataGridViewTextBoxColumn19.Name = "dataGridViewTextBoxColumn19";
+            dataGridViewTextBoxColumn19.ReadOnly = true;
+            dataGridViewTextBoxColumn19.Width = 113;
             // 
             // dataGridViewTextBoxColumn20
             // 
-            this.dataGridViewTextBoxColumn20.DataPropertyName = "is_in_standby";
+            dataGridViewTextBoxColumn20.DataPropertyName = "is_in_standby";
             dataGridViewCellStyle32.Format = "P1";
-            this.dataGridViewTextBoxColumn20.DefaultCellStyle = dataGridViewCellStyle32;
-            this.dataGridViewTextBoxColumn20.HeaderText = "Standby";
-            this.dataGridViewTextBoxColumn20.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn20.Name = "dataGridViewTextBoxColumn20";
-            this.dataGridViewTextBoxColumn20.ReadOnly = true;
-            this.dataGridViewTextBoxColumn20.Width = 89;
+            dataGridViewTextBoxColumn20.DefaultCellStyle = dataGridViewCellStyle32;
+            dataGridViewTextBoxColumn20.HeaderText = "Standby";
+            dataGridViewTextBoxColumn20.MinimumWidth = 6;
+            dataGridViewTextBoxColumn20.Name = "dataGridViewTextBoxColumn20";
+            dataGridViewTextBoxColumn20.ReadOnly = true;
+            dataGridViewTextBoxColumn20.Width = 89;
             // 
             // dataGridViewTextBoxColumn21
             // 
-            this.dataGridViewTextBoxColumn21.DataPropertyName = "state_desc";
-            this.dataGridViewTextBoxColumn21.HeaderText = "State";
-            this.dataGridViewTextBoxColumn21.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn21.Name = "dataGridViewTextBoxColumn21";
-            this.dataGridViewTextBoxColumn21.ReadOnly = true;
-            this.dataGridViewTextBoxColumn21.Width = 70;
+            dataGridViewTextBoxColumn21.DataPropertyName = "state_desc";
+            dataGridViewTextBoxColumn21.HeaderText = "State";
+            dataGridViewTextBoxColumn21.MinimumWidth = 6;
+            dataGridViewTextBoxColumn21.Name = "dataGridViewTextBoxColumn21";
+            dataGridViewTextBoxColumn21.ReadOnly = true;
+            dataGridViewTextBoxColumn21.Width = 70;
             // 
             // dataGridViewTextBoxColumn22
             // 
-            this.dataGridViewTextBoxColumn22.DataPropertyName = "ConfiguredLevel";
-            this.dataGridViewTextBoxColumn22.HeaderText = "Configured Level";
-            this.dataGridViewTextBoxColumn22.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn22.Name = "dataGridViewTextBoxColumn22";
-            this.dataGridViewTextBoxColumn22.ReadOnly = true;
-            this.dataGridViewTextBoxColumn22.Width = 132;
+            dataGridViewTextBoxColumn22.DataPropertyName = "ConfiguredLevel";
+            dataGridViewTextBoxColumn22.HeaderText = "Configured Level";
+            dataGridViewTextBoxColumn22.MinimumWidth = 6;
+            dataGridViewTextBoxColumn22.Name = "dataGridViewTextBoxColumn22";
+            dataGridViewTextBoxColumn22.ReadOnly = true;
+            dataGridViewTextBoxColumn22.Width = 132;
             // 
             // dataGridViewTextBoxColumn23
             // 
-            this.dataGridViewTextBoxColumn23.DataPropertyName = "FileSnapshotAge";
-            this.dataGridViewTextBoxColumn23.HeaderText = "File Snapshot Age";
-            this.dataGridViewTextBoxColumn23.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn23.Name = "dataGridViewTextBoxColumn23";
-            this.dataGridViewTextBoxColumn23.ReadOnly = true;
-            this.dataGridViewTextBoxColumn23.Width = 139;
+            dataGridViewTextBoxColumn23.DataPropertyName = "FileSnapshotAge";
+            dataGridViewTextBoxColumn23.HeaderText = "File Snapshot Age";
+            dataGridViewTextBoxColumn23.MinimumWidth = 6;
+            dataGridViewTextBoxColumn23.Name = "dataGridViewTextBoxColumn23";
+            dataGridViewTextBoxColumn23.ReadOnly = true;
+            dataGridViewTextBoxColumn23.Width = 139;
             // 
             // dataGridViewTextBoxColumn24
             // 
-            this.dataGridViewTextBoxColumn24.DataPropertyName = "FileSnapshotAge";
-            this.dataGridViewTextBoxColumn24.HeaderText = "File Snapshot Age";
-            this.dataGridViewTextBoxColumn24.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn24.Name = "dataGridViewTextBoxColumn24";
-            this.dataGridViewTextBoxColumn24.ReadOnly = true;
-            this.dataGridViewTextBoxColumn24.Width = 139;
+            dataGridViewTextBoxColumn24.DataPropertyName = "FileSnapshotAge";
+            dataGridViewTextBoxColumn24.HeaderText = "File Snapshot Age";
+            dataGridViewTextBoxColumn24.MinimumWidth = 6;
+            dataGridViewTextBoxColumn24.Name = "dataGridViewTextBoxColumn24";
+            dataGridViewTextBoxColumn24.ReadOnly = true;
+            dataGridViewTextBoxColumn24.Width = 139;
             // 
             // dataGridViewTextBoxColumn25
             // 
-            this.dataGridViewTextBoxColumn25.DataPropertyName = "is_in_standby";
-            this.dataGridViewTextBoxColumn25.HeaderText = "Standby";
-            this.dataGridViewTextBoxColumn25.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn25.Name = "dataGridViewTextBoxColumn25";
-            this.dataGridViewTextBoxColumn25.Width = 89;
+            dataGridViewTextBoxColumn25.DataPropertyName = "is_in_standby";
+            dataGridViewTextBoxColumn25.HeaderText = "Standby";
+            dataGridViewTextBoxColumn25.MinimumWidth = 6;
+            dataGridViewTextBoxColumn25.Name = "dataGridViewTextBoxColumn25";
+            dataGridViewTextBoxColumn25.Width = 89;
             // 
             // dataGridViewTextBoxColumn26
             // 
-            this.dataGridViewTextBoxColumn26.DataPropertyName = "state_desc";
-            this.dataGridViewTextBoxColumn26.HeaderText = "State";
-            this.dataGridViewTextBoxColumn26.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn26.Name = "dataGridViewTextBoxColumn26";
-            this.dataGridViewTextBoxColumn26.Width = 70;
+            dataGridViewTextBoxColumn26.DataPropertyName = "state_desc";
+            dataGridViewTextBoxColumn26.HeaderText = "State";
+            dataGridViewTextBoxColumn26.MinimumWidth = 6;
+            dataGridViewTextBoxColumn26.Name = "dataGridViewTextBoxColumn26";
+            dataGridViewTextBoxColumn26.Width = 70;
             // 
             // dataGridViewTextBoxColumn27
             // 
-            this.dataGridViewTextBoxColumn27.DataPropertyName = "ConfiguredLevel";
-            this.dataGridViewTextBoxColumn27.HeaderText = "Configured Level";
-            this.dataGridViewTextBoxColumn27.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn27.Name = "dataGridViewTextBoxColumn27";
-            this.dataGridViewTextBoxColumn27.Width = 132;
+            dataGridViewTextBoxColumn27.DataPropertyName = "ConfiguredLevel";
+            dataGridViewTextBoxColumn27.HeaderText = "Configured Level";
+            dataGridViewTextBoxColumn27.MinimumWidth = 6;
+            dataGridViewTextBoxColumn27.Name = "dataGridViewTextBoxColumn27";
+            dataGridViewTextBoxColumn27.Width = 132;
             // 
             // dataGridViewTextBoxColumn28
             // 
-            this.dataGridViewTextBoxColumn28.DataPropertyName = "FileSnapshotAge";
-            this.dataGridViewTextBoxColumn28.HeaderText = "File Snapshot Age";
-            this.dataGridViewTextBoxColumn28.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn28.Name = "dataGridViewTextBoxColumn28";
-            this.dataGridViewTextBoxColumn28.Width = 139;
+            dataGridViewTextBoxColumn28.DataPropertyName = "FileSnapshotAge";
+            dataGridViewTextBoxColumn28.HeaderText = "File Snapshot Age";
+            dataGridViewTextBoxColumn28.MinimumWidth = 6;
+            dataGridViewTextBoxColumn28.Name = "dataGridViewTextBoxColumn28";
+            dataGridViewTextBoxColumn28.Width = 139;
             // 
             // dataGridViewTextBoxColumn29
             // 
-            this.dataGridViewTextBoxColumn29.DataPropertyName = "ConfiguredLevel";
-            this.dataGridViewTextBoxColumn29.HeaderText = "Configured Level";
-            this.dataGridViewTextBoxColumn29.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn29.Name = "dataGridViewTextBoxColumn29";
-            this.dataGridViewTextBoxColumn29.Width = 132;
+            dataGridViewTextBoxColumn29.DataPropertyName = "ConfiguredLevel";
+            dataGridViewTextBoxColumn29.HeaderText = "Configured Level";
+            dataGridViewTextBoxColumn29.MinimumWidth = 6;
+            dataGridViewTextBoxColumn29.Name = "dataGridViewTextBoxColumn29";
+            dataGridViewTextBoxColumn29.Width = 132;
             // 
             // dataGridViewTextBoxColumn30
             // 
-            this.dataGridViewTextBoxColumn30.DataPropertyName = "FileSnapshotAge";
-            this.dataGridViewTextBoxColumn30.HeaderText = "File Snapshot Age";
-            this.dataGridViewTextBoxColumn30.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn30.Name = "dataGridViewTextBoxColumn30";
-            this.dataGridViewTextBoxColumn30.Width = 139;
+            dataGridViewTextBoxColumn30.DataPropertyName = "FileSnapshotAge";
+            dataGridViewTextBoxColumn30.HeaderText = "File Snapshot Age";
+            dataGridViewTextBoxColumn30.MinimumWidth = 6;
+            dataGridViewTextBoxColumn30.Name = "dataGridViewTextBoxColumn30";
+            dataGridViewTextBoxColumn30.Width = 139;
             // 
             // statusStrip1
             // 
-            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.lblInfo});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 246);
-            this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(1414, 22);
-            this.statusStrip1.TabIndex = 4;
-            this.statusStrip1.Text = "statusStrip1";
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblInfo });
+            statusStrip1.Location = new System.Drawing.Point(0, 335);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip1.Size = new System.Drawing.Size(1616, 22);
+            statusStrip1.TabIndex = 4;
+            statusStrip1.Text = "statusStrip1";
             // 
             // lblInfo
             // 
-            this.lblInfo.Name = "lblInfo";
-            this.lblInfo.Size = new System.Drawing.Size(0, 17);
+            lblInfo.Name = "lblInfo";
+            lblInfo.Size = new System.Drawing.Size(0, 16);
             // 
             // DBFilesControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.dgvFiles);
-            this.Controls.Add(this.toolStrip1);
-            this.Controls.Add(this.statusStrip1);
-            this.Name = "DBFilesControl";
-            this.Size = new System.Drawing.Size(1414, 268);
-            this.Load += new System.EventHandler(this.DBFilesControl_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.dgvFiles)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.statusStrip1.ResumeLayout(false);
-            this.statusStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(dgvFiles);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "DBFilesControl";
+            Size = new System.Drawing.Size(1616, 357);
+            Load += DBFilesControl_Load;
+            ((System.ComponentModel.ISupportInitialize)dgvFiles).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -1170,5 +1136,6 @@
         private StatusFilterToolStrip statusFilterToolStrip1;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel lblInfo;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
     }
 }

--- a/DBADashGUI/DBFiles/DBFilesControl.resx
+++ b/DBADashGUI/DBFiles/DBFilesControl.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -160,7 +220,7 @@
   <data name="statusFilterToolStrip1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAHbSURBVDhPjZK9SwJxHMbvT6m9SYKWs8EabogKc1CijLpB
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAHbSURBVDhPjZK9SwJxHMbvT6m9SYKWs8EabogKc1CijLpB
         HCKkLE6pqJBeDSsqzV6Iiny7osFBe6FwKiFoMGgqSIgg3Bz95vPr7tK7hr7wLMc9n+/zfO84/VyFT6NP
         a7ulj+UQQV+5INPzdbh0lz2JKq8ZJ70r84VQpPw0JlG8s4eCphamdXcz01mgmwryOL3cbJezWZlXbD8D
         89vKeuXc5qAwb6Gca5heZxaoOB+kz9sler8M0P2Bm/a8rZRZ66XiXahSB8HmtKOf9iyCZlQFgCqAjqR2
@@ -174,7 +234,7 @@
   <data name="tsLevel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
@@ -189,7 +249,7 @@
   <data name="tsType.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
         YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
         0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
         bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc

--- a/DBADashGUI/Drives/DrivesControl.Designer.cs
+++ b/DBADashGUI/Drives/DrivesControl.Designer.cs
@@ -29,235 +29,240 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DrivesControl));
-            this.pnlDrives = new System.Windows.Forms.Panel();
-            this.driveControl1 = new DBADashGUI.DriveControl();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.statusFilterToolStrip1 = new DBADashGUI.StatusFilterToolStrip();
-            this.tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
-            this.configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsGridView = new System.Windows.Forms.ToolStripButton();
-            this.tsDrivesView = new System.Windows.Forms.ToolStripButton();
-            this.tsColumns = new System.Windows.Forms.ToolStripDropDownButton();
-            this.includeAllMetricsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pnlSpacing = new System.Windows.Forms.Panel();
-            this.pnlDrives.SuspendLayout();
-            this.toolStrip1.SuspendLayout();
-            this.SuspendLayout();
+            pnlDrives = new System.Windows.Forms.Panel();
+            driveControl1 = new DriveControl();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            statusFilterToolStrip1 = new StatusFilterToolStrip();
+            tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
+            configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsGridView = new System.Windows.Forms.ToolStripButton();
+            tsDrivesView = new System.Windows.Forms.ToolStripButton();
+            tsColumns = new System.Windows.Forms.ToolStripDropDownButton();
+            includeAllMetricsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            pnlSpacing = new System.Windows.Forms.Panel();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            pnlDrives.SuspendLayout();
+            toolStrip1.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // pnlDrives
             // 
-            this.pnlDrives.AutoScroll = true;
-            this.pnlDrives.Controls.Add(this.driveControl1);
-            this.pnlDrives.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlDrives.Location = new System.Drawing.Point(0, 47);
-            this.pnlDrives.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.pnlDrives.Name = "pnlDrives";
-            this.pnlDrives.Size = new System.Drawing.Size(735, 274);
-            this.pnlDrives.TabIndex = 3;
+            pnlDrives.AutoScroll = true;
+            pnlDrives.Controls.Add(driveControl1);
+            pnlDrives.Dock = System.Windows.Forms.DockStyle.Fill;
+            pnlDrives.Location = new System.Drawing.Point(0, 47);
+            pnlDrives.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            pnlDrives.Name = "pnlDrives";
+            pnlDrives.Size = new System.Drawing.Size(735, 250);
+            pnlDrives.TabIndex = 3;
             // 
             // driveControl1
             // 
-            this.driveControl1.DisplayInstanceName = false;
-            this.driveControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.driveControl1.Drive.CriticalThreshold = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.driveControl1.Drive.DriveCapacity = ((long)(0));
-            this.driveControl1.Drive.DriveCapacityGB = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.driveControl1.Drive.DriveCheckType = DBADashGUI.DriveThreshold.DriveCheckTypeEnum.None;
-            this.driveControl1.Drive.DriveCheckTypeChar = '-';
-            this.driveControl1.Drive.DriveID = 0;
-            this.driveControl1.Drive.DriveLabel = null;
-            this.driveControl1.Drive.DriveLetter = null;
-            this.driveControl1.Drive.FreeSpace = ((long)(0));
-            this.driveControl1.Drive.FreeSpaceGB = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.driveControl1.Drive.Inherited = false;
-            this.driveControl1.Drive.InstanceID = 0;
-            this.driveControl1.Drive.SnapshotDate = new System.DateTime(((long)(0)));
-            this.driveControl1.Drive.WarningThreshold = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
-            this.driveControl1.Location = new System.Drawing.Point(0, 0);
-            this.driveControl1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
-            this.driveControl1.Name = "driveControl1";
-            this.driveControl1.Size = new System.Drawing.Size(735, 274);
-            this.driveControl1.TabIndex = 0;
+            driveControl1.DisplayInstanceName = false;
+            driveControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            driveControl1.Drive.CriticalThreshold = new decimal(new int[] { 0, 0, 0, 0 });
+            driveControl1.Drive.DriveCapacity = 0L;
+            driveControl1.Drive.DriveCapacityGB = new decimal(new int[] { 0, 0, 0, 0 });
+            driveControl1.Drive.DriveCheckType = DriveThreshold.DriveCheckTypeEnum.None;
+            driveControl1.Drive.DriveCheckTypeChar = '-';
+            driveControl1.Drive.DriveID = 0;
+            driveControl1.Drive.DriveLabel = null;
+            driveControl1.Drive.DriveLetter = null;
+            driveControl1.Drive.FreeSpace = 0L;
+            driveControl1.Drive.FreeSpaceGB = new decimal(new int[] { 0, 0, 0, 0 });
+            driveControl1.Drive.Inherited = false;
+            driveControl1.Drive.InstanceID = 0;
+            driveControl1.Drive.SnapshotDate = new System.DateTime(0L);
+            driveControl1.Drive.WarningThreshold = new decimal(new int[] { 0, 0, 0, 0 });
+            driveControl1.Location = new System.Drawing.Point(0, 0);
+            driveControl1.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
+            driveControl1.Name = "driveControl1";
+            driveControl1.Size = new System.Drawing.Size(735, 250);
+            driveControl1.TabIndex = 0;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.statusFilterToolStrip1,
-            this.tsConfigure,
-            this.tsGridView,
-            this.tsDrivesView,
-            this.tsColumns});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(735, 27);
-            this.toolStrip1.TabIndex = 7;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, statusFilterToolStrip1, tsConfigure, tsGridView, tsDrivesView, tsColumns, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(735, 27);
+            toolStrip1.TabIndex = 7;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // statusFilterToolStrip1
             // 
-            this.statusFilterToolStrip1.Acknowledged = false;
-            this.statusFilterToolStrip1.AcknowledgedVisible = false;
-            this.statusFilterToolStrip1.Critical = true;
-            this.statusFilterToolStrip1.CriticalVisible = true;
-            this.statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.statusFilterToolStrip1.Image = ((System.Drawing.Image)(resources.GetObject("statusFilterToolStrip1.Image")));
-            this.statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.statusFilterToolStrip1.NA = true;
-            this.statusFilterToolStrip1.Name = "statusFilterToolStrip1";
-            this.statusFilterToolStrip1.NAVisible = true;
-            this.statusFilterToolStrip1.OK = true;
-            this.statusFilterToolStrip1.OKVisible = true;
-            this.statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
-            this.statusFilterToolStrip1.Text = "ALL";
-            this.statusFilterToolStrip1.Warning = true;
-            this.statusFilterToolStrip1.WarningVisible = true;
-            this.statusFilterToolStrip1.UserChangedStatusFilter += new System.EventHandler(this.Status_Selected);
+            statusFilterToolStrip1.Acknowledged = false;
+            statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.Critical = true;
+            statusFilterToolStrip1.CriticalVisible = true;
+            statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            statusFilterToolStrip1.Image = (System.Drawing.Image)resources.GetObject("statusFilterToolStrip1.Image");
+            statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            statusFilterToolStrip1.NA = true;
+            statusFilterToolStrip1.Name = "statusFilterToolStrip1";
+            statusFilterToolStrip1.NAVisible = true;
+            statusFilterToolStrip1.OK = true;
+            statusFilterToolStrip1.OKVisible = true;
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
+            statusFilterToolStrip1.Text = "ALL";
+            statusFilterToolStrip1.Warning = true;
+            statusFilterToolStrip1.WarningVisible = true;
+            statusFilterToolStrip1.UserChangedStatusFilter += Status_Selected;
             // 
             // tsConfigure
             // 
-            this.tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.configureInstanceThresholdsToolStripMenuItem,
-            this.configureRootThresholdsToolStripMenuItem});
-            this.tsConfigure.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
-            this.tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsConfigure.Name = "tsConfigure";
-            this.tsConfigure.Size = new System.Drawing.Size(34, 24);
-            this.tsConfigure.Text = "Configure";
+            tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { configureInstanceThresholdsToolStripMenuItem, configureRootThresholdsToolStripMenuItem });
+            tsConfigure.Image = Properties.Resources.SettingsOutline_16x;
+            tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsConfigure.Name = "tsConfigure";
+            tsConfigure.Size = new System.Drawing.Size(34, 24);
+            tsConfigure.Text = "Configure";
             // 
             // configureInstanceThresholdsToolStripMenuItem
             // 
-            this.configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
-            this.configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
-            this.configureInstanceThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureInstanceThresholdsToolStripMenuItem_Click);
+            configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
+            configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
+            configureInstanceThresholdsToolStripMenuItem.Click += ConfigureInstanceThresholdsToolStripMenuItem_Click;
             // 
             // configureRootThresholdsToolStripMenuItem
             // 
-            this.configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
-            this.configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
-            this.configureRootThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureRootThresholdsToolStripMenuItem_Click);
+            configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
+            configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
+            configureRootThresholdsToolStripMenuItem.Click += ConfigureRootThresholdsToolStripMenuItem_Click;
             // 
             // tsGridView
             // 
-            this.tsGridView.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsGridView.Image = global::DBADashGUI.Properties.Resources.Table_16x;
-            this.tsGridView.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsGridView.Name = "tsGridView";
-            this.tsGridView.Size = new System.Drawing.Size(29, 24);
-            this.tsGridView.Text = "Table View";
-            this.tsGridView.Click += new System.EventHandler(this.TsGridView_Click);
+            tsGridView.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsGridView.Image = Properties.Resources.Table_16x;
+            tsGridView.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsGridView.Name = "tsGridView";
+            tsGridView.Size = new System.Drawing.Size(29, 24);
+            tsGridView.Text = "Table View";
+            tsGridView.Click += TsGridView_Click;
             // 
             // tsDrivesView
             // 
-            this.tsDrivesView.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsDrivesView.Image = global::DBADashGUI.Properties.Resources.Hard_Drive;
-            this.tsDrivesView.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsDrivesView.Name = "tsDrivesView";
-            this.tsDrivesView.Size = new System.Drawing.Size(29, 24);
-            this.tsDrivesView.Text = "Drives View";
-            this.tsDrivesView.Click += new System.EventHandler(this.TsDrivesView_Click);
+            tsDrivesView.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsDrivesView.Image = Properties.Resources.Hard_Drive;
+            tsDrivesView.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsDrivesView.Name = "tsDrivesView";
+            tsDrivesView.Size = new System.Drawing.Size(29, 24);
+            tsDrivesView.Text = "Drives View";
+            tsDrivesView.Click += TsDrivesView_Click;
             // 
             // tsColumns
             // 
-            this.tsColumns.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsColumns.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.includeAllMetricsToolStripMenuItem});
-            this.tsColumns.Image = global::DBADashGUI.Properties.Resources.Column_16x;
-            this.tsColumns.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsColumns.Name = "tsColumns";
-            this.tsColumns.Size = new System.Drawing.Size(34, 24);
-            this.tsColumns.Text = "Columns";
+            tsColumns.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsColumns.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { includeAllMetricsToolStripMenuItem });
+            tsColumns.Image = Properties.Resources.Column_16x;
+            tsColumns.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsColumns.Name = "tsColumns";
+            tsColumns.Size = new System.Drawing.Size(34, 24);
+            tsColumns.Text = "Columns";
             // 
             // includeAllMetricsToolStripMenuItem
             // 
-            this.includeAllMetricsToolStripMenuItem.CheckOnClick = true;
-            this.includeAllMetricsToolStripMenuItem.Name = "includeAllMetricsToolStripMenuItem";
-            this.includeAllMetricsToolStripMenuItem.Size = new System.Drawing.Size(214, 26);
-            this.includeAllMetricsToolStripMenuItem.Text = "Include All Metrics";
-            this.includeAllMetricsToolStripMenuItem.Click += new System.EventHandler(this.IncludeAllMetricsToolStripMenuItem_Click);
+            includeAllMetricsToolStripMenuItem.CheckOnClick = true;
+            includeAllMetricsToolStripMenuItem.Name = "includeAllMetricsToolStripMenuItem";
+            includeAllMetricsToolStripMenuItem.Size = new System.Drawing.Size(214, 26);
+            includeAllMetricsToolStripMenuItem.Text = "Include All Metrics";
+            includeAllMetricsToolStripMenuItem.Click += IncludeAllMetricsToolStripMenuItem_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += TsTrigger_Click;
             // 
             // pnlSpacing
             // 
-            this.pnlSpacing.Dock = System.Windows.Forms.DockStyle.Top;
-            this.pnlSpacing.Location = new System.Drawing.Point(0, 27);
-            this.pnlSpacing.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.pnlSpacing.Name = "pnlSpacing";
-            this.pnlSpacing.Size = new System.Drawing.Size(735, 20);
-            this.pnlSpacing.TabIndex = 8;
+            pnlSpacing.Dock = System.Windows.Forms.DockStyle.Top;
+            pnlSpacing.Location = new System.Drawing.Point(0, 27);
+            pnlSpacing.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            pnlSpacing.Name = "pnlSpacing";
+            pnlSpacing.Size = new System.Drawing.Size(735, 20);
+            pnlSpacing.TabIndex = 8;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
+            statusStrip1.Location = new System.Drawing.Point(0, 297);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Size = new System.Drawing.Size(735, 24);
+            statusStrip1.TabIndex = 9;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatus
+            // 
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 18);
             // 
             // DrivesControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.pnlDrives);
-            this.Controls.Add(this.pnlSpacing);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "DrivesControl";
-            this.Size = new System.Drawing.Size(735, 321);
-            this.pnlDrives.ResumeLayout(false);
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(pnlDrives);
+            Controls.Add(pnlSpacing);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "DrivesControl";
+            Size = new System.Drawing.Size(735, 321);
+            pnlDrives.ResumeLayout(false);
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -276,5 +281,8 @@
         private System.Windows.Forms.ToolStripMenuItem includeAllMetricsToolStripMenuItem;
         private System.Windows.Forms.ToolStripButton tsExcel;
         private StatusFilterToolStrip statusFilterToolStrip1;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }

--- a/DBADashGUI/Drives/DrivesControl.resx
+++ b/DBADashGUI/Drives/DrivesControl.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -75,4 +135,7 @@
         sdlgrh3cBIfF12GqXhrCwbTO2nDcNxpvR7NQRXnOAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>143, 17</value>
+  </metadata>
 </root>

--- a/DBADashGUI/ExtensionMethods.cs
+++ b/DBADashGUI/ExtensionMethods.cs
@@ -513,5 +513,31 @@ namespace DBADashGUI
         {
             return hexString.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? hexString[2..] : hexString;
         }
+
+        public static void InvokeSetStatus(this ToolStripStatusLabel label, string message, string tooltip, Color color)
+        {
+            label.Owner?.Invoke(() =>
+            {
+                label.Visible = true;
+                label.Text = message;
+                label.ToolTipText = tooltip;
+                label.IsLink = !string.IsNullOrEmpty(tooltip);
+                label.ForeColor = color;
+                label.LinkColor = color;
+            });
+        }
+
+        public static void InvokeSetStatus(this ToolStripLabel label, string message, string tooltip, Color color)
+        {
+            label.Owner?.Invoke(() =>
+            {
+                label.Visible = true;
+                label.Text = message;
+                label.ToolTipText = tooltip;
+                label.IsLink = !string.IsNullOrEmpty(tooltip);
+                label.ForeColor = color;
+                label.LinkColor = color;
+            });
+        }
     }
 }

--- a/DBADashGUI/HA/AG.Designer.cs
+++ b/DBADashGUI/HA/AG.Designer.cs
@@ -29,105 +29,133 @@ namespace DBADashGUI.HA
         /// </summary>
         private void InitializeComponent()
         {
-            this.dgv = new System.Windows.Forms.DataGridView();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.tsBack = new System.Windows.Forms.ToolStripButton();
-            ((System.ComponentModel.ISupportInitialize)(this.dgv)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            this.SuspendLayout();
+            dgv = new System.Windows.Forms.DataGridView();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            tsBack = new System.Windows.Forms.ToolStripButton();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)dgv).BeginInit();
+            toolStrip1.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // dgv
             // 
-            this.dgv.AllowUserToAddRows = false;
-            this.dgv.AllowUserToDeleteRows = false;
-            this.dgv.BackgroundColor = System.Drawing.Color.White;
-            this.dgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgv.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgv.Location = new System.Drawing.Point(0, 27);
-            this.dgv.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgv.Name = "dgv";
-            this.dgv.ReadOnly = true;
-            this.dgv.RowHeadersVisible = false;
-            this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
-            this.dgv.Size = new System.Drawing.Size(752, 545);
-            this.dgv.TabIndex = 0;
-            this.dgv.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.Dgv_CellContentClick);
-            this.dgv.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.Dgv_RowsAdded);
+            dgv.AllowUserToAddRows = false;
+            dgv.AllowUserToDeleteRows = false;
+            dgv.BackgroundColor = System.Drawing.Color.White;
+            dgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgv.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgv.Location = new System.Drawing.Point(0, 27);
+            dgv.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgv.Name = "dgv";
+            dgv.ReadOnly = true;
+            dgv.RowHeadersVisible = false;
+            dgv.RowHeadersWidth = 51;
+            dgv.RowTemplate.Height = 24;
+            dgv.Size = new System.Drawing.Size(752, 523);
+            dgv.TabIndex = 0;
+            dgv.CellContentClick += Dgv_CellContentClick;
+            dgv.RowsAdded += Dgv_RowsAdded;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.tsBack});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(752, 27);
-            this.toolStrip1.TabIndex = 1;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, tsBack, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(752, 27);
+            toolStrip1.TabIndex = 1;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // tsBack
             // 
-            this.tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsBack.Enabled = false;
-            this.tsBack.Image = global::DBADashGUI.Properties.Resources.Previous_grey_16x;
-            this.tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsBack.Name = "tsBack";
-            this.tsBack.Size = new System.Drawing.Size(29, 24);
-            this.tsBack.Text = "Back";
-            this.tsBack.Click += new System.EventHandler(this.TsBack_Click);
+            tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsBack.Enabled = false;
+            tsBack.Image = Properties.Resources.Previous_grey_16x;
+            tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsBack.Name = "tsBack";
+            tsBack.Size = new System.Drawing.Size(29, 24);
+            tsBack.Text = "Back";
+            tsBack.Click += TsBack_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += tsTrigger_Click;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
+            statusStrip1.Location = new System.Drawing.Point(0, 550);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Size = new System.Drawing.Size(752, 22);
+            statusStrip1.TabIndex = 2;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatus
+            // 
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 16);
             // 
             // AG
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.dgv);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "AG";
-            this.Size = new System.Drawing.Size(752, 572);
-            ((System.ComponentModel.ISupportInitialize)(this.dgv)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(dgv);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "AG";
+            Size = new System.Drawing.Size(752, 572);
+            ((System.ComponentModel.ISupportInitialize)dgv).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -138,5 +166,8 @@ namespace DBADashGUI.HA
         private System.Windows.Forms.ToolStripButton tsCopy;
         private System.Windows.Forms.ToolStripButton tsBack;
         private System.Windows.Forms.ToolStripButton tsExcel;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }

--- a/DBADashGUI/HA/AG.resx
+++ b/DBADashGUI/HA/AG.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -59,5 +119,8 @@
   </resheader>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>143, 17</value>
   </metadata>
 </root>

--- a/DBADashGUI/HA/LogShippingControl.Designer.cs
+++ b/DBADashGUI/HA/LogShippingControl.Designer.cs
@@ -32,528 +32,537 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LogShippingControl));
-            this.dgvLogShipping = new System.Windows.Forms.DataGridView();
-            this.Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Status = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.RestoreDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.BackupStartDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.TimeSinceLast = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LatencyOfLast = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.TotalTimeBehind = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SnapshotDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LastFile = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ThresholdConfiguredLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Configure = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
-            this.configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tsBack = new System.Windows.Forms.ToolStripButton();
-            this.dgvSummary = new System.Windows.Forms.DataGridView();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.toolStrip2 = new System.Windows.Forms.ToolStrip();
-            this.tsCopyDetail = new System.Windows.Forms.ToolStripButton();
-            this.tsExportExcelDetail = new System.Windows.Forms.ToolStripButton();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.statusFilterToolStrip1 = new DBADashGUI.StatusFilterToolStrip();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvLogShipping)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvSummary)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
-            this.toolStrip2.SuspendLayout();
-            this.SuspendLayout();
+            dgvLogShipping = new System.Windows.Forms.DataGridView();
+            Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Status = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            RestoreDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            BackupStartDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            TimeSinceLast = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            LatencyOfLast = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            TotalTimeBehind = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            SnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            SnapshotDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            LastFile = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ThresholdConfiguredLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Configure = new System.Windows.Forms.DataGridViewLinkColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
+            configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsBack = new System.Windows.Forms.ToolStripButton();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            dgvSummary = new System.Windows.Forms.DataGridView();
+            splitContainer1 = new System.Windows.Forms.SplitContainer();
+            toolStrip2 = new System.Windows.Forms.ToolStrip();
+            tsCopyDetail = new System.Windows.Forms.ToolStripButton();
+            tsExportExcelDetail = new System.Windows.Forms.ToolStripButton();
+            statusFilterToolStrip1 = new StatusFilterToolStrip();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)dgvLogShipping).BeginInit();
+            toolStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dgvSummary).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
+            splitContainer1.Panel1.SuspendLayout();
+            splitContainer1.Panel2.SuspendLayout();
+            splitContainer1.SuspendLayout();
+            toolStrip2.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // dgvLogShipping
             // 
-            this.dgvLogShipping.AllowUserToAddRows = false;
-            this.dgvLogShipping.AllowUserToDeleteRows = false;
-            this.dgvLogShipping.BackgroundColor = System.Drawing.Color.White;
-            this.dgvLogShipping.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
+            dgvLogShipping.AllowUserToAddRows = false;
+            dgvLogShipping.AllowUserToDeleteRows = false;
+            dgvLogShipping.BackgroundColor = System.Drawing.Color.White;
+            dgvLogShipping.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvLogShipping.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.dgvLogShipping.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvLogShipping.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Instance,
-            this.Database,
-            this.Status,
-            this.RestoreDate,
-            this.BackupStartDate,
-            this.TimeSinceLast,
-            this.LatencyOfLast,
-            this.TotalTimeBehind,
-            this.SnapshotAge,
-            this.SnapshotDate,
-            this.LastFile,
-            this.ThresholdConfiguredLevel,
-            this.Configure});
+            dgvLogShipping.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dgvLogShipping.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvLogShipping.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { Instance, Database, Status, RestoreDate, BackupStartDate, TimeSinceLast, LatencyOfLast, TotalTimeBehind, SnapshotAge, SnapshotDate, LastFile, ThresholdConfiguredLevel, Configure });
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvLogShipping.DefaultCellStyle = dataGridViewCellStyle2;
-            this.dgvLogShipping.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvLogShipping.Location = new System.Drawing.Point(0, 27);
-            this.dgvLogShipping.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvLogShipping.Name = "dgvLogShipping";
-            this.dgvLogShipping.ReadOnly = true;
+            dgvLogShipping.DefaultCellStyle = dataGridViewCellStyle2;
+            dgvLogShipping.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvLogShipping.Location = new System.Drawing.Point(0, 27);
+            dgvLogShipping.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvLogShipping.Name = "dgvLogShipping";
+            dgvLogShipping.ReadOnly = true;
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvLogShipping.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
-            this.dgvLogShipping.RowHeadersVisible = false;
-            this.dgvLogShipping.RowHeadersWidth = 51;
-            this.dgvLogShipping.RowTemplate.Height = 24;
-            this.dgvLogShipping.Size = new System.Drawing.Size(698, 287);
-            this.dgvLogShipping.TabIndex = 0;
-            this.dgvLogShipping.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvLogShipping_CellContentClick);
-            this.dgvLogShipping.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvLogShipping_RowsAdded);
+            dgvLogShipping.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dgvLogShipping.RowHeadersVisible = false;
+            dgvLogShipping.RowHeadersWidth = 51;
+            dgvLogShipping.RowTemplate.Height = 24;
+            dgvLogShipping.Size = new System.Drawing.Size(698, 276);
+            dgvLogShipping.TabIndex = 0;
+            dgvLogShipping.CellContentClick += DgvLogShipping_CellContentClick;
+            dgvLogShipping.RowsAdded += DgvLogShipping_RowsAdded;
             // 
             // Instance
             // 
-            this.Instance.DataPropertyName = "InstanceDisplayName";
-            this.Instance.HeaderText = "Instance";
-            this.Instance.MinimumWidth = 6;
-            this.Instance.Name = "Instance";
-            this.Instance.ReadOnly = true;
-            this.Instance.Width = 90;
+            Instance.DataPropertyName = "InstanceDisplayName";
+            Instance.HeaderText = "Instance";
+            Instance.MinimumWidth = 6;
+            Instance.Name = "Instance";
+            Instance.ReadOnly = true;
+            Instance.Width = 90;
             // 
             // Database
             // 
-            this.Database.DataPropertyName = "name";
-            this.Database.HeaderText = "Database";
-            this.Database.MinimumWidth = 6;
-            this.Database.Name = "Database";
-            this.Database.ReadOnly = true;
-            this.Database.Width = 98;
+            Database.DataPropertyName = "name";
+            Database.HeaderText = "Database";
+            Database.MinimumWidth = 6;
+            Database.Name = "Database";
+            Database.ReadOnly = true;
+            Database.Width = 98;
             // 
             // Status
             // 
-            this.Status.DataPropertyName = "StatusDescription";
-            this.Status.HeaderText = "Status";
-            this.Status.MinimumWidth = 6;
-            this.Status.Name = "Status";
-            this.Status.ReadOnly = true;
-            this.Status.Width = 77;
+            Status.DataPropertyName = "StatusDescription";
+            Status.HeaderText = "Status";
+            Status.MinimumWidth = 6;
+            Status.Name = "Status";
+            Status.ReadOnly = true;
+            Status.Width = 77;
             // 
             // RestoreDate
             // 
-            this.RestoreDate.DataPropertyName = "restore_date";
-            this.RestoreDate.HeaderText = "Restore Date";
-            this.RestoreDate.MinimumWidth = 6;
-            this.RestoreDate.Name = "RestoreDate";
-            this.RestoreDate.ReadOnly = true;
-            this.RestoreDate.Width = 111;
+            RestoreDate.DataPropertyName = "restore_date";
+            RestoreDate.HeaderText = "Restore Date";
+            RestoreDate.MinimumWidth = 6;
+            RestoreDate.Name = "RestoreDate";
+            RestoreDate.ReadOnly = true;
+            RestoreDate.Width = 111;
             // 
             // BackupStartDate
             // 
-            this.BackupStartDate.DataPropertyName = "backup_start_date";
-            this.BackupStartDate.HeaderText = "Backup Start Date";
-            this.BackupStartDate.MinimumWidth = 6;
-            this.BackupStartDate.Name = "BackupStartDate";
-            this.BackupStartDate.ReadOnly = true;
-            this.BackupStartDate.Width = 112;
+            BackupStartDate.DataPropertyName = "backup_start_date";
+            BackupStartDate.HeaderText = "Backup Start Date";
+            BackupStartDate.MinimumWidth = 6;
+            BackupStartDate.Name = "BackupStartDate";
+            BackupStartDate.ReadOnly = true;
+            BackupStartDate.Width = 112;
             // 
             // TimeSinceLast
             // 
-            this.TimeSinceLast.DataPropertyName = "TimeSinceLast";
-            this.TimeSinceLast.HeaderText = "Time Since Last";
-            this.TimeSinceLast.MinimumWidth = 6;
-            this.TimeSinceLast.Name = "TimeSinceLast";
-            this.TimeSinceLast.ReadOnly = true;
-            this.TimeSinceLast.Width = 127;
+            TimeSinceLast.DataPropertyName = "TimeSinceLast";
+            TimeSinceLast.HeaderText = "Time Since Last";
+            TimeSinceLast.MinimumWidth = 6;
+            TimeSinceLast.Name = "TimeSinceLast";
+            TimeSinceLast.ReadOnly = true;
+            TimeSinceLast.Width = 127;
             // 
             // LatencyOfLast
             // 
-            this.LatencyOfLast.DataPropertyName = "LatencyOfLast";
-            this.LatencyOfLast.HeaderText = "Latency of Last";
-            this.LatencyOfLast.MinimumWidth = 6;
-            this.LatencyOfLast.Name = "LatencyOfLast";
-            this.LatencyOfLast.ReadOnly = true;
-            this.LatencyOfLast.Width = 99;
+            LatencyOfLast.DataPropertyName = "LatencyOfLast";
+            LatencyOfLast.HeaderText = "Latency of Last";
+            LatencyOfLast.MinimumWidth = 6;
+            LatencyOfLast.Name = "LatencyOfLast";
+            LatencyOfLast.ReadOnly = true;
+            LatencyOfLast.Width = 99;
             // 
             // TotalTimeBehind
             // 
-            this.TotalTimeBehind.DataPropertyName = "TotalTimeBehind";
-            this.TotalTimeBehind.HeaderText = "Total Time Behind";
-            this.TotalTimeBehind.MinimumWidth = 6;
-            this.TotalTimeBehind.Name = "TotalTimeBehind";
-            this.TotalTimeBehind.ReadOnly = true;
-            this.TotalTimeBehind.Width = 139;
+            TotalTimeBehind.DataPropertyName = "TotalTimeBehind";
+            TotalTimeBehind.HeaderText = "Total Time Behind";
+            TotalTimeBehind.MinimumWidth = 6;
+            TotalTimeBehind.Name = "TotalTimeBehind";
+            TotalTimeBehind.ReadOnly = true;
+            TotalTimeBehind.Width = 139;
             // 
             // SnapshotAge
             // 
-            this.SnapshotAge.DataPropertyName = "SnapshotAge";
-            this.SnapshotAge.HeaderText = "Snapshot Age";
-            this.SnapshotAge.MinimumWidth = 6;
-            this.SnapshotAge.Name = "SnapshotAge";
-            this.SnapshotAge.ReadOnly = true;
-            this.SnapshotAge.Width = 116;
+            SnapshotAge.DataPropertyName = "SnapshotAge";
+            SnapshotAge.HeaderText = "Snapshot Age";
+            SnapshotAge.MinimumWidth = 6;
+            SnapshotAge.Name = "SnapshotAge";
+            SnapshotAge.ReadOnly = true;
+            SnapshotAge.Width = 116;
             // 
             // SnapshotDate
             // 
-            this.SnapshotDate.DataPropertyName = "SnapshotDate";
-            this.SnapshotDate.HeaderText = "Snapshot Date";
-            this.SnapshotDate.MinimumWidth = 6;
-            this.SnapshotDate.Name = "SnapshotDate";
-            this.SnapshotDate.ReadOnly = true;
-            this.SnapshotDate.Width = 143;
+            SnapshotDate.DataPropertyName = "SnapshotDate";
+            SnapshotDate.HeaderText = "Snapshot Date";
+            SnapshotDate.MinimumWidth = 6;
+            SnapshotDate.Name = "SnapshotDate";
+            SnapshotDate.ReadOnly = true;
+            SnapshotDate.Width = 143;
             // 
             // LastFile
             // 
-            this.LastFile.DataPropertyName = "last_file";
-            this.LastFile.HeaderText = "Last File";
-            this.LastFile.MinimumWidth = 6;
-            this.LastFile.Name = "LastFile";
-            this.LastFile.ReadOnly = true;
-            this.LastFile.Width = 64;
+            LastFile.DataPropertyName = "last_file";
+            LastFile.HeaderText = "Last File";
+            LastFile.MinimumWidth = 6;
+            LastFile.Name = "LastFile";
+            LastFile.ReadOnly = true;
+            LastFile.Width = 64;
             // 
             // ThresholdConfiguredLevel
             // 
-            this.ThresholdConfiguredLevel.DataPropertyName = "ThresholdConfiguredLevel";
-            this.ThresholdConfiguredLevel.HeaderText = "Threshold Configured Level";
-            this.ThresholdConfiguredLevel.MinimumWidth = 6;
-            this.ThresholdConfiguredLevel.Name = "ThresholdConfiguredLevel";
-            this.ThresholdConfiguredLevel.ReadOnly = true;
-            this.ThresholdConfiguredLevel.Width = 163;
+            ThresholdConfiguredLevel.DataPropertyName = "ThresholdConfiguredLevel";
+            ThresholdConfiguredLevel.HeaderText = "Threshold Configured Level";
+            ThresholdConfiguredLevel.MinimumWidth = 6;
+            ThresholdConfiguredLevel.Name = "ThresholdConfiguredLevel";
+            ThresholdConfiguredLevel.ReadOnly = true;
+            ThresholdConfiguredLevel.Width = 163;
             // 
             // Configure
             // 
-            this.Configure.HeaderText = "Configure";
-            this.Configure.MinimumWidth = 6;
-            this.Configure.Name = "Configure";
-            this.Configure.ReadOnly = true;
-            this.Configure.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.Configure.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Configure.Text = "Configure";
-            this.Configure.UseColumnTextForLinkValue = true;
-            this.Configure.Width = 98;
+            Configure.HeaderText = "Configure";
+            Configure.MinimumWidth = 6;
+            Configure.Name = "Configure";
+            Configure.ReadOnly = true;
+            Configure.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            Configure.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            Configure.Text = "Configure";
+            Configure.UseColumnTextForLinkValue = true;
+            Configure.Width = 98;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.tsConfigure,
-            this.tsBack});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(698, 27);
-            this.toolStrip1.TabIndex = 2;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, tsConfigure, tsBack, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(698, 27);
+            toolStrip1.TabIndex = 2;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // tsConfigure
             // 
-            this.tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.configureInstanceThresholdsToolStripMenuItem,
-            this.configureRootThresholdsToolStripMenuItem});
-            this.tsConfigure.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
-            this.tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsConfigure.Name = "tsConfigure";
-            this.tsConfigure.Size = new System.Drawing.Size(34, 24);
-            this.tsConfigure.Text = "Configure";
+            tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { configureInstanceThresholdsToolStripMenuItem, configureRootThresholdsToolStripMenuItem });
+            tsConfigure.Image = Properties.Resources.SettingsOutline_16x;
+            tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsConfigure.Name = "tsConfigure";
+            tsConfigure.Size = new System.Drawing.Size(34, 24);
+            tsConfigure.Text = "Configure";
             // 
             // configureInstanceThresholdsToolStripMenuItem
             // 
-            this.configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
-            this.configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
-            this.configureInstanceThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureInstanceThresholdsToolStripMenuItem_Click);
+            configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
+            configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
+            configureInstanceThresholdsToolStripMenuItem.Click += ConfigureInstanceThresholdsToolStripMenuItem_Click;
             // 
             // configureRootThresholdsToolStripMenuItem
             // 
-            this.configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
-            this.configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
-            this.configureRootThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureRootThresholdsToolStripMenuItem_Click);
+            configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
+            configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
+            configureRootThresholdsToolStripMenuItem.Click += ConfigureRootThresholdsToolStripMenuItem_Click;
             // 
             // tsBack
             // 
-            this.tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsBack.Image = global::DBADashGUI.Properties.Resources.Previous_grey_16x;
-            this.tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsBack.Name = "tsBack";
-            this.tsBack.Size = new System.Drawing.Size(29, 24);
-            this.tsBack.Text = "Back";
-            this.tsBack.Click += new System.EventHandler(this.TsBack_Click);
+            tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsBack.Image = Properties.Resources.Previous_grey_16x;
+            tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsBack.Name = "tsBack";
+            tsBack.Size = new System.Drawing.Size(29, 24);
+            tsBack.Text = "Back";
+            tsBack.Click += TsBack_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += tsTrigger_Click;
             // 
             // dgvSummary
             // 
-            this.dgvSummary.AllowUserToAddRows = false;
-            this.dgvSummary.AllowUserToDeleteRows = false;
-            this.dgvSummary.BackgroundColor = System.Drawing.Color.White;
-            this.dgvSummary.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvSummary.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvSummary.Location = new System.Drawing.Point(0, 0);
-            this.dgvSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvSummary.Name = "dgvSummary";
-            this.dgvSummary.ReadOnly = true;
-            this.dgvSummary.RowHeadersVisible = false;
-            this.dgvSummary.RowHeadersWidth = 51;
-            this.dgvSummary.RowTemplate.Height = 24;
-            this.dgvSummary.Size = new System.Drawing.Size(698, 195);
-            this.dgvSummary.TabIndex = 3;
-            this.dgvSummary.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvSummary_CellContentClick);
-            this.dgvSummary.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvSummary_RowsAdded);
+            dgvSummary.AllowUserToAddRows = false;
+            dgvSummary.AllowUserToDeleteRows = false;
+            dgvSummary.BackgroundColor = System.Drawing.Color.White;
+            dgvSummary.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvSummary.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvSummary.Location = new System.Drawing.Point(0, 0);
+            dgvSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvSummary.Name = "dgvSummary";
+            dgvSummary.ReadOnly = true;
+            dgvSummary.RowHeadersVisible = false;
+            dgvSummary.RowHeadersWidth = 51;
+            dgvSummary.RowTemplate.Height = 24;
+            dgvSummary.Size = new System.Drawing.Size(698, 184);
+            dgvSummary.TabIndex = 3;
+            dgvSummary.CellContentClick += DgvSummary_CellContentClick;
+            dgvSummary.RowsAdded += DgvSummary_RowsAdded;
             // 
             // splitContainer1
             // 
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 27);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer1.Location = new System.Drawing.Point(0, 27);
+            splitContainer1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            splitContainer1.Name = "splitContainer1";
+            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.dgvSummary);
+            splitContainer1.Panel1.Controls.Add(dgvSummary);
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.dgvLogShipping);
-            this.splitContainer1.Panel2.Controls.Add(this.toolStrip2);
-            this.splitContainer1.Size = new System.Drawing.Size(698, 514);
-            this.splitContainer1.SplitterDistance = 195;
-            this.splitContainer1.SplitterWidth = 5;
-            this.splitContainer1.TabIndex = 4;
+            splitContainer1.Panel2.Controls.Add(dgvLogShipping);
+            splitContainer1.Panel2.Controls.Add(toolStrip2);
+            splitContainer1.Size = new System.Drawing.Size(698, 492);
+            splitContainer1.SplitterDistance = 184;
+            splitContainer1.SplitterWidth = 5;
+            splitContainer1.TabIndex = 4;
             // 
             // toolStrip2
             // 
-            this.toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsCopyDetail,
-            this.tsExportExcelDetail,
-            this.statusFilterToolStrip1});
-            this.toolStrip2.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip2.Name = "toolStrip2";
-            this.toolStrip2.Size = new System.Drawing.Size(698, 27);
-            this.toolStrip2.TabIndex = 1;
-            this.toolStrip2.Text = "toolStrip2";
+            toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsCopyDetail, tsExportExcelDetail, statusFilterToolStrip1 });
+            toolStrip2.Location = new System.Drawing.Point(0, 0);
+            toolStrip2.Name = "toolStrip2";
+            toolStrip2.Size = new System.Drawing.Size(698, 27);
+            toolStrip2.TabIndex = 1;
+            toolStrip2.Text = "toolStrip2";
             // 
             // tsCopyDetail
             // 
-            this.tsCopyDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopyDetail.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopyDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopyDetail.Name = "tsCopyDetail";
-            this.tsCopyDetail.Size = new System.Drawing.Size(29, 24);
-            this.tsCopyDetail.Text = "Copy";
-            this.tsCopyDetail.Click += new System.EventHandler(this.TsCopyDetail_Click);
+            tsCopyDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopyDetail.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopyDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopyDetail.Name = "tsCopyDetail";
+            tsCopyDetail.Size = new System.Drawing.Size(29, 24);
+            tsCopyDetail.Text = "Copy";
+            tsCopyDetail.Click += TsCopyDetail_Click;
             // 
             // tsExportExcelDetail
             // 
-            this.tsExportExcelDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExportExcelDetail.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExportExcelDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExportExcelDetail.Name = "tsExportExcelDetail";
-            this.tsExportExcelDetail.Size = new System.Drawing.Size(29, 24);
-            this.tsExportExcelDetail.Text = "Export Excel";
-            this.tsExportExcelDetail.Click += new System.EventHandler(this.TsExportExcelDetail_Click);
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
-            this.dataGridViewTextBoxColumn1.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.Width = 90;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "name";
-            this.dataGridViewTextBoxColumn2.HeaderText = "Database";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.Width = 98;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "StatusDescription";
-            this.dataGridViewTextBoxColumn3.HeaderText = "Status";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.Width = 77;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "restore_date";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Restore Date";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.Width = 111;
-            // 
-            // dataGridViewTextBoxColumn5
-            // 
-            this.dataGridViewTextBoxColumn5.DataPropertyName = "backup_start_date";
-            this.dataGridViewTextBoxColumn5.HeaderText = "Backup Start Date";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.Width = 112;
-            // 
-            // dataGridViewTextBoxColumn6
-            // 
-            this.dataGridViewTextBoxColumn6.DataPropertyName = "TimeSinceLast";
-            this.dataGridViewTextBoxColumn6.HeaderText = "Time Since Last";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.Width = 127;
-            // 
-            // dataGridViewTextBoxColumn7
-            // 
-            this.dataGridViewTextBoxColumn7.DataPropertyName = "LatencyOfLast";
-            this.dataGridViewTextBoxColumn7.HeaderText = "Latency of Last";
-            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            this.dataGridViewTextBoxColumn7.Width = 99;
-            // 
-            // dataGridViewTextBoxColumn8
-            // 
-            this.dataGridViewTextBoxColumn8.DataPropertyName = "TotalTimeBehind";
-            this.dataGridViewTextBoxColumn8.HeaderText = "Total Time Behind";
-            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            this.dataGridViewTextBoxColumn8.Width = 139;
-            // 
-            // dataGridViewTextBoxColumn9
-            // 
-            this.dataGridViewTextBoxColumn9.DataPropertyName = "SnapshotAge";
-            this.dataGridViewTextBoxColumn9.HeaderText = "Snapshot Age";
-            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            this.dataGridViewTextBoxColumn9.Width = 116;
-            // 
-            // dataGridViewTextBoxColumn10
-            // 
-            this.dataGridViewTextBoxColumn10.DataPropertyName = "LogRestoresDate";
-            this.dataGridViewTextBoxColumn10.HeaderText = "Log Restores Date";
-            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            this.dataGridViewTextBoxColumn10.Width = 143;
-            // 
-            // dataGridViewTextBoxColumn11
-            // 
-            this.dataGridViewTextBoxColumn11.DataPropertyName = "last_file";
-            this.dataGridViewTextBoxColumn11.HeaderText = "Last File";
-            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            this.dataGridViewTextBoxColumn11.Width = 64;
-            // 
-            // dataGridViewTextBoxColumn12
-            // 
-            this.dataGridViewTextBoxColumn12.DataPropertyName = "ThresholdConfiguredLevel";
-            this.dataGridViewTextBoxColumn12.HeaderText = "Threshold Configured Level";
-            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            this.dataGridViewTextBoxColumn12.Width = 163;
+            tsExportExcelDetail.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExportExcelDetail.Image = Properties.Resources.excel16x16;
+            tsExportExcelDetail.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExportExcelDetail.Name = "tsExportExcelDetail";
+            tsExportExcelDetail.Size = new System.Drawing.Size(29, 24);
+            tsExportExcelDetail.Text = "Export Excel";
+            tsExportExcelDetail.Click += TsExportExcelDetail_Click;
             // 
             // statusFilterToolStrip1
             // 
-            this.statusFilterToolStrip1.Acknowledged = true;
-            this.statusFilterToolStrip1.AcknowledgedVisible = false;
-            this.statusFilterToolStrip1.Critical = true;
-            this.statusFilterToolStrip1.CriticalVisible = true;
-            this.statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.statusFilterToolStrip1.Image = ((System.Drawing.Image)(resources.GetObject("statusFilterToolStrip1.Image")));
-            this.statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.statusFilterToolStrip1.NA = true;
-            this.statusFilterToolStrip1.Name = "statusFilterToolStrip1";
-            this.statusFilterToolStrip1.NAVisible = true;
-            this.statusFilterToolStrip1.OK = true;
-            this.statusFilterToolStrip1.OKVisible = true;
-            this.statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
-            this.statusFilterToolStrip1.Text = "ALL";
-            this.statusFilterToolStrip1.Warning = true;
-            this.statusFilterToolStrip1.WarningVisible = true;
-            this.statusFilterToolStrip1.UserChangedStatusFilter += new System.EventHandler(this.TsFilter_Click);
+            statusFilterToolStrip1.Acknowledged = false;
+            statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.Critical = true;
+            statusFilterToolStrip1.CriticalVisible = true;
+            statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            statusFilterToolStrip1.Image = (System.Drawing.Image)resources.GetObject("statusFilterToolStrip1.Image");
+            statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            statusFilterToolStrip1.NA = true;
+            statusFilterToolStrip1.Name = "statusFilterToolStrip1";
+            statusFilterToolStrip1.NAVisible = true;
+            statusFilterToolStrip1.OK = true;
+            statusFilterToolStrip1.OKVisible = true;
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
+            statusFilterToolStrip1.Text = "ALL";
+            statusFilterToolStrip1.Warning = true;
+            statusFilterToolStrip1.WarningVisible = true;
+            statusFilterToolStrip1.UserChangedStatusFilter += TsFilter_Click;
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            dataGridViewTextBoxColumn1.DataPropertyName = "Instance";
+            dataGridViewTextBoxColumn1.HeaderText = "Instance";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.Width = 90;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            dataGridViewTextBoxColumn2.DataPropertyName = "name";
+            dataGridViewTextBoxColumn2.HeaderText = "Database";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.Width = 98;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            dataGridViewTextBoxColumn3.DataPropertyName = "StatusDescription";
+            dataGridViewTextBoxColumn3.HeaderText = "Status";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.Width = 77;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            dataGridViewTextBoxColumn4.DataPropertyName = "restore_date";
+            dataGridViewTextBoxColumn4.HeaderText = "Restore Date";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.Width = 111;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            dataGridViewTextBoxColumn5.DataPropertyName = "backup_start_date";
+            dataGridViewTextBoxColumn5.HeaderText = "Backup Start Date";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.Width = 112;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            dataGridViewTextBoxColumn6.DataPropertyName = "TimeSinceLast";
+            dataGridViewTextBoxColumn6.HeaderText = "Time Since Last";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.Width = 127;
+            // 
+            // dataGridViewTextBoxColumn7
+            // 
+            dataGridViewTextBoxColumn7.DataPropertyName = "LatencyOfLast";
+            dataGridViewTextBoxColumn7.HeaderText = "Latency of Last";
+            dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            dataGridViewTextBoxColumn7.Width = 99;
+            // 
+            // dataGridViewTextBoxColumn8
+            // 
+            dataGridViewTextBoxColumn8.DataPropertyName = "TotalTimeBehind";
+            dataGridViewTextBoxColumn8.HeaderText = "Total Time Behind";
+            dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            dataGridViewTextBoxColumn8.Width = 139;
+            // 
+            // dataGridViewTextBoxColumn9
+            // 
+            dataGridViewTextBoxColumn9.DataPropertyName = "SnapshotAge";
+            dataGridViewTextBoxColumn9.HeaderText = "Snapshot Age";
+            dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            dataGridViewTextBoxColumn9.Width = 116;
+            // 
+            // dataGridViewTextBoxColumn10
+            // 
+            dataGridViewTextBoxColumn10.DataPropertyName = "LogRestoresDate";
+            dataGridViewTextBoxColumn10.HeaderText = "Log Restores Date";
+            dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            dataGridViewTextBoxColumn10.Width = 143;
+            // 
+            // dataGridViewTextBoxColumn11
+            // 
+            dataGridViewTextBoxColumn11.DataPropertyName = "last_file";
+            dataGridViewTextBoxColumn11.HeaderText = "Last File";
+            dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            dataGridViewTextBoxColumn11.Width = 64;
+            // 
+            // dataGridViewTextBoxColumn12
+            // 
+            dataGridViewTextBoxColumn12.DataPropertyName = "ThresholdConfiguredLevel";
+            dataGridViewTextBoxColumn12.HeaderText = "Threshold Configured Level";
+            dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            dataGridViewTextBoxColumn12.Width = 163;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
+            statusStrip1.Location = new System.Drawing.Point(0, 519);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Size = new System.Drawing.Size(698, 22);
+            statusStrip1.TabIndex = 5;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatus
+            // 
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 16);
             // 
             // LogShippingControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.splitContainer1);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "LogShippingControl";
-            this.Size = new System.Drawing.Size(698, 541);
-            ((System.ComponentModel.ISupportInitialize)(this.dgvLogShipping)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvSummary)).EndInit();
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            this.splitContainer1.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
-            this.toolStrip2.ResumeLayout(false);
-            this.toolStrip2.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(splitContainer1);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "LogShippingControl";
+            Size = new System.Drawing.Size(698, 541);
+            ((System.ComponentModel.ISupportInitialize)dgvLogShipping).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)dgvSummary).EndInit();
+            splitContainer1.Panel1.ResumeLayout(false);
+            splitContainer1.Panel2.ResumeLayout(false);
+            splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
+            splitContainer1.ResumeLayout(false);
+            toolStrip2.ResumeLayout(false);
+            toolStrip2.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -598,5 +607,8 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn ThresholdConfiguredLevel;
         private System.Windows.Forms.DataGridViewLinkColumn Configure;
         private StatusFilterToolStrip statusFilterToolStrip1;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }

--- a/DBADashGUI/HA/LogShippingControl.resx
+++ b/DBADashGUI/HA/LogShippingControl.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -114,4 +174,7 @@
         sdlgrh3cBIfF12GqXhrCwbTO2nDcNxpvR7NQRXnOAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>267, 17</value>
+  </metadata>
 </root>

--- a/DBADashGUI/LastGoodCheckDB/LastGoodCheckDBControl.Designer.cs
+++ b/DBADashGUI/LastGoodCheckDB/LastGoodCheckDBControl.Designer.cs
@@ -32,249 +32,267 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LastGoodCheckDBControl));
-            this.dgvLastGoodCheckDB = new System.Windows.Forms.DataGridView();
-            this.Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.LastGoodCheckDbTime = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DaysSinceLastGoodCheckDB = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colCreateDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ExcludedFromCheck = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Configure = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsCopy = new System.Windows.Forms.ToolStripButton();
-            this.tsExcel = new System.Windows.Forms.ToolStripButton();
-            this.statusFilterToolStrip1 = new DBADashGUI.StatusFilterToolStrip();
-            this.tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
-            this.configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvLastGoodCheckDB)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            this.SuspendLayout();
+            dgvLastGoodCheckDB = new System.Windows.Forms.DataGridView();
+            Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            LastGoodCheckDbTime = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            DaysSinceLastGoodCheckDB = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colCreateDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ExcludedFromCheck = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Configure = new System.Windows.Forms.DataGridViewLinkColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            statusFilterToolStrip1 = new StatusFilterToolStrip();
+            tsConfigure = new System.Windows.Forms.ToolStripDropDownButton();
+            configureInstanceThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            configureRootThresholdsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
+            ((System.ComponentModel.ISupportInitialize)dgvLastGoodCheckDB).BeginInit();
+            toolStrip1.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // dgvLastGoodCheckDB
             // 
-            this.dgvLastGoodCheckDB.AllowUserToAddRows = false;
-            this.dgvLastGoodCheckDB.AllowUserToDeleteRows = false;
-            this.dgvLastGoodCheckDB.BackgroundColor = System.Drawing.Color.White;
-            this.dgvLastGoodCheckDB.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
+            dgvLastGoodCheckDB.AllowUserToAddRows = false;
+            dgvLastGoodCheckDB.AllowUserToDeleteRows = false;
+            dgvLastGoodCheckDB.BackgroundColor = System.Drawing.Color.White;
+            dgvLastGoodCheckDB.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvLastGoodCheckDB.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.dgvLastGoodCheckDB.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvLastGoodCheckDB.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.Instance,
-            this.Database,
-            this.LastGoodCheckDbTime,
-            this.DaysSinceLastGoodCheckDB,
-            this.colCreateDate,
-            this.ExcludedFromCheck,
-            this.Configure});
+            dgvLastGoodCheckDB.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dgvLastGoodCheckDB.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dgvLastGoodCheckDB.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { Instance, Database, LastGoodCheckDbTime, DaysSinceLastGoodCheckDB, colCreateDate, ExcludedFromCheck, Configure });
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvLastGoodCheckDB.DefaultCellStyle = dataGridViewCellStyle2;
-            this.dgvLastGoodCheckDB.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvLastGoodCheckDB.Location = new System.Drawing.Point(0, 27);
-            this.dgvLastGoodCheckDB.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvLastGoodCheckDB.Name = "dgvLastGoodCheckDB";
-            this.dgvLastGoodCheckDB.ReadOnly = true;
+            dgvLastGoodCheckDB.DefaultCellStyle = dataGridViewCellStyle2;
+            dgvLastGoodCheckDB.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvLastGoodCheckDB.Location = new System.Drawing.Point(0, 27);
+            dgvLastGoodCheckDB.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvLastGoodCheckDB.Name = "dgvLastGoodCheckDB";
+            dgvLastGoodCheckDB.ReadOnly = true;
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvLastGoodCheckDB.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
-            this.dgvLastGoodCheckDB.RowHeadersVisible = false;
-            this.dgvLastGoodCheckDB.RowHeadersWidth = 51;
-            this.dgvLastGoodCheckDB.Size = new System.Drawing.Size(1250, 322);
-            this.dgvLastGoodCheckDB.TabIndex = 0;
-            this.dgvLastGoodCheckDB.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvLastGoodCheckDB_CellContentClick);
-            this.dgvLastGoodCheckDB.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.DgvLastGoodCheckDB_RowsAdded);
+            dgvLastGoodCheckDB.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dgvLastGoodCheckDB.RowHeadersVisible = false;
+            dgvLastGoodCheckDB.RowHeadersWidth = 51;
+            dgvLastGoodCheckDB.Size = new System.Drawing.Size(1250, 300);
+            dgvLastGoodCheckDB.TabIndex = 0;
+            dgvLastGoodCheckDB.CellContentClick += DgvLastGoodCheckDB_CellContentClick;
+            dgvLastGoodCheckDB.RowsAdded += DgvLastGoodCheckDB_RowsAdded;
             // 
             // Instance
             // 
-            this.Instance.DataPropertyName = "InstanceDisplayName";
-            this.Instance.HeaderText = "Instance";
-            this.Instance.MinimumWidth = 6;
-            this.Instance.Name = "Instance";
-            this.Instance.ReadOnly = true;
-            this.Instance.Width = 125;
+            Instance.DataPropertyName = "InstanceDisplayName";
+            Instance.HeaderText = "Instance";
+            Instance.MinimumWidth = 6;
+            Instance.Name = "Instance";
+            Instance.ReadOnly = true;
+            Instance.Width = 125;
             // 
             // Database
             // 
-            this.Database.DataPropertyName = "Name";
-            this.Database.HeaderText = "Database";
-            this.Database.MinimumWidth = 6;
-            this.Database.Name = "Database";
-            this.Database.ReadOnly = true;
-            this.Database.Width = 125;
+            Database.DataPropertyName = "Name";
+            Database.HeaderText = "Database";
+            Database.MinimumWidth = 6;
+            Database.Name = "Database";
+            Database.ReadOnly = true;
+            Database.Width = 125;
             // 
             // LastGoodCheckDbTime
             // 
-            this.LastGoodCheckDbTime.DataPropertyName = "LastGoodCheckDbTimeUTC";
-            this.LastGoodCheckDbTime.HeaderText = "Last Good Check DB";
-            this.LastGoodCheckDbTime.MinimumWidth = 6;
-            this.LastGoodCheckDbTime.Name = "LastGoodCheckDbTime";
-            this.LastGoodCheckDbTime.ReadOnly = true;
-            this.LastGoodCheckDbTime.Width = 125;
+            LastGoodCheckDbTime.DataPropertyName = "LastGoodCheckDbTimeUTC";
+            LastGoodCheckDbTime.HeaderText = "Last Good Check DB";
+            LastGoodCheckDbTime.MinimumWidth = 6;
+            LastGoodCheckDbTime.Name = "LastGoodCheckDbTime";
+            LastGoodCheckDbTime.ReadOnly = true;
+            LastGoodCheckDbTime.Width = 125;
             // 
             // DaysSinceLastGoodCheckDB
             // 
-            this.DaysSinceLastGoodCheckDB.DataPropertyName = "DaysSinceLastGoodCheckDB";
-            this.DaysSinceLastGoodCheckDB.HeaderText = "Days Since Last Good CheckDB";
-            this.DaysSinceLastGoodCheckDB.MinimumWidth = 6;
-            this.DaysSinceLastGoodCheckDB.Name = "DaysSinceLastGoodCheckDB";
-            this.DaysSinceLastGoodCheckDB.ReadOnly = true;
-            this.DaysSinceLastGoodCheckDB.Width = 125;
+            DaysSinceLastGoodCheckDB.DataPropertyName = "DaysSinceLastGoodCheckDB";
+            DaysSinceLastGoodCheckDB.HeaderText = "Days Since Last Good CheckDB";
+            DaysSinceLastGoodCheckDB.MinimumWidth = 6;
+            DaysSinceLastGoodCheckDB.Name = "DaysSinceLastGoodCheckDB";
+            DaysSinceLastGoodCheckDB.ReadOnly = true;
+            DaysSinceLastGoodCheckDB.Width = 125;
             // 
             // colCreateDate
             // 
-            this.colCreateDate.DataPropertyName = "create_date_utc";
-            this.colCreateDate.HeaderText = "Create Date";
-            this.colCreateDate.MinimumWidth = 6;
-            this.colCreateDate.Name = "colCreateDate";
-            this.colCreateDate.ReadOnly = true;
-            this.colCreateDate.Width = 125;
+            colCreateDate.DataPropertyName = "create_date_utc";
+            colCreateDate.HeaderText = "Create Date";
+            colCreateDate.MinimumWidth = 6;
+            colCreateDate.Name = "colCreateDate";
+            colCreateDate.ReadOnly = true;
+            colCreateDate.Width = 125;
             // 
             // ExcludedFromCheck
             // 
-            this.ExcludedFromCheck.DataPropertyName = "LastGoodCheckDBExcludedReason";
-            this.ExcludedFromCheck.HeaderText = "Excluded Reason";
-            this.ExcludedFromCheck.MinimumWidth = 6;
-            this.ExcludedFromCheck.Name = "ExcludedFromCheck";
-            this.ExcludedFromCheck.ReadOnly = true;
-            this.ExcludedFromCheck.Width = 125;
+            ExcludedFromCheck.DataPropertyName = "LastGoodCheckDBExcludedReason";
+            ExcludedFromCheck.HeaderText = "Excluded Reason";
+            ExcludedFromCheck.MinimumWidth = 6;
+            ExcludedFromCheck.Name = "ExcludedFromCheck";
+            ExcludedFromCheck.ReadOnly = true;
+            ExcludedFromCheck.Width = 125;
             // 
             // Configure
             // 
-            this.Configure.HeaderText = "Configure";
-            this.Configure.MinimumWidth = 6;
-            this.Configure.Name = "Configure";
-            this.Configure.ReadOnly = true;
-            this.Configure.Text = "Configure";
-            this.Configure.UseColumnTextForLinkValue = true;
-            this.Configure.Width = 125;
+            Configure.HeaderText = "Configure";
+            Configure.MinimumWidth = 6;
+            Configure.Name = "Configure";
+            Configure.ReadOnly = true;
+            Configure.Text = "Configure";
+            Configure.UseColumnTextForLinkValue = true;
+            Configure.Width = 125;
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsCopy,
-            this.tsExcel,
-            this.statusFilterToolStrip1,
-            this.tsConfigure});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(1250, 27);
-            this.toolStrip1.TabIndex = 4;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, statusFilterToolStrip1, tsConfigure, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(1250, 27);
+            toolStrip1.TabIndex = 4;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsRefresh
             // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsCopy
             // 
-            this.tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsCopy.Image = global::DBADashGUI.Properties.Resources.ASX_Copy_blue_16x;
-            this.tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsCopy.Name = "tsCopy";
-            this.tsCopy.Size = new System.Drawing.Size(29, 24);
-            this.tsCopy.Text = "Copy";
-            this.tsCopy.Click += new System.EventHandler(this.TsCopy_Click);
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy";
+            tsCopy.Click += TsCopy_Click;
             // 
             // tsExcel
             // 
-            this.tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsExcel.Image = global::DBADashGUI.Properties.Resources.excel16x16;
-            this.tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsExcel.Name = "tsExcel";
-            this.tsExcel.Size = new System.Drawing.Size(29, 24);
-            this.tsExcel.Text = "Export Excel";
-            this.tsExcel.Click += new System.EventHandler(this.TsExcel_Click);
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export Excel";
+            tsExcel.Click += TsExcel_Click;
             // 
             // statusFilterToolStrip1
             // 
-            this.statusFilterToolStrip1.Acknowledged = false;
-            this.statusFilterToolStrip1.AcknowledgedVisible = false;
-            this.statusFilterToolStrip1.Critical = true;
-            this.statusFilterToolStrip1.CriticalVisible = true;
-            this.statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            this.statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.statusFilterToolStrip1.Image = ((System.Drawing.Image)(resources.GetObject("statusFilterToolStrip1.Image")));
-            this.statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.statusFilterToolStrip1.NA = true;
-            this.statusFilterToolStrip1.Name = "statusFilterToolStrip1";
-            this.statusFilterToolStrip1.NAVisible = true;
-            this.statusFilterToolStrip1.OK = true;
-            this.statusFilterToolStrip1.OKVisible = true;
-            this.statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
-            this.statusFilterToolStrip1.Text = "ALL";
-            this.statusFilterToolStrip1.Warning = true;
-            this.statusFilterToolStrip1.WarningVisible = true;
-            this.statusFilterToolStrip1.UserChangedStatusFilter += new System.EventHandler(this.Status_Selected);
+            statusFilterToolStrip1.Acknowledged = false;
+            statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.Critical = true;
+            statusFilterToolStrip1.CriticalVisible = true;
+            statusFilterToolStrip1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            statusFilterToolStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            statusFilterToolStrip1.Image = (System.Drawing.Image)resources.GetObject("statusFilterToolStrip1.Image");
+            statusFilterToolStrip1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            statusFilterToolStrip1.NA = true;
+            statusFilterToolStrip1.Name = "statusFilterToolStrip1";
+            statusFilterToolStrip1.NAVisible = true;
+            statusFilterToolStrip1.OK = true;
+            statusFilterToolStrip1.OKVisible = true;
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
+            statusFilterToolStrip1.Text = "ALL";
+            statusFilterToolStrip1.Warning = true;
+            statusFilterToolStrip1.WarningVisible = true;
+            statusFilterToolStrip1.UserChangedStatusFilter += Status_Selected;
             // 
             // tsConfigure
             // 
-            this.tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.configureInstanceThresholdsToolStripMenuItem,
-            this.configureRootThresholdsToolStripMenuItem});
-            this.tsConfigure.Image = global::DBADashGUI.Properties.Resources.SettingsOutline_16x;
-            this.tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsConfigure.Name = "tsConfigure";
-            this.tsConfigure.Size = new System.Drawing.Size(34, 24);
-            this.tsConfigure.Text = "Configure";
+            tsConfigure.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsConfigure.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { configureInstanceThresholdsToolStripMenuItem, configureRootThresholdsToolStripMenuItem });
+            tsConfigure.Image = Properties.Resources.SettingsOutline_16x;
+            tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsConfigure.Name = "tsConfigure";
+            tsConfigure.Size = new System.Drawing.Size(34, 24);
+            tsConfigure.Text = "Configure";
             // 
             // configureInstanceThresholdsToolStripMenuItem
             // 
-            this.configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
-            this.configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
-            this.configureInstanceThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureInstanceThresholdsToolStripMenuItem_Click);
+            configureInstanceThresholdsToolStripMenuItem.Name = "configureInstanceThresholdsToolStripMenuItem";
+            configureInstanceThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureInstanceThresholdsToolStripMenuItem.Text = "Configure Instance Thresholds";
+            configureInstanceThresholdsToolStripMenuItem.Click += ConfigureInstanceThresholdsToolStripMenuItem_Click;
             // 
             // configureRootThresholdsToolStripMenuItem
             // 
-            this.configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
-            this.configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
-            this.configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
-            this.configureRootThresholdsToolStripMenuItem.Click += new System.EventHandler(this.ConfigureRootThresholdsToolStripMenuItem_Click);
+            configureRootThresholdsToolStripMenuItem.Name = "configureRootThresholdsToolStripMenuItem";
+            configureRootThresholdsToolStripMenuItem.Size = new System.Drawing.Size(290, 26);
+            configureRootThresholdsToolStripMenuItem.Text = "Configure Root Thresholds";
+            configureRootThresholdsToolStripMenuItem.Click += ConfigureRootThresholdsToolStripMenuItem_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += TsTrigger_Click;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
+            statusStrip1.Location = new System.Drawing.Point(0, 327);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Size = new System.Drawing.Size(1250, 22);
+            statusStrip1.TabIndex = 5;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStatus
+            // 
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 16);
             // 
             // LastGoodCheckDBControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.dgvLastGoodCheckDB);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "LastGoodCheckDBControl";
-            this.Size = new System.Drawing.Size(1250, 349);
-            this.Load += new System.EventHandler(this.LastGoodCheckDB_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.dgvLastGoodCheckDB)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(dgvLastGoodCheckDB);
+            Controls.Add(toolStrip1);
+            Controls.Add(statusStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "LastGoodCheckDBControl";
+            Size = new System.Drawing.Size(1250, 349);
+            Load += LastGoodCheckDB_Load;
+            ((System.ComponentModel.ISupportInitialize)dgvLastGoodCheckDB).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -295,5 +313,8 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn ExcludedFromCheck;
         private System.Windows.Forms.DataGridViewLinkColumn Configure;
         private StatusFilterToolStrip statusFilterToolStrip1;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel lblStatus;
     }
 }

--- a/DBADashGUI/LastGoodCheckDB/LastGoodCheckDBControl.resx
+++ b/DBADashGUI/LastGoodCheckDB/LastGoodCheckDBControl.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -96,4 +156,7 @@
         sdlgrh3cBIfF12GqXhrCwbTO2nDcNxpvR7NQRXnOAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>143, 17</value>
+  </metadata>
 </root>

--- a/DBADashGUI/Main.Designer.cs
+++ b/DBADashGUI/Main.Designer.cs
@@ -1748,7 +1748,6 @@ namespace DBADashGUI
             // 
             // customChecks1
             // 
-            customChecks1.Context = null;
             customChecks1.Dock = System.Windows.Forms.DockStyle.Fill;
             customChecks1.IncludeCritical = true;
             customChecks1.IncludeNA = false;

--- a/DBADashGUI/SchemaCompare/SchemaSnapshots.Designer.cs
+++ b/DBADashGUI/SchemaCompare/SchemaSnapshots.Designer.cs
@@ -34,622 +34,621 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SchemaSnapshots));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.splitSnapshotSummary = new System.Windows.Forms.SplitContainer();
-            this.gvSnapshots = new System.Windows.Forms.DataGridView();
-            this.dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colDB = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.SnapshotDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ValidatedDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ValidForDays = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.DaysSinceValidation = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colCreated = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Modified = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Dropped = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colExport = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.toolStrip2 = new System.Windows.Forms.ToolStrip();
-            this.tsSummaryBack = new System.Windows.Forms.ToolStripButton();
-            this.tsSummaryPageNum = new System.Windows.Forms.ToolStripLabel();
-            this.tsSummaryNext = new System.Windows.Forms.ToolStripButton();
-            this.toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
-            this.tsSummaryPageSize = new System.Windows.Forms.ToolStripComboBox();
-            this.gvSnapshotsDetail = new System.Windows.Forms.DataGridView();
-            this.colObjectName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colSchemaName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colAction = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colView = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.colDiff = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.dgvInstanceSummary = new System.Windows.Forms.DataGridView();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsRefresh = new System.Windows.Forms.ToolStripButton();
-            this.tsBack = new System.Windows.Forms.ToolStripButton();
-            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colInstance = new System.Windows.Forms.DataGridViewLinkColumn();
-            this.colLastUpdated = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.colLastValidated = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            ((System.ComponentModel.ISupportInitialize)(this.splitSnapshotSummary)).BeginInit();
-            this.splitSnapshotSummary.Panel1.SuspendLayout();
-            this.splitSnapshotSummary.Panel2.SuspendLayout();
-            this.splitSnapshotSummary.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gvSnapshots)).BeginInit();
-            this.toolStrip2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gvSnapshotsDetail)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvInstanceSummary)).BeginInit();
-            this.toolStrip1.SuspendLayout();
-            this.SuspendLayout();
+            splitSnapshotSummary = new System.Windows.Forms.SplitContainer();
+            gvSnapshots = new System.Windows.Forms.DataGridView();
+            toolStrip2 = new System.Windows.Forms.ToolStrip();
+            tsSummaryBack = new System.Windows.Forms.ToolStripButton();
+            tsSummaryPageNum = new System.Windows.Forms.ToolStripLabel();
+            tsSummaryNext = new System.Windows.Forms.ToolStripButton();
+            toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
+            tsSummaryPageSize = new System.Windows.Forms.ToolStripComboBox();
+            lblStatus = new System.Windows.Forms.ToolStripLabel();
+            gvSnapshotsDetail = new System.Windows.Forms.DataGridView();
+            colObjectName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colSchemaName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colAction = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colView = new System.Windows.Forms.DataGridViewLinkColumn();
+            colDiff = new System.Windows.Forms.DataGridViewLinkColumn();
+            dgvInstanceSummary = new System.Windows.Forms.DataGridView();
+            colInstance = new System.Windows.Forms.DataGridViewLinkColumn();
+            colLastUpdated = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colLastValidated = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsBack = new System.Windows.Forms.ToolStripButton();
+            tsTrigger = new System.Windows.Forms.ToolStripButton();
+            dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn6 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn7 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn8 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn9 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn10 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn11 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn12 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn13 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            dataGridViewTextBoxColumn14 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colDB = new System.Windows.Forms.DataGridViewLinkColumn();
+            SnapshotDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ValidatedDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ValidForDays = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            DaysSinceValidation = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colCreated = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Modified = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            Dropped = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colExport = new System.Windows.Forms.DataGridViewLinkColumn();
+            colTriggerSnapshot = new System.Windows.Forms.DataGridViewLinkColumn();
+            ((System.ComponentModel.ISupportInitialize)splitSnapshotSummary).BeginInit();
+            splitSnapshotSummary.Panel1.SuspendLayout();
+            splitSnapshotSummary.Panel2.SuspendLayout();
+            splitSnapshotSummary.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)gvSnapshots).BeginInit();
+            toolStrip2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)gvSnapshotsDetail).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)dgvInstanceSummary).BeginInit();
+            toolStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // splitSnapshotSummary
             // 
-            this.splitSnapshotSummary.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.splitSnapshotSummary.Location = new System.Drawing.Point(0, 255);
-            this.splitSnapshotSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.splitSnapshotSummary.Name = "splitSnapshotSummary";
-            this.splitSnapshotSummary.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            splitSnapshotSummary.Dock = System.Windows.Forms.DockStyle.Bottom;
+            splitSnapshotSummary.Location = new System.Drawing.Point(0, 255);
+            splitSnapshotSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            splitSnapshotSummary.Name = "splitSnapshotSummary";
+            splitSnapshotSummary.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // splitSnapshotSummary.Panel1
             // 
-            this.splitSnapshotSummary.Panel1.Controls.Add(this.gvSnapshots);
-            this.splitSnapshotSummary.Panel1.Controls.Add(this.toolStrip2);
+            splitSnapshotSummary.Panel1.Controls.Add(gvSnapshots);
+            splitSnapshotSummary.Panel1.Controls.Add(toolStrip2);
             // 
             // splitSnapshotSummary.Panel2
             // 
-            this.splitSnapshotSummary.Panel2.Controls.Add(this.gvSnapshotsDetail);
-            this.splitSnapshotSummary.Size = new System.Drawing.Size(2019, 1271);
-            this.splitSnapshotSummary.SplitterDistance = 776;
-            this.splitSnapshotSummary.SplitterWidth = 5;
-            this.splitSnapshotSummary.TabIndex = 1;
+            splitSnapshotSummary.Panel2.Controls.Add(gvSnapshotsDetail);
+            splitSnapshotSummary.Size = new System.Drawing.Size(2019, 1271);
+            splitSnapshotSummary.SplitterDistance = 776;
+            splitSnapshotSummary.SplitterWidth = 5;
+            splitSnapshotSummary.TabIndex = 1;
             // 
             // gvSnapshots
             // 
-            this.gvSnapshots.AllowUserToAddRows = false;
-            this.gvSnapshots.AllowUserToDeleteRows = false;
-            this.gvSnapshots.BackgroundColor = System.Drawing.Color.White;
+            gvSnapshots.AllowUserToAddRows = false;
+            gvSnapshots.AllowUserToDeleteRows = false;
+            gvSnapshots.BackgroundColor = System.Drawing.Color.White;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.gvSnapshots.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
-            this.gvSnapshots.ColumnHeadersHeight = 29;
-            this.gvSnapshots.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.dataGridViewTextBoxColumn14,
-            this.colDB,
-            this.SnapshotDate,
-            this.ValidatedDate,
-            this.ValidForDays,
-            this.DaysSinceValidation,
-            this.colCreated,
-            this.Modified,
-            this.Dropped,
-            this.colExport});
+            gvSnapshots.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            gvSnapshots.ColumnHeadersHeight = 29;
+            gvSnapshots.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { dataGridViewTextBoxColumn14, colDB, SnapshotDate, ValidatedDate, ValidForDays, DaysSinceValidation, colCreated, Modified, Dropped, colExport, colTriggerSnapshot });
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.gvSnapshots.DefaultCellStyle = dataGridViewCellStyle2;
-            this.gvSnapshots.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gvSnapshots.Location = new System.Drawing.Point(0, 0);
-            this.gvSnapshots.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.gvSnapshots.Name = "gvSnapshots";
-            this.gvSnapshots.ReadOnly = true;
+            gvSnapshots.DefaultCellStyle = dataGridViewCellStyle2;
+            gvSnapshots.Dock = System.Windows.Forms.DockStyle.Fill;
+            gvSnapshots.Location = new System.Drawing.Point(0, 0);
+            gvSnapshots.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            gvSnapshots.Name = "gvSnapshots";
+            gvSnapshots.ReadOnly = true;
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.gvSnapshots.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
-            this.gvSnapshots.RowHeadersVisible = false;
-            this.gvSnapshots.RowHeadersWidth = 51;
-            this.gvSnapshots.RowTemplate.Height = 24;
-            this.gvSnapshots.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.gvSnapshots.Size = new System.Drawing.Size(2019, 748);
-            this.gvSnapshots.TabIndex = 0;
-            this.gvSnapshots.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GvSnapshots_CellContentClick);
-            this.gvSnapshots.SelectionChanged += new System.EventHandler(this.GvSnapshots_SelectionChanged);
-            // 
-            // dataGridViewTextBoxColumn14
-            // 
-            this.dataGridViewTextBoxColumn14.DataPropertyName = "InstanceGroupName";
-            this.dataGridViewTextBoxColumn14.HeaderText = "Instance";
-            this.dataGridViewTextBoxColumn14.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
-            this.dataGridViewTextBoxColumn14.ReadOnly = true;
-            this.dataGridViewTextBoxColumn14.Width = 125;
-            // 
-            // colDB
-            // 
-            this.colDB.DataPropertyName = "DB";
-            this.colDB.HeaderText = "DB";
-            this.colDB.MinimumWidth = 6;
-            this.colDB.Name = "colDB";
-            this.colDB.ReadOnly = true;
-            this.colDB.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colDB.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colDB.Width = 56;
-            // 
-            // SnapshotDate
-            // 
-            this.SnapshotDate.DataPropertyName = "SnapshotDate";
-            this.SnapshotDate.HeaderText = "Snapshot Date";
-            this.SnapshotDate.MinimumWidth = 6;
-            this.SnapshotDate.Name = "SnapshotDate";
-            this.SnapshotDate.ReadOnly = true;
-            this.SnapshotDate.Width = 131;
-            // 
-            // ValidatedDate
-            // 
-            this.ValidatedDate.DataPropertyName = "ValidatedDate";
-            this.ValidatedDate.HeaderText = "Validated Date";
-            this.ValidatedDate.MinimumWidth = 6;
-            this.ValidatedDate.Name = "ValidatedDate";
-            this.ValidatedDate.ReadOnly = true;
-            this.ValidatedDate.Width = 130;
-            // 
-            // ValidForDays
-            // 
-            this.ValidForDays.DataPropertyName = "ValidForDays";
-            this.ValidForDays.HeaderText = "Valid For (Days)";
-            this.ValidForDays.MinimumWidth = 6;
-            this.ValidForDays.Name = "ValidForDays";
-            this.ValidForDays.ReadOnly = true;
-            this.ValidForDays.Width = 125;
-            // 
-            // DaysSinceValidation
-            // 
-            this.DaysSinceValidation.DataPropertyName = "DaysSinceValidation";
-            this.DaysSinceValidation.HeaderText = "Days Since Validation";
-            this.DaysSinceValidation.MinimumWidth = 6;
-            this.DaysSinceValidation.Name = "DaysSinceValidation";
-            this.DaysSinceValidation.ReadOnly = true;
-            this.DaysSinceValidation.Width = 125;
-            // 
-            // colCreated
-            // 
-            this.colCreated.DataPropertyName = "Created";
-            this.colCreated.HeaderText = "Created";
-            this.colCreated.MinimumWidth = 6;
-            this.colCreated.Name = "colCreated";
-            this.colCreated.ReadOnly = true;
-            this.colCreated.Width = 87;
-            // 
-            // Modified
-            // 
-            this.Modified.DataPropertyName = "Modified";
-            this.Modified.HeaderText = "Modified";
-            this.Modified.MinimumWidth = 6;
-            this.Modified.Name = "Modified";
-            this.Modified.ReadOnly = true;
-            this.Modified.Width = 90;
-            // 
-            // Dropped
-            // 
-            this.Dropped.DataPropertyName = "Dropped";
-            this.Dropped.HeaderText = "Dropped";
-            this.Dropped.MinimumWidth = 6;
-            this.Dropped.Name = "Dropped";
-            this.Dropped.ReadOnly = true;
-            this.Dropped.Width = 92;
-            // 
-            // colExport
-            // 
-            this.colExport.HeaderText = "Export";
-            this.colExport.MinimumWidth = 6;
-            this.colExport.Name = "colExport";
-            this.colExport.ReadOnly = true;
-            this.colExport.Text = "Export";
-            this.colExport.ToolTipText = "Export DB Schema to disk";
-            this.colExport.UseColumnTextForLinkValue = true;
-            this.colExport.Width = 125;
+            gvSnapshots.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            gvSnapshots.RowHeadersVisible = false;
+            gvSnapshots.RowHeadersWidth = 51;
+            gvSnapshots.RowTemplate.Height = 24;
+            gvSnapshots.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            gvSnapshots.Size = new System.Drawing.Size(2019, 748);
+            gvSnapshots.TabIndex = 0;
+            gvSnapshots.CellContentClick += GvSnapshots_CellContentClick;
+            gvSnapshots.SelectionChanged += GvSnapshots_SelectionChanged;
             // 
             // toolStrip2
             // 
-            this.toolStrip2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsSummaryBack,
-            this.tsSummaryPageNum,
-            this.tsSummaryNext,
-            this.toolStripLabel3,
-            this.tsSummaryPageSize});
-            this.toolStrip2.Location = new System.Drawing.Point(0, 748);
-            this.toolStrip2.Name = "toolStrip2";
-            this.toolStrip2.Size = new System.Drawing.Size(2019, 28);
-            this.toolStrip2.TabIndex = 2;
-            this.toolStrip2.Text = "toolStrip2";
+            toolStrip2.Dock = System.Windows.Forms.DockStyle.Bottom;
+            toolStrip2.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsSummaryBack, tsSummaryPageNum, tsSummaryNext, toolStripLabel3, tsSummaryPageSize, lblStatus });
+            toolStrip2.Location = new System.Drawing.Point(0, 748);
+            toolStrip2.Name = "toolStrip2";
+            toolStrip2.Size = new System.Drawing.Size(2019, 28);
+            toolStrip2.TabIndex = 2;
+            toolStrip2.Text = "toolStrip2";
             // 
             // tsSummaryBack
             // 
-            this.tsSummaryBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsSummaryBack.Image = ((System.Drawing.Image)(resources.GetObject("tsSummaryBack.Image")));
-            this.tsSummaryBack.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsSummaryBack.Name = "tsSummaryBack";
-            this.tsSummaryBack.Size = new System.Drawing.Size(29, 25);
-            this.tsSummaryBack.Text = "Previous";
-            this.tsSummaryBack.Click += new System.EventHandler(this.TsSummaryBack_Click);
+            tsSummaryBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsSummaryBack.Image = (System.Drawing.Image)resources.GetObject("tsSummaryBack.Image");
+            tsSummaryBack.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsSummaryBack.Name = "tsSummaryBack";
+            tsSummaryBack.Size = new System.Drawing.Size(29, 25);
+            tsSummaryBack.Text = "Previous";
+            tsSummaryBack.Click += TsSummaryBack_Click;
             // 
             // tsSummaryPageNum
             // 
-            this.tsSummaryPageNum.Name = "tsSummaryPageNum";
-            this.tsSummaryPageNum.Size = new System.Drawing.Size(53, 25);
-            this.tsSummaryPageNum.Text = "Page 1";
+            tsSummaryPageNum.Name = "tsSummaryPageNum";
+            tsSummaryPageNum.Size = new System.Drawing.Size(53, 25);
+            tsSummaryPageNum.Text = "Page 1";
             // 
             // tsSummaryNext
             // 
-            this.tsSummaryNext.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsSummaryNext.Image = ((System.Drawing.Image)(resources.GetObject("tsSummaryNext.Image")));
-            this.tsSummaryNext.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsSummaryNext.Name = "tsSummaryNext";
-            this.tsSummaryNext.Size = new System.Drawing.Size(29, 25);
-            this.tsSummaryNext.Text = "Next";
-            this.tsSummaryNext.Click += new System.EventHandler(this.TsSummaryNext_Click);
+            tsSummaryNext.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsSummaryNext.Image = (System.Drawing.Image)resources.GetObject("tsSummaryNext.Image");
+            tsSummaryNext.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsSummaryNext.Name = "tsSummaryNext";
+            tsSummaryNext.Size = new System.Drawing.Size(29, 25);
+            tsSummaryNext.Text = "Next";
+            tsSummaryNext.Click += TsSummaryNext_Click;
             // 
             // toolStripLabel3
             // 
-            this.toolStripLabel3.Name = "toolStripLabel3";
-            this.toolStripLabel3.Size = new System.Drawing.Size(75, 25);
-            this.toolStripLabel3.Text = "Page Size:";
+            toolStripLabel3.Name = "toolStripLabel3";
+            toolStripLabel3.Size = new System.Drawing.Size(75, 25);
+            toolStripLabel3.Text = "Page Size:";
             // 
             // tsSummaryPageSize
             // 
-            this.tsSummaryPageSize.Items.AddRange(new object[] {
-            "100",
-            "200",
-            "500",
-            "1000",
-            "5000"});
-            this.tsSummaryPageSize.Name = "tsSummaryPageSize";
-            this.tsSummaryPageSize.Size = new System.Drawing.Size(121, 28);
-            this.tsSummaryPageSize.Text = "100";
-            this.tsSummaryPageSize.Validated += new System.EventHandler(this.TsSummaryPageSize_Validated);
+            tsSummaryPageSize.Items.AddRange(new object[] { "100", "200", "500", "1000", "5000" });
+            tsSummaryPageSize.Name = "tsSummaryPageSize";
+            tsSummaryPageSize.Size = new System.Drawing.Size(121, 28);
+            tsSummaryPageSize.Text = "100";
+            tsSummaryPageSize.Validated += TsSummaryPageSize_Validated;
+            // 
+            // lblStatus
+            // 
+            lblStatus.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            lblStatus.Name = "lblStatus";
+            lblStatus.Size = new System.Drawing.Size(0, 25);
             // 
             // gvSnapshotsDetail
             // 
-            this.gvSnapshotsDetail.AllowUserToAddRows = false;
-            this.gvSnapshotsDetail.AllowUserToDeleteRows = false;
-            this.gvSnapshotsDetail.BackgroundColor = System.Drawing.Color.White;
+            gvSnapshotsDetail.AllowUserToAddRows = false;
+            gvSnapshotsDetail.AllowUserToDeleteRows = false;
+            gvSnapshotsDetail.BackgroundColor = System.Drawing.Color.White;
             dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.gvSnapshotsDetail.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle4;
-            this.gvSnapshotsDetail.ColumnHeadersHeight = 29;
-            this.gvSnapshotsDetail.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.colObjectName,
-            this.colSchemaName,
-            this.colAction,
-            this.colView,
-            this.colDiff});
+            gvSnapshotsDetail.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle4;
+            gvSnapshotsDetail.ColumnHeadersHeight = 29;
+            gvSnapshotsDetail.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { colObjectName, colSchemaName, colAction, colView, colDiff });
             dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F);
             dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.gvSnapshotsDetail.DefaultCellStyle = dataGridViewCellStyle5;
-            this.gvSnapshotsDetail.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.gvSnapshotsDetail.Location = new System.Drawing.Point(0, 0);
-            this.gvSnapshotsDetail.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.gvSnapshotsDetail.Name = "gvSnapshotsDetail";
-            this.gvSnapshotsDetail.ReadOnly = true;
-            this.gvSnapshotsDetail.RowHeadersVisible = false;
-            this.gvSnapshotsDetail.RowHeadersWidth = 51;
-            this.gvSnapshotsDetail.RowTemplate.Height = 24;
-            this.gvSnapshotsDetail.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
-            this.gvSnapshotsDetail.Size = new System.Drawing.Size(2019, 490);
-            this.gvSnapshotsDetail.TabIndex = 0;
-            this.gvSnapshotsDetail.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GvSnapshotsDetail_CellContentClick);
+            gvSnapshotsDetail.DefaultCellStyle = dataGridViewCellStyle5;
+            gvSnapshotsDetail.Dock = System.Windows.Forms.DockStyle.Fill;
+            gvSnapshotsDetail.Location = new System.Drawing.Point(0, 0);
+            gvSnapshotsDetail.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            gvSnapshotsDetail.Name = "gvSnapshotsDetail";
+            gvSnapshotsDetail.ReadOnly = true;
+            gvSnapshotsDetail.RowHeadersVisible = false;
+            gvSnapshotsDetail.RowHeadersWidth = 51;
+            gvSnapshotsDetail.RowTemplate.Height = 24;
+            gvSnapshotsDetail.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            gvSnapshotsDetail.Size = new System.Drawing.Size(2019, 490);
+            gvSnapshotsDetail.TabIndex = 0;
+            gvSnapshotsDetail.CellContentClick += GvSnapshotsDetail_CellContentClick;
             // 
             // colObjectName
             // 
-            this.colObjectName.DataPropertyName = "ObjectName";
-            this.colObjectName.HeaderText = "Object Name";
-            this.colObjectName.MinimumWidth = 6;
-            this.colObjectName.Name = "colObjectName";
-            this.colObjectName.ReadOnly = true;
-            this.colObjectName.Width = 119;
+            colObjectName.DataPropertyName = "ObjectName";
+            colObjectName.HeaderText = "Object Name";
+            colObjectName.MinimumWidth = 6;
+            colObjectName.Name = "colObjectName";
+            colObjectName.ReadOnly = true;
+            colObjectName.Width = 119;
             // 
             // colSchemaName
             // 
-            this.colSchemaName.DataPropertyName = "SchemaName";
-            this.colSchemaName.HeaderText = "Schema Name";
-            this.colSchemaName.MinimumWidth = 6;
-            this.colSchemaName.Name = "colSchemaName";
-            this.colSchemaName.ReadOnly = true;
-            this.colSchemaName.Width = 129;
+            colSchemaName.DataPropertyName = "SchemaName";
+            colSchemaName.HeaderText = "Schema Name";
+            colSchemaName.MinimumWidth = 6;
+            colSchemaName.Name = "colSchemaName";
+            colSchemaName.ReadOnly = true;
+            colSchemaName.Width = 129;
             // 
             // colAction
             // 
-            this.colAction.DataPropertyName = "Action";
-            this.colAction.HeaderText = "Action";
-            this.colAction.MinimumWidth = 6;
-            this.colAction.Name = "colAction";
-            this.colAction.ReadOnly = true;
-            this.colAction.Width = 76;
+            colAction.DataPropertyName = "Action";
+            colAction.HeaderText = "Action";
+            colAction.MinimumWidth = 6;
+            colAction.Name = "colAction";
+            colAction.ReadOnly = true;
+            colAction.Width = 76;
             // 
             // colView
             // 
-            this.colView.DataPropertyName = "newDDLID";
-            this.colView.HeaderText = "View";
-            this.colView.MinimumWidth = 6;
-            this.colView.Name = "colView";
-            this.colView.ReadOnly = true;
-            this.colView.Text = "View";
-            this.colView.UseColumnTextForLinkValue = true;
-            this.colView.Width = 125;
+            colView.DataPropertyName = "newDDLID";
+            colView.HeaderText = "View";
+            colView.MinimumWidth = 6;
+            colView.Name = "colView";
+            colView.ReadOnly = true;
+            colView.Text = "View";
+            colView.UseColumnTextForLinkValue = true;
+            colView.Width = 125;
             // 
             // colDiff
             // 
-            this.colDiff.DataPropertyName = "OldDDLID";
-            this.colDiff.HeaderText = "Diff";
-            this.colDiff.MinimumWidth = 6;
-            this.colDiff.Name = "colDiff";
-            this.colDiff.ReadOnly = true;
-            this.colDiff.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colDiff.Text = "Diff";
-            this.colDiff.UseColumnTextForLinkValue = true;
-            this.colDiff.Width = 125;
+            colDiff.DataPropertyName = "OldDDLID";
+            colDiff.HeaderText = "Diff";
+            colDiff.MinimumWidth = 6;
+            colDiff.Name = "colDiff";
+            colDiff.ReadOnly = true;
+            colDiff.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colDiff.Text = "Diff";
+            colDiff.UseColumnTextForLinkValue = true;
+            colDiff.Width = 125;
             // 
             // dgvInstanceSummary
             // 
-            this.dgvInstanceSummary.AllowUserToAddRows = false;
-            this.dgvInstanceSummary.AllowUserToDeleteRows = false;
-            this.dgvInstanceSummary.BackgroundColor = System.Drawing.Color.White;
-            this.dgvInstanceSummary.ColumnHeadersHeight = 29;
-            this.dgvInstanceSummary.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.colInstance,
-            this.colLastUpdated,
-            this.colLastValidated});
-            this.dgvInstanceSummary.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.dgvInstanceSummary.Location = new System.Drawing.Point(0, 27);
-            this.dgvInstanceSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.dgvInstanceSummary.Name = "dgvInstanceSummary";
-            this.dgvInstanceSummary.ReadOnly = true;
-            this.dgvInstanceSummary.RowHeadersVisible = false;
-            this.dgvInstanceSummary.RowHeadersWidth = 51;
-            this.dgvInstanceSummary.RowTemplate.Height = 24;
-            this.dgvInstanceSummary.Size = new System.Drawing.Size(2019, 228);
-            this.dgvInstanceSummary.TabIndex = 3;
-            this.dgvInstanceSummary.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.DgvInstanceSummary_CellContentClick);
-            // 
-            // toolStrip1
-            // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsRefresh,
-            this.tsBack});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(2019, 27);
-            this.toolStrip1.TabIndex = 4;
-            this.toolStrip1.Text = "toolStrip1";
-            // 
-            // tsRefresh
-            // 
-            this.tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsRefresh.Image = global::DBADashGUI.Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            this.tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsRefresh.Name = "tsRefresh";
-            this.tsRefresh.Size = new System.Drawing.Size(29, 24);
-            this.tsRefresh.Text = "Refresh";
-            this.tsRefresh.Click += new System.EventHandler(this.TsRefresh_Click);
-            // 
-            // tsBack
-            // 
-            this.tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsBack.Image = global::DBADashGUI.Properties.Resources.Previous_grey_16x;
-            this.tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsBack.Name = "tsBack";
-            this.tsBack.Size = new System.Drawing.Size(29, 24);
-            this.tsBack.Text = "Up level";
-            this.tsBack.Click += new System.EventHandler(this.TsBack_Click);
-            // 
-            // dataGridViewTextBoxColumn1
-            // 
-            this.dataGridViewTextBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn1.DataPropertyName = "DB";
-            this.dataGridViewTextBoxColumn1.HeaderText = "DB";
-            this.dataGridViewTextBoxColumn1.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-            this.dataGridViewTextBoxColumn1.ReadOnly = true;
-            this.dataGridViewTextBoxColumn1.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "SnapshotDate";
-            this.dataGridViewTextBoxColumn2.HeaderText = "Snapshot Date";
-            this.dataGridViewTextBoxColumn2.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
-            this.dataGridViewTextBoxColumn2.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "ValidatedDate";
-            this.dataGridViewTextBoxColumn3.HeaderText = "Validated Date";
-            this.dataGridViewTextBoxColumn3.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "ValidForDays";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Valid For (Days)";
-            this.dataGridViewTextBoxColumn4.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn5
-            // 
-            this.dataGridViewTextBoxColumn5.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn5.DataPropertyName = "DaysSinceValidation";
-            this.dataGridViewTextBoxColumn5.HeaderText = "Days Since Validation";
-            this.dataGridViewTextBoxColumn5.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-            this.dataGridViewTextBoxColumn5.ReadOnly = true;
-            this.dataGridViewTextBoxColumn5.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn6
-            // 
-            this.dataGridViewTextBoxColumn6.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn6.DataPropertyName = "Created";
-            this.dataGridViewTextBoxColumn6.HeaderText = "Created";
-            this.dataGridViewTextBoxColumn6.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
-            this.dataGridViewTextBoxColumn6.ReadOnly = true;
-            this.dataGridViewTextBoxColumn6.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn7
-            // 
-            this.dataGridViewTextBoxColumn7.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn7.DataPropertyName = "Modified";
-            this.dataGridViewTextBoxColumn7.HeaderText = "Modified";
-            this.dataGridViewTextBoxColumn7.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
-            this.dataGridViewTextBoxColumn7.ReadOnly = true;
-            this.dataGridViewTextBoxColumn7.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn8
-            // 
-            this.dataGridViewTextBoxColumn8.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn8.DataPropertyName = "Dropped";
-            this.dataGridViewTextBoxColumn8.HeaderText = "Dropped";
-            this.dataGridViewTextBoxColumn8.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
-            this.dataGridViewTextBoxColumn8.ReadOnly = true;
-            this.dataGridViewTextBoxColumn8.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn9
-            // 
-            this.dataGridViewTextBoxColumn9.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn9.DataPropertyName = "ObjectName";
-            this.dataGridViewTextBoxColumn9.HeaderText = "Object Name";
-            this.dataGridViewTextBoxColumn9.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
-            this.dataGridViewTextBoxColumn9.ReadOnly = true;
-            this.dataGridViewTextBoxColumn9.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn10
-            // 
-            this.dataGridViewTextBoxColumn10.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn10.DataPropertyName = "SchemaName";
-            this.dataGridViewTextBoxColumn10.HeaderText = "Schema Name";
-            this.dataGridViewTextBoxColumn10.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
-            this.dataGridViewTextBoxColumn10.ReadOnly = true;
-            this.dataGridViewTextBoxColumn10.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn11
-            // 
-            this.dataGridViewTextBoxColumn11.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn11.DataPropertyName = "Action";
-            this.dataGridViewTextBoxColumn11.HeaderText = "Action";
-            this.dataGridViewTextBoxColumn11.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
-            this.dataGridViewTextBoxColumn11.ReadOnly = true;
-            this.dataGridViewTextBoxColumn11.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn12
-            // 
-            this.dataGridViewTextBoxColumn12.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
-            this.dataGridViewTextBoxColumn12.DataPropertyName = "SchemaName";
-            this.dataGridViewTextBoxColumn12.HeaderText = "Schema Name";
-            this.dataGridViewTextBoxColumn12.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
-            this.dataGridViewTextBoxColumn12.ReadOnly = true;
-            this.dataGridViewTextBoxColumn12.Width = 125;
-            // 
-            // dataGridViewTextBoxColumn13
-            // 
-            this.dataGridViewTextBoxColumn13.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.dataGridViewTextBoxColumn13.DataPropertyName = "Action";
-            this.dataGridViewTextBoxColumn13.HeaderText = "Action";
-            this.dataGridViewTextBoxColumn13.MinimumWidth = 6;
-            this.dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
-            this.dataGridViewTextBoxColumn13.ReadOnly = true;
-            this.dataGridViewTextBoxColumn13.Width = 125;
+            dgvInstanceSummary.AllowUserToAddRows = false;
+            dgvInstanceSummary.AllowUserToDeleteRows = false;
+            dgvInstanceSummary.BackgroundColor = System.Drawing.Color.White;
+            dgvInstanceSummary.ColumnHeadersHeight = 29;
+            dgvInstanceSummary.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { colInstance, colLastUpdated, colLastValidated });
+            dgvInstanceSummary.Dock = System.Windows.Forms.DockStyle.Fill;
+            dgvInstanceSummary.Location = new System.Drawing.Point(0, 27);
+            dgvInstanceSummary.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            dgvInstanceSummary.Name = "dgvInstanceSummary";
+            dgvInstanceSummary.ReadOnly = true;
+            dgvInstanceSummary.RowHeadersVisible = false;
+            dgvInstanceSummary.RowHeadersWidth = 51;
+            dgvInstanceSummary.RowTemplate.Height = 24;
+            dgvInstanceSummary.Size = new System.Drawing.Size(2019, 228);
+            dgvInstanceSummary.TabIndex = 3;
+            dgvInstanceSummary.CellContentClick += DgvInstanceSummary_CellContentClick;
             // 
             // colInstance
             // 
-            this.colInstance.DataPropertyName = "InstanceGroupName";
-            this.colInstance.HeaderText = "Instance";
-            this.colInstance.MinimumWidth = 6;
-            this.colInstance.Name = "colInstance";
-            this.colInstance.ReadOnly = true;
-            this.colInstance.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.colInstance.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.colInstance.Width = 90;
+            colInstance.DataPropertyName = "InstanceGroupName";
+            colInstance.HeaderText = "Instance";
+            colInstance.MinimumWidth = 6;
+            colInstance.Name = "colInstance";
+            colInstance.ReadOnly = true;
+            colInstance.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colInstance.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colInstance.Width = 90;
             // 
             // colLastUpdated
             // 
-            this.colLastUpdated.DataPropertyName = "LastUpdated";
-            this.colLastUpdated.HeaderText = "Last Updated";
-            this.colLastUpdated.MinimumWidth = 6;
-            this.colLastUpdated.Name = "colLastUpdated";
-            this.colLastUpdated.ReadOnly = true;
-            this.colLastUpdated.Width = 122;
+            colLastUpdated.DataPropertyName = "LastUpdated";
+            colLastUpdated.HeaderText = "Last Updated";
+            colLastUpdated.MinimumWidth = 6;
+            colLastUpdated.Name = "colLastUpdated";
+            colLastUpdated.ReadOnly = true;
+            colLastUpdated.Width = 122;
             // 
             // colLastValidated
             // 
-            this.colLastValidated.DataPropertyName = "LastValidated";
-            this.colLastValidated.HeaderText = "Last Validated";
-            this.colLastValidated.MinimumWidth = 6;
-            this.colLastValidated.Name = "colLastValidated";
-            this.colLastValidated.ReadOnly = true;
-            this.colLastValidated.Width = 127;
+            colLastValidated.DataPropertyName = "LastValidated";
+            colLastValidated.HeaderText = "Last Validated";
+            colLastValidated.MinimumWidth = 6;
+            colLastValidated.Name = "colLastValidated";
+            colLastValidated.ReadOnly = true;
+            colLastValidated.Width = 127;
+            // 
+            // toolStrip1
+            // 
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsBack, tsTrigger });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(2019, 27);
+            toolStrip1.TabIndex = 4;
+            toolStrip1.Text = "toolStrip1";
+            // 
+            // tsRefresh
+            // 
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
+            // 
+            // tsBack
+            // 
+            tsBack.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsBack.Image = Properties.Resources.Previous_grey_16x;
+            tsBack.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsBack.Name = "tsBack";
+            tsBack.Size = new System.Drawing.Size(29, 24);
+            tsBack.Text = "Up level";
+            tsBack.Click += TsBack_Click;
+            // 
+            // tsTrigger
+            // 
+            tsTrigger.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
+            tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTrigger.Name = "tsTrigger";
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
+            tsTrigger.Text = "Trigger Collection";
+            tsTrigger.Visible = false;
+            tsTrigger.Click += tsTrigger_Click;
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            dataGridViewTextBoxColumn1.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn1.DataPropertyName = "DB";
+            dataGridViewTextBoxColumn1.HeaderText = "DB";
+            dataGridViewTextBoxColumn1.MinimumWidth = 6;
+            dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            dataGridViewTextBoxColumn1.ReadOnly = true;
+            dataGridViewTextBoxColumn1.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn2.DataPropertyName = "SnapshotDate";
+            dataGridViewTextBoxColumn2.HeaderText = "Snapshot Date";
+            dataGridViewTextBoxColumn2.MinimumWidth = 6;
+            dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            dataGridViewTextBoxColumn2.ReadOnly = true;
+            dataGridViewTextBoxColumn2.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            dataGridViewTextBoxColumn3.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn3.DataPropertyName = "ValidatedDate";
+            dataGridViewTextBoxColumn3.HeaderText = "Validated Date";
+            dataGridViewTextBoxColumn3.MinimumWidth = 6;
+            dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            dataGridViewTextBoxColumn3.ReadOnly = true;
+            dataGridViewTextBoxColumn3.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            dataGridViewTextBoxColumn4.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn4.DataPropertyName = "ValidForDays";
+            dataGridViewTextBoxColumn4.HeaderText = "Valid For (Days)";
+            dataGridViewTextBoxColumn4.MinimumWidth = 6;
+            dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            dataGridViewTextBoxColumn4.ReadOnly = true;
+            dataGridViewTextBoxColumn4.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            dataGridViewTextBoxColumn5.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn5.DataPropertyName = "DaysSinceValidation";
+            dataGridViewTextBoxColumn5.HeaderText = "Days Since Validation";
+            dataGridViewTextBoxColumn5.MinimumWidth = 6;
+            dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            dataGridViewTextBoxColumn5.ReadOnly = true;
+            dataGridViewTextBoxColumn5.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn6
+            // 
+            dataGridViewTextBoxColumn6.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn6.DataPropertyName = "Created";
+            dataGridViewTextBoxColumn6.HeaderText = "Created";
+            dataGridViewTextBoxColumn6.MinimumWidth = 6;
+            dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
+            dataGridViewTextBoxColumn6.ReadOnly = true;
+            dataGridViewTextBoxColumn6.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn7
+            // 
+            dataGridViewTextBoxColumn7.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn7.DataPropertyName = "Modified";
+            dataGridViewTextBoxColumn7.HeaderText = "Modified";
+            dataGridViewTextBoxColumn7.MinimumWidth = 6;
+            dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
+            dataGridViewTextBoxColumn7.ReadOnly = true;
+            dataGridViewTextBoxColumn7.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn8
+            // 
+            dataGridViewTextBoxColumn8.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn8.DataPropertyName = "Dropped";
+            dataGridViewTextBoxColumn8.HeaderText = "Dropped";
+            dataGridViewTextBoxColumn8.MinimumWidth = 6;
+            dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
+            dataGridViewTextBoxColumn8.ReadOnly = true;
+            dataGridViewTextBoxColumn8.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn9
+            // 
+            dataGridViewTextBoxColumn9.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn9.DataPropertyName = "ObjectName";
+            dataGridViewTextBoxColumn9.HeaderText = "Object Name";
+            dataGridViewTextBoxColumn9.MinimumWidth = 6;
+            dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
+            dataGridViewTextBoxColumn9.ReadOnly = true;
+            dataGridViewTextBoxColumn9.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn10
+            // 
+            dataGridViewTextBoxColumn10.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn10.DataPropertyName = "SchemaName";
+            dataGridViewTextBoxColumn10.HeaderText = "Schema Name";
+            dataGridViewTextBoxColumn10.MinimumWidth = 6;
+            dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
+            dataGridViewTextBoxColumn10.ReadOnly = true;
+            dataGridViewTextBoxColumn10.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn11
+            // 
+            dataGridViewTextBoxColumn11.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn11.DataPropertyName = "Action";
+            dataGridViewTextBoxColumn11.HeaderText = "Action";
+            dataGridViewTextBoxColumn11.MinimumWidth = 6;
+            dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
+            dataGridViewTextBoxColumn11.ReadOnly = true;
+            dataGridViewTextBoxColumn11.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn12
+            // 
+            dataGridViewTextBoxColumn12.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.DisplayedCells;
+            dataGridViewTextBoxColumn12.DataPropertyName = "SchemaName";
+            dataGridViewTextBoxColumn12.HeaderText = "Schema Name";
+            dataGridViewTextBoxColumn12.MinimumWidth = 6;
+            dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
+            dataGridViewTextBoxColumn12.ReadOnly = true;
+            dataGridViewTextBoxColumn12.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn13
+            // 
+            dataGridViewTextBoxColumn13.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            dataGridViewTextBoxColumn13.DataPropertyName = "Action";
+            dataGridViewTextBoxColumn13.HeaderText = "Action";
+            dataGridViewTextBoxColumn13.MinimumWidth = 6;
+            dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
+            dataGridViewTextBoxColumn13.ReadOnly = true;
+            dataGridViewTextBoxColumn13.Width = 125;
+            // 
+            // dataGridViewTextBoxColumn14
+            // 
+            dataGridViewTextBoxColumn14.DataPropertyName = "InstanceGroupName";
+            dataGridViewTextBoxColumn14.HeaderText = "Instance";
+            dataGridViewTextBoxColumn14.MinimumWidth = 6;
+            dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
+            dataGridViewTextBoxColumn14.ReadOnly = true;
+            dataGridViewTextBoxColumn14.Width = 125;
+            // 
+            // colDB
+            // 
+            colDB.DataPropertyName = "DB";
+            colDB.HeaderText = "DB";
+            colDB.MinimumWidth = 6;
+            colDB.Name = "colDB";
+            colDB.ReadOnly = true;
+            colDB.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            colDB.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            colDB.Width = 56;
+            // 
+            // SnapshotDate
+            // 
+            SnapshotDate.DataPropertyName = "SnapshotDate";
+            SnapshotDate.HeaderText = "Snapshot Date";
+            SnapshotDate.MinimumWidth = 6;
+            SnapshotDate.Name = "SnapshotDate";
+            SnapshotDate.ReadOnly = true;
+            SnapshotDate.Width = 131;
+            // 
+            // ValidatedDate
+            // 
+            ValidatedDate.DataPropertyName = "ValidatedDate";
+            ValidatedDate.HeaderText = "Validated Date";
+            ValidatedDate.MinimumWidth = 6;
+            ValidatedDate.Name = "ValidatedDate";
+            ValidatedDate.ReadOnly = true;
+            ValidatedDate.Width = 130;
+            // 
+            // ValidForDays
+            // 
+            ValidForDays.DataPropertyName = "ValidForDays";
+            ValidForDays.HeaderText = "Valid For (Days)";
+            ValidForDays.MinimumWidth = 6;
+            ValidForDays.Name = "ValidForDays";
+            ValidForDays.ReadOnly = true;
+            ValidForDays.Width = 125;
+            // 
+            // DaysSinceValidation
+            // 
+            DaysSinceValidation.DataPropertyName = "DaysSinceValidation";
+            DaysSinceValidation.HeaderText = "Days Since Validation";
+            DaysSinceValidation.MinimumWidth = 6;
+            DaysSinceValidation.Name = "DaysSinceValidation";
+            DaysSinceValidation.ReadOnly = true;
+            DaysSinceValidation.Width = 125;
+            // 
+            // colCreated
+            // 
+            colCreated.DataPropertyName = "Created";
+            colCreated.HeaderText = "Created";
+            colCreated.MinimumWidth = 6;
+            colCreated.Name = "colCreated";
+            colCreated.ReadOnly = true;
+            colCreated.Width = 87;
+            // 
+            // Modified
+            // 
+            Modified.DataPropertyName = "Modified";
+            Modified.HeaderText = "Modified";
+            Modified.MinimumWidth = 6;
+            Modified.Name = "Modified";
+            Modified.ReadOnly = true;
+            Modified.Width = 90;
+            // 
+            // Dropped
+            // 
+            Dropped.DataPropertyName = "Dropped";
+            Dropped.HeaderText = "Dropped";
+            Dropped.MinimumWidth = 6;
+            Dropped.Name = "Dropped";
+            Dropped.ReadOnly = true;
+            Dropped.Width = 92;
+            // 
+            // colExport
+            // 
+            colExport.HeaderText = "Export";
+            colExport.MinimumWidth = 6;
+            colExport.Name = "colExport";
+            colExport.ReadOnly = true;
+            colExport.Text = "Export";
+            colExport.ToolTipText = "Export DB Schema to disk";
+            colExport.UseColumnTextForLinkValue = true;
+            colExport.Width = 125;
+            // 
+            // colTriggerSnapshot
+            // 
+            colTriggerSnapshot.HeaderText = "Trigger Snapshot";
+            colTriggerSnapshot.MinimumWidth = 6;
+            colTriggerSnapshot.Name = "colTriggerSnapshot";
+            colTriggerSnapshot.ReadOnly = true;
+            colTriggerSnapshot.Text = "Trigger Snapshot";
+            colTriggerSnapshot.UseColumnTextForLinkValue = true;
+            colTriggerSnapshot.Width = 125;
             // 
             // SchemaSnapshots
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.dgvInstanceSummary);
-            this.Controls.Add(this.splitSnapshotSummary);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "SchemaSnapshots";
-            this.Size = new System.Drawing.Size(2019, 1526);
-            this.Load += new System.EventHandler(this.SchemaSnapshots_Load);
-            this.splitSnapshotSummary.Panel1.ResumeLayout(false);
-            this.splitSnapshotSummary.Panel1.PerformLayout();
-            this.splitSnapshotSummary.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.splitSnapshotSummary)).EndInit();
-            this.splitSnapshotSummary.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.gvSnapshots)).EndInit();
-            this.toolStrip2.ResumeLayout(false);
-            this.toolStrip2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.gvSnapshotsDetail)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.dgvInstanceSummary)).EndInit();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(dgvInstanceSummary);
+            Controls.Add(splitSnapshotSummary);
+            Controls.Add(toolStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "SchemaSnapshots";
+            Size = new System.Drawing.Size(2019, 1526);
+            Load += SchemaSnapshots_Load;
+            splitSnapshotSummary.Panel1.ResumeLayout(false);
+            splitSnapshotSummary.Panel1.PerformLayout();
+            splitSnapshotSummary.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitSnapshotSummary).EndInit();
+            splitSnapshotSummary.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)gvSnapshots).EndInit();
+            toolStrip2.ResumeLayout(false);
+            toolStrip2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)gvSnapshotsDetail).EndInit();
+            ((System.ComponentModel.ISupportInitialize)dgvInstanceSummary).EndInit();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -685,6 +684,11 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn colAction;
         private System.Windows.Forms.DataGridViewLinkColumn colView;
         private System.Windows.Forms.DataGridViewLinkColumn colDiff;
+        private System.Windows.Forms.DataGridViewLinkColumn colInstance;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLastUpdated;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colLastValidated;
+        private System.Windows.Forms.ToolStripButton tsTrigger;
+        private System.Windows.Forms.ToolStripLabel lblStatus;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn14;
         private System.Windows.Forms.DataGridViewLinkColumn colDB;
         private System.Windows.Forms.DataGridViewTextBoxColumn SnapshotDate;
@@ -695,8 +699,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn Modified;
         private System.Windows.Forms.DataGridViewTextBoxColumn Dropped;
         private System.Windows.Forms.DataGridViewLinkColumn colExport;
-        private System.Windows.Forms.DataGridViewLinkColumn colInstance;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLastUpdated;
-        private System.Windows.Forms.DataGridViewTextBoxColumn colLastValidated;
+        private System.Windows.Forms.DataGridViewLinkColumn colTriggerSnapshot;
     }
 }

--- a/DBADashGUI/SchemaCompare/SchemaSnapshots.resx
+++ b/DBADashGUI/SchemaCompare/SchemaSnapshots.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -85,6 +145,9 @@
     <value>True</value>
   </metadata>
   <metadata name="colExport.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="colTriggerSnapshot.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="toolStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">


### PR DESCRIPTION
Make it easier to trigger collections directly from the associated tab instead of navigating to the collection dates tab to trigger the collection.
Added to Files, Drives, Availability Groups, Backup, Last Good CheckDB, Custom and schema snapshots.  Support added for triggering snapshot of individual database.