### PR TITLE
ObjectExecutionStats - replace database_id with database_name

### DIFF
--- a/DBADash/DBImporter.cs
+++ b/DBADash/DBImporter.cs
@@ -280,6 +280,10 @@ namespace DBADash
                     }
                 }
             }
+            if (data.Tables.Contains("ObjectExecutionStats") && !data.Tables["ObjectExecutionStats"]!.Columns.Contains("database_name"))
+            {
+                data.Tables["ObjectExecutionStats"].TableName = "ObjectExecutionStatsLegacy"; // Call ObjectExecutionStatsLegacy_Upd which will add the database_name column and call ObjectExecutionStats_Upd
+            }
         }
 
         private readonly HashSet<string> tablesToProcess = new()
@@ -294,7 +298,7 @@ namespace DBADash
             "Jobs", "JobHistory", "AvailabilityReplicas", "AvailabilityGroups", "JobSteps",
             "DatabaseQueryStoreOptions", "ResourceGovernorConfiguration", "AzureDBResourceGovernance",
             "RunningQueries", "QueryText", "QueryPlans", "InternalPerformanceCounters", "MemoryUsage",
-            "SessionWaits", "IdentityColumns", "RunningJobs", "TableSize", "ServerServices"
+            "SessionWaits", "IdentityColumns", "RunningJobs", "TableSize", "ServerServices","ObjectExecutionStatsLegacy"
         };
 
         public void Update()

--- a/DBADash/SQL/SQLObjectExecutionStats.sql
+++ b/DBADash/SQL/SQLObjectExecutionStats.sql
@@ -6,6 +6,7 @@ BEGIN
 	SET @SQL = N'
 			SELECT object_id,
 				   database_id,
+				   ' + CASE WHEN @IsAzure=1 THEN 'DB_NAME()' ELSE 'DB_NAME(database_id)' END + 'AS database_name,
 				   ISNULL(OBJECT_NAME(object_id, database_id),''{object_id:'' + CAST(object_id AS SYSNAME) + ''}'') object_name,
 				   total_worker_time,
 				   total_elapsed_time,
@@ -26,6 +27,7 @@ BEGIN
 	SET @SQL = @SQL + 'UNION ALL
 		SELECT object_id,
 		   database_id,
+		   ' + CASE WHEN @IsAzure=1 THEN 'DB_NAME()' ELSE 'DB_NAME(database_id)' END + 'AS database_name,
 		   ISNULL(OBJECT_NAME(object_id, database_id),''{object_id:'' + CAST(object_id AS SYSNAME) + ''}'') object_name,
 		   total_worker_time,
 		   total_elapsed_time,
@@ -46,6 +48,7 @@ BEGIN
 	SET @SQL = @SQL + 'UNION ALL
 		SELECT object_id,
 		   database_id,
+		   ' + CASE WHEN @IsAzure=1 THEN 'DB_NAME()' ELSE 'DB_NAME(database_id)' END + 'AS database_name,
 		   ISNULL(OBJECT_NAME(object_id, database_id),''{object_id:'' + CAST(object_id AS SYSNAME) + ''}'') object_name,
 		   total_worker_time,
 		   total_elapsed_time,

--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -741,6 +741,8 @@
     <Build Include="dbo\Tables\ServerServices.sql" />
     <Build Include="dbo\User Defined Types\ServerServices.sql" />
     <Build Include="dbo\Stored Procedures\ServerServices_Get.sql" />
+    <Build Include="dbo\Stored Procedures\ObjectExecutionStatsLegacy_Upd.sql" />
+    <Build Include="dbo\User Defined Types\ObjectExecutionStats.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/DBADashDB/Staging/Tables/ObjectExecutionStats.sql
+++ b/DBADashDB/Staging/Tables/ObjectExecutionStats.sql
@@ -1,16 +1,16 @@
-﻿CREATE TABLE [Staging].[ObjectExecutionStats] (
-    [InstanceID]           INT            NOT NULL,
-    [object_id]            INT            NOT NULL,
-    [database_id]          INT            NOT NULL,
-    [object_name]          NVARCHAR (128) NULL,
-    [total_worker_time]    BIGINT         NOT NULL,
-    [total_elapsed_time]   BIGINT         NOT NULL,
-    [total_logical_reads]  BIGINT         NOT NULL,
-    [total_logical_writes] BIGINT         NOT NULL,
-    [total_physical_reads] BIGINT         NOT NULL,
-    [cached_time]          DATETIME       NOT NULL,
-    [execution_count]      BIGINT         NOT NULL,
-    [current_time_utc]     DATETIME2 (3)  NOT NULL,
-    CONSTRAINT [PK_Staging_ObjectExecutionStats] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [object_id] ASC, [database_id] ASC, [cached_time] ASC)
+﻿CREATE TABLE Staging.ObjectExecutionStats (
+    InstanceID INT NOT NULL,
+    object_id INT NOT NULL,
+    database_id INT NOT NULL,
+    database_name NVARCHAR(128) NOT NULL CONSTRAINT DF_Staging_ObjectExecutionStats_database_name DEFAULT(CAST(NEWID() AS NVARCHAR(128))),
+    object_name NVARCHAR(128) NULL,
+    total_worker_time BIGINT NOT NULL,
+    total_elapsed_time BIGINT NOT NULL,
+    total_logical_reads BIGINT NOT NULL,
+    total_logical_writes BIGINT NOT NULL,
+    total_physical_reads BIGINT NOT NULL,
+    cached_time DATETIME NOT NULL,
+    execution_count BIGINT NOT NULL,
+    current_time_utc DATETIME2(3) NOT NULL,
+    CONSTRAINT PK_Staging_ObjectExecutionStats PRIMARY KEY CLUSTERED (InstanceID ASC, object_id ASC, database_name ASC, cached_time ASC)
 );
-

--- a/DBADashDB/dbo/Stored Procedures/ObjectExecutionStatsLegacy_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/ObjectExecutionStatsLegacy_Upd.sql
@@ -1,0 +1,43 @@
+﻿CREATE PROC dbo.ObjectExecutionStatsLegacy_Upd(
+    @ObjectExecutionStatsLegacy dbo.ProcStats READONLY,
+    @InstanceID INT,
+    @SnapshotDate DATETIME2(3)
+)
+AS
+DECLARE @ObjectExecutionStats dbo.ObjectExecutionStats
+INSERT INTO @ObjectExecutionStats(
+       object_id,
+       database_id,
+       database_name,
+       object_name,
+       total_worker_time,
+       total_elapsed_time,
+       total_logical_reads,
+       total_logical_writes,
+       total_physical_reads,
+       cached_time,
+       execution_count,
+       current_time_utc,
+       type,
+       schema_name)
+SELECT  T.object_id,
+       T.database_id,
+       D.name,
+       T.object_name,
+       T.total_worker_time,
+       T.total_elapsed_time,
+       T.total_logical_reads,
+       T.total_logical_writes,
+       T.total_physical_reads,
+       T.cached_time,
+       T.execution_count,
+       T.current_time_utc,
+       T.type,
+       T.schema_name	
+FROM @ObjectExecutionStatsLegacy T
+JOIN dbo.Databases D ON T.database_id = D.database_id AND D.InstanceID=@InstanceID
+WHERE D.IsActive=1
+
+EXEC dbo.ObjectExecutionStats_Upd @ObjectExecutionStats=@ObjectExecutionStats,
+        @InstanceID = @InstanceID, 
+        @SnapshotDate = @SnapshotDate

--- a/DBADashDB/dbo/User Defined Types/ObjectExecutionStats.sql
+++ b/DBADashDB/dbo/User Defined Types/ObjectExecutionStats.sql
@@ -1,0 +1,16 @@
+﻿CREATE TYPE dbo.ObjectExecutionStats AS TABLE (
+    object_id INT NOT NULL,
+    database_id INT NOT NULL,
+    database_name NVARCHAR(128) NULL,
+    object_name NVARCHAR(128) NULL,
+    total_worker_time BIGINT NOT NULL,
+    total_elapsed_time BIGINT NOT NULL,
+    total_logical_reads BIGINT NOT NULL,
+    total_logical_writes BIGINT NOT NULL,
+    total_physical_reads BIGINT NOT NULL,
+    cached_time DATETIME NULL,
+    execution_count BIGINT NOT NULL,
+    current_time_utc DATETIME2(3) NOT NULL,
+    type CHAR(2) NULL,
+    schema_name NVARCHAR(128) NULL
+);


### PR DESCRIPTION
This fixes an issue in AzureDB where the database_id/DB_ID might not be consistent. Capturing database_name and using that instead of database_id to join to dbo.Databases.