### PR TITLE
Fix Invalid Database Error

### DIFF
--- a/DBADash/Upgrade/DBValidations.cs
+++ b/DBADash/Upgrade/DBValidations.cs
@@ -57,7 +57,8 @@ BEGIN
 END
 ELSE IF NOT EXISTS(SELECT * 
 			FROM sys.objects
-			WHERE type NOT IN('S','IT','SQ')          
+			WHERE type NOT IN('S','IT','SQ')
+            AND is_ms_shipped=0
             )
         AND DB_ID()>4
 BEGIN


### PR DESCRIPTION
Fix invalid database error that can occur when deploying to an empty database in azure due to database_firewall_rules view. Excluding is_ms_shipped=1 objects from check. #998