### PR TITLE
SMO Statement timeout

### DIFF
--- a/DBADash/CollectionCommandTimeout.cs
+++ b/DBADash/CollectionCommandTimeout.cs
@@ -95,7 +95,7 @@ namespace DBADash
                 { CollectionType.DatabaseMirroring, 120 },
                 { CollectionType.Jobs, 120 },
                 { CollectionType.AzureDBResourceGovernance, 120 },
-                { CollectionType.SchemaSnapshot, 300 },
+                { CollectionType.SchemaSnapshot, 1200 },
                 { CollectionType.ServerPrincipals, 300 },
                 { CollectionType.ServerRoleMembers, 300 },
                 { CollectionType.ServerPermissions, 300 },

--- a/DBADash/SchemaSnapshotDB.cs
+++ b/DBADash/SchemaSnapshotDB.cs
@@ -189,7 +189,8 @@ namespace DBADash
                 dtSchema.Columns.Add("DDL", typeof(byte[]));
                 dtSchema.Columns.Add("ObjectDateCreated", typeof(DateTime));
                 dtSchema.Columns.Add("ObjectDateModified", typeof(DateTime));
-                var instance = new Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn));
+                var instance = new Server(new Microsoft.SqlServer.Management.Common.ServerConnection(cn) );
+                instance.ConnectionContext.StatementTimeout = CollectionType.SchemaSnapshot.GetCommandTimeout();
                 instance.SetDefaultInitFields(typeof(Table), true);
 
                 var db = instance.Databases[DBName];


### PR DESCRIPTION
Allow schema snapshot timeout to be configured.  Set default timeout to 20min.