### PR TITLE
Improve support for monitoring read replicas in Azure

### DIFF
--- a/DBADash/DBADashConnection.cs
+++ b/DBADash/DBADashConnection.cs
@@ -158,6 +158,19 @@ namespace DBADash
             }
         }
 
+        public ApplicationIntent? ApplicationIntent()
+        {
+            if (connectionType == ConnectionType.SQL)
+            {
+                SqlConnectionStringBuilder builder = new(connectionString);
+                return builder.ApplicationIntent;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         public string DataSource()
         {
             if (connectionType == ConnectionType.SQL)

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -141,6 +141,10 @@ namespace DBADashServiceConfig
                             src.SourceConnection.Validate();
                             validated = true;
                             src.ConnectionID = src.GetGeneratedConnectionID();
+                            if(src.SourceConnection.ApplicationIntent() == ApplicationIntent.ReadOnly)
+                            {
+                                src.ConnectionID += "|ReadOnly";
+                            }
 
                             if (src.SourceConnection.Type == ConnectionType.SQL &&
                                 string.IsNullOrEmpty(src.SourceConnection.ConnectionInfo.ServerName))


### PR DESCRIPTION
Consider connections with ApplicationIntent ReadOnly as a different connection.  Append |ReadOnly to the ConnectionID.  This allows read replica connections to be configured in the service config tool.
#465