### PR TITLE
Add support for custom external diff tool

### DIFF
--- a/DBADashGUI/App.config
+++ b/DBADashGUI/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="DBADashGUI.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
+    <userSettings>
+        <DBADashGUI.Properties.Settings>
+            <setting name="DiffToolBinaryPath" serializeAs="String">
+                <value>C:\Program Files\WinMerge\WinMergeU.exe</value>
+            </setting>
+            <setting name="DiffToolArguments" serializeAs="String">
+                <value>/u /e /wl /wr /dl "Old DDL" /dr "New DDL" /fileext sql $OLD$ $NEW$</value>
+            </setting>
+        </DBADashGUI.Properties.Settings>
+    </userSettings>
+</configuration>

--- a/DBADashGUI/Properties/Settings.Designer.cs
+++ b/DBADashGUI/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DBADashGUI.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.11.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -80,6 +80,30 @@ namespace DBADashGUI.Properties {
             }
             set {
                 this["PerformanceSummaryMigrated"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DiffToolBinaryPath {
+            get {
+                return ((string)(this["DiffToolBinaryPath"]));
+            }
+            set {
+                this["DiffToolBinaryPath"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DiffToolArguments {
+            get {
+                return ((string)(this["DiffToolArguments"]));
+            }
+            set {
+                this["DiffToolArguments"] = value;
             }
         }
     }

--- a/DBADashGUI/Properties/Settings.settings
+++ b/DBADashGUI/Properties/Settings.settings
@@ -17,5 +17,11 @@
     <Setting Name="PerformanceSummaryMigrated" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="DiffToolBinaryPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="DiffToolArguments" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
This is not necessarily the full solution, but figured I would create a draft PR just to see what you thought about the idea in general.

This works for me, but I'm sure there are situations I may not be accounting for.

I chose to store the config values in `app.config` rather than in the `DBADash.Users` table due to security. All it takes is for someone to update that table and now you can execute whatever you want on their machine as soon as they click "diff".

The way I have it set up here is essentially the same way that Fork handles it by using special variables that get replaced with the actual value.