### PR TITLE
Fix ObjectExecutionStats graph issue

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/ObjectExecutionStats_Get.sql
@@ -387,8 +387,8 @@ BEGIN;
 			0 AS MaxExecutionsPerMin,
 			0 AS Measure,
 			0 AS TotalMeasure,
-			0 AS ProcRankPeriod,
-			0 AS ProcRankTotal
+			1 AS ProcRankPeriod,
+			1 AS ProcRankTotal
 	FROM dbo.DBObjects O
 	JOIN dbo.Databases D ON D.DatabaseID = O.DatabaseID
 	CROSS JOIN @DateGroups DG


### PR DESCRIPTION
Issue with ordering when zero fill is used due to ProcRankTotal being 0 instead of 1 like the rest of the results.  Empty time periods were listed before everything else instead of in order causing chart display issues. #1051