### PR TITLE
ObjectExecutionStats improvement

### DIFF
--- a/DBADashDB/Staging/Tables/ObjectExecutionStats.sql
+++ b/DBADashDB/Staging/Tables/ObjectExecutionStats.sql
@@ -2,7 +2,7 @@
     InstanceID INT NOT NULL,
     object_id INT NOT NULL,
     database_id INT NOT NULL,
-    database_name NVARCHAR(128) NOT NULL CONSTRAINT DF_Staging_ObjectExecutionStats_database_name DEFAULT(CAST(NEWID() AS NVARCHAR(128))),
+    database_name NVARCHAR(128) NOT NULL CONSTRAINT DF_Staging_ObjectExecutionStats_database_name DEFAULT (CONVERT([nvarchar](128),newid())),
     object_name NVARCHAR(128) NULL,
     total_worker_time BIGINT NOT NULL,
     total_elapsed_time BIGINT NOT NULL,

--- a/DBADashDB/dbo/Tables/ObjectExecutionStats.sql
+++ b/DBADashDB/dbo/Tables/ObjectExecutionStats.sql
@@ -11,6 +11,8 @@
     [execution_count]      BIGINT        NOT NULL,
     [IsCompile]            BIT           NOT NULL,
     [MaxExecutionsPerMin]  AS            ([execution_count]/(nullif([PeriodTime],(0))/(60000000.0))),
+    [PeriodStartTime]  AS (dateadd(day, -([PeriodTime]/(86400000000.)),dateadd(millisecond, -(([PeriodTime]%(86400000000.))/(1000)),[SnapshotDate]))),
+	[PeriodEndTime]  AS ([SnapshotDate]),
     CONSTRAINT [PK_ObjectExecutionStats] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [SnapshotDate] ASC, [ObjectID] ASC) WITH (DATA_COMPRESSION = PAGE) ON [PS_ObjectExecutionStats] ([SnapshotDate]),
     CONSTRAINT [FK_ObjectExecutionStats_Instances] FOREIGN KEY ([InstanceID]) REFERENCES [dbo].[Instances] ([InstanceID])
 ) ON [PS_ObjectExecutionStats] ([SnapshotDate]);

--- a/DBADashDB/dbo/Tables/ObjectExecutionStats_60MIN.sql
+++ b/DBADashDB/dbo/Tables/ObjectExecutionStats_60MIN.sql
@@ -11,6 +11,8 @@
     [execution_count]      BIGINT        NOT NULL,
     [IsCompile]            BIT           NOT NULL,
     [MaxExecutionsPerMin]  DECIMAL (19, 6)   NULL,
+   	[PeriodStartTime]  AS (dateadd(day, -([PeriodTime]/(86400000000.)),dateadd(millisecond, -(([PeriodTime]%(86400000000.))/(1000)),[SnapshotDate]))),
+	[PeriodEndTime]  AS ([SnapshotDate]),
     CONSTRAINT [PK_ObjectExecutionStats_60MIN] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [SnapshotDate] ASC, [ObjectID] ASC) WITH (DATA_COMPRESSION = PAGE) ON PS_ObjectExecutionStats_60MIN(SnapshotDate)
 ) ON PS_ObjectExecutionStats_60MIN(SnapshotDate);
 

--- a/DBADashGUI/CommonData.cs
+++ b/DBADashGUI/CommonData.cs
@@ -81,7 +81,7 @@ namespace DBADashGUI
             return dt;
         }
 
-        public static DataTable ObjectExecutionStats(int instanceID, int databaseID, long objectID, int dateGrouping, string measure, DateTime FromDate, DateTime ToDate, string instance = "")
+        public static DataTable ObjectExecutionStats(int instanceID, int databaseID, long objectID, int dateGrouping, string measure, DateTime FromDate, DateTime ToDate, string instance = "", int top = 10, bool includeOther = false)
         {
             using var cn = new SqlConnection(Common.ConnectionString);
             using var cmd = new SqlCommand("dbo.ObjectExecutionStats_Get", cn) { CommandType = CommandType.StoredProcedure };
@@ -97,6 +97,8 @@ namespace DBADashGUI
             cmd.Parameters.AddWithValue("DateGroupingMin", dateGrouping);
             cmd.Parameters.AddWithValue("Measure", measure);
             cmd.Parameters.AddIfGreaterThanZero("DatabaseID", databaseID);
+            cmd.Parameters.AddIfGreaterThanZero("Top", top);
+            cmd.Parameters.AddWithValue("IncludeOther", includeOther);
             if (DateRange.HasTimeOfDayFilter)
             {
                 cmd.Parameters.AddWithValue("Hours", DateRange.TimeOfDay.AsDataTable());
@@ -270,9 +272,9 @@ namespace DBADashGUI
 
         public static DBADashAgent GetDBADashAgent(int agentID)
         {
-            var cacheKey = "DBADashAgent_" + agentID;    
-            if (cache.Get(cacheKey) is DBADashAgent agent) return agent; 
-            agent =  DBADashAgent.GetDBADashAgent(Common.ConnectionString,agentID);
+            var cacheKey = "DBADashAgent_" + agentID;
+            if (cache.Get(cacheKey) is DBADashAgent agent) return agent;
+            agent = DBADashAgent.GetDBADashAgent(Common.ConnectionString, agentID);
             cache.Add(cacheKey, agent, DateTimeOffset.Now.AddMinutes(10));
             return agent;
         }

--- a/DBADashGUI/Performance/ObjectExecution.Designer.cs
+++ b/DBADashGUI/Performance/ObjectExecution.Designer.cs
@@ -28,103 +28,165 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.objectExecChart = new LiveCharts.WinForms.CartesianChart();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.tsClose = new System.Windows.Forms.ToolStripButton();
-            this.tsUp = new System.Windows.Forms.ToolStripButton();
-            this.lblExecution = new System.Windows.Forms.ToolStripLabel();
-            this.tsMeasures = new System.Windows.Forms.ToolStripDropDownButton();
-            this.tsDateGroup = new System.Windows.Forms.ToolStripDropDownButton();
-            this.toolStrip1.SuspendLayout();
-            this.SuspendLayout();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ObjectExecution));
+            objectExecChart = new LiveCharts.WinForms.CartesianChart();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsClose = new System.Windows.Forms.ToolStripButton();
+            tsUp = new System.Windows.Forms.ToolStripButton();
+            lblExecution = new System.Windows.Forms.ToolStripLabel();
+            tsDateGroup = new System.Windows.Forms.ToolStripDropDownButton();
+            tsMeasures = new System.Windows.Forms.ToolStripDropDownButton();
+            tsTop = new System.Windows.Forms.ToolStripDropDownButton();
+            tsTop5 = new System.Windows.Forms.ToolStripMenuItem();
+            tsTop10 = new System.Windows.Forms.ToolStripMenuItem();
+            tsTop20 = new System.Windows.Forms.ToolStripMenuItem();
+            tsTop40 = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            includeOtherToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStrip1.SuspendLayout();
+            SuspendLayout();
             // 
             // objectExecChart
             // 
-            this.objectExecChart.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.objectExecChart.Location = new System.Drawing.Point(0, 27);
-            this.objectExecChart.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.objectExecChart.Name = "objectExecChart";
-            this.objectExecChart.Size = new System.Drawing.Size(492, 325);
-            this.objectExecChart.TabIndex = 0;
-            this.objectExecChart.Text = "cartesianChart1";
+            objectExecChart.Dock = System.Windows.Forms.DockStyle.Fill;
+            objectExecChart.Location = new System.Drawing.Point(0, 27);
+            objectExecChart.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            objectExecChart.Name = "objectExecChart";
+            objectExecChart.Size = new System.Drawing.Size(492, 325);
+            objectExecChart.TabIndex = 0;
+            objectExecChart.Text = "cartesianChart1";
             // 
             // toolStrip1
             // 
-            this.toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsClose,
-            this.tsUp,
-            this.lblExecution,
-            this.tsDateGroup,
-            this.tsMeasures});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.Size = new System.Drawing.Size(492, 27);
-            this.toolStrip1.TabIndex = 1;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsClose, tsUp, lblExecution, tsDateGroup, tsMeasures, tsTop });
+            toolStrip1.Location = new System.Drawing.Point(0, 0);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.Size = new System.Drawing.Size(492, 27);
+            toolStrip1.TabIndex = 1;
+            toolStrip1.Text = "toolStrip1";
             // 
             // tsClose
             // 
-            this.tsClose.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.tsClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsClose.Image = global::DBADashGUI.Properties.Resources.Close_red_16x;
-            this.tsClose.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsClose.Name = "tsClose";
-            this.tsClose.Size = new System.Drawing.Size(29, 24);
-            this.tsClose.Text = "Close";
-            this.tsClose.Visible = false;
-            this.tsClose.Click += new System.EventHandler(this.TsClose_Click);
+            tsClose.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsClose.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsClose.Image = Properties.Resources.Close_red_16x;
+            tsClose.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsClose.Name = "tsClose";
+            tsClose.Size = new System.Drawing.Size(29, 24);
+            tsClose.Text = "Close";
+            tsClose.Visible = false;
+            tsClose.Click += TsClose_Click;
             // 
             // tsUp
             // 
-            this.tsUp.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.tsUp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.tsUp.Image = global::DBADashGUI.Properties.Resources.arrow_Up_16xLG;
-            this.tsUp.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsUp.Name = "tsUp";
-            this.tsUp.Size = new System.Drawing.Size(29, 24);
-            this.tsUp.Text = "Move Up";
-            this.tsUp.Click += new System.EventHandler(this.TsUp_Click);
+            tsUp.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsUp.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsUp.Image = Properties.Resources.arrow_Up_16xLG;
+            tsUp.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsUp.Name = "tsUp";
+            tsUp.Size = new System.Drawing.Size(29, 24);
+            tsUp.Text = "Move Up";
+            tsUp.Click += TsUp_Click;
             // 
             // lblExecution
             // 
-            this.lblExecution.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.lblExecution.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
-            this.lblExecution.Name = "lblExecution";
-            this.lblExecution.Size = new System.Drawing.Size(116, 24);
-            this.lblExecution.Text = "Execution Stats";
-            // 
-            // tsMeasures
-            // 
-            this.tsMeasures.Image = global::DBADashGUI.Properties.Resources.AddComputedField_16x;
-            this.tsMeasures.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsMeasures.Name = "tsMeasures";
-            this.tsMeasures.Size = new System.Drawing.Size(105, 24);
-            this.tsMeasures.Text = "Measures";
+            lblExecution.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            lblExecution.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            lblExecution.Name = "lblExecution";
+            lblExecution.Size = new System.Drawing.Size(116, 24);
+            lblExecution.Text = "Execution Stats";
             // 
             // tsDateGroup
             // 
-            this.tsDateGroup.Image = global::DBADashGUI.Properties.Resources.Time_16x;
-            this.tsDateGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.tsDateGroup.Name = "tsDateGroup";
-            this.tsDateGroup.Size = new System.Drawing.Size(76, 24);
-            this.tsDateGroup.Text = "1min";
+            tsDateGroup.Image = Properties.Resources.Time_16x;
+            tsDateGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsDateGroup.Name = "tsDateGroup";
+            tsDateGroup.Size = new System.Drawing.Size(76, 24);
+            tsDateGroup.Text = "1min";
+            // 
+            // tsMeasures
+            // 
+            tsMeasures.Image = Properties.Resources.AddComputedField_16x;
+            tsMeasures.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsMeasures.Name = "tsMeasures";
+            tsMeasures.Size = new System.Drawing.Size(105, 24);
+            tsMeasures.Text = "Measures";
+            // 
+            // tsTop
+            // 
+            tsTop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            tsTop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { tsTop5, tsTop10, tsTop20, tsTop40, toolStripMenuItem1, includeOtherToolStripMenuItem });
+            tsTop.Image = (System.Drawing.Image)resources.GetObject("tsTop.Image");
+            tsTop.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsTop.Name = "tsTop";
+            tsTop.Size = new System.Drawing.Size(60, 24);
+            tsTop.Tag = "5";
+            tsTop.Text = "Top 5";
+            // 
+            // tsTop5
+            // 
+            tsTop5.Checked = true;
+            tsTop5.CheckState = System.Windows.Forms.CheckState.Checked;
+            tsTop5.Name = "tsTop5";
+            tsTop5.Size = new System.Drawing.Size(246, 26);
+            tsTop5.Tag = "5";
+            tsTop5.Text = "Top 5 (Overall/Period)";
+            tsTop5.Click += Top_Select;
+            // 
+            // tsTop10
+            // 
+            tsTop10.Name = "tsTop10";
+            tsTop10.Size = new System.Drawing.Size(246, 26);
+            tsTop10.Tag = "10";
+            tsTop10.Text = "Top 10 (Overall/Period)";
+            tsTop10.Click += Top_Select;
+            // 
+            // tsTop20
+            // 
+            tsTop20.Name = "tsTop20";
+            tsTop20.Size = new System.Drawing.Size(246, 26);
+            tsTop20.Tag = "20";
+            tsTop20.Text = "Top 20 (Overall/Period)";
+            tsTop20.Click += Top_Select;
+            // 
+            // tsTop40
+            // 
+            tsTop40.Name = "tsTop40";
+            tsTop40.Size = new System.Drawing.Size(246, 26);
+            tsTop40.Tag = "40";
+            tsTop40.Text = "Top 40 (Overall/Period)";
+            tsTop40.Click += Top_Select;
+            // 
+            // toolStripMenuItem1
+            // 
+            toolStripMenuItem1.Name = "toolStripMenuItem1";
+            toolStripMenuItem1.Size = new System.Drawing.Size(243, 6);
+            // 
+            // includeOtherToolStripMenuItem
+            // 
+            includeOtherToolStripMenuItem.Checked = true;
+            includeOtherToolStripMenuItem.CheckOnClick = true;
+            includeOtherToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            includeOtherToolStripMenuItem.Name = "includeOtherToolStripMenuItem";
+            includeOtherToolStripMenuItem.Size = new System.Drawing.Size(246, 26);
+            includeOtherToolStripMenuItem.Text = "Include Other";
+            includeOtherToolStripMenuItem.Click += includeOtherToolStripMenuItem_Click;
             // 
             // ObjectExecution
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.objectExecChart);
-            this.Controls.Add(this.toolStrip1);
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            this.Name = "ObjectExecution";
-            this.Size = new System.Drawing.Size(492, 352);
-            this.Load += new System.EventHandler(this.ObjectExecution_Load);
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(objectExecChart);
+            Controls.Add(toolStrip1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "ObjectExecution";
+            Size = new System.Drawing.Size(492, 352);
+            Load += ObjectExecution_Load;
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -136,5 +198,12 @@
         private System.Windows.Forms.ToolStripDropDownButton tsDateGroup;
         private System.Windows.Forms.ToolStripButton tsClose;
         private System.Windows.Forms.ToolStripButton tsUp;
+        private System.Windows.Forms.ToolStripDropDownButton tsTop;
+        private System.Windows.Forms.ToolStripMenuItem tsTop10;
+        private System.Windows.Forms.ToolStripMenuItem tsTop20;
+        private System.Windows.Forms.ToolStripMenuItem tsTop5;
+        private System.Windows.Forms.ToolStripMenuItem tsTop40;
+        private System.Windows.Forms.ToolStripMenuItem includeOtherToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
     }
 }

--- a/DBADashGUI/Performance/ObjectExecution.resx
+++ b/DBADashGUI/Performance/ObjectExecution.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -60,4 +120,16 @@
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="tsTop.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAEKSURBVEhL3ZG9DsFQHMXvczDZvIOtXsHObuhqkViI3Quw
+        6CYmNoMYJJ0NBiFFIoIytOuf0+TeXP3yde+iyS+3OcP53Z4y3/dJJ4HAsiwyTVMp6BQCBIZhKAWdEcHV
+        vSlBmeB82NFy1KLluEWOPRC5MoHdMWhazwi4RJlALgf4EuT6BI+5kCsTrGddUY658E+QvyXYHq9UnRyC
+        U87f4aUApcXhnrI9Jzg/laQKFntXlHM+lSQK5psL5fvbp/JvJLGCQqmSWM5JkiCT84igXGtSrruKLQ0T
+        luAdmZxHBG37FFuWBC/j5XKOmX8WAH7rcI6ZMffPgjQwN2bXJgDo/COBTpjneQ2dML0PY3cISreGe8HM
+        qgAAAABJRU5ErkJggg==
+</value>
+  </data>
 </root>

--- a/DBADashGUI/Performance/Performance.cs
+++ b/DBADashGUI/Performance/Performance.cs
@@ -10,6 +10,7 @@ namespace DBADashGUI.Performance
         public Performance()
         {
             InitializeComponent();
+            objectExecution1.Metric.Measure = "duration_ms_per_sec";
         }
 
         private DBADashContext context;


### PR DESCRIPTION
Change sort order of bars to list objects sorted by selected metric (overall).  Change to display top 5 by default and include "Other" as an item on the chart.  Default to duration/sec.

#1010 