### PR TITLE
IdentityColumnsHistory row_count nullable

### DIFF
--- a/DBADashDB/dbo/Tables/IdentityColumnsHistory.sql
+++ b/DBADashDB/dbo/Tables/IdentityColumnsHistory.sql
@@ -4,6 +4,6 @@
 	object_id INT NOT NULL,
 	SnapshotDate DATETIME2(2) NOT NULL,
 	last_value BIGINT NULL,
-	row_count BIGINT NOT NULL,
+	row_count BIGINT NULL,
 	CONSTRAINT PK_IdentityColumnsHistory PRIMARY KEY(InstanceID,DatabaseID,object_id,SnapshotDate) WITH(DATA_COMPRESSION=PAGE) ON PS_IdentityColumnsHistory(SnapshotDate) 
 ) ON PS_IdentityColumnsHistory(SnapshotDate)


### PR DESCRIPTION
Fix:
Cannot insert the value NULL into column 'row_count', table 'DBADashDB.dbo.IdentityColumnsHistory'

row_count should be nullable as it comes from sys.dm_db_partition_stats where the column is nullable.  The column is already nullable in the IdentityColumn table.

#962