### PR TITLE
InstanceTags - Add/Del - Fix param datatype and length inconsistency

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/InstanceTags_Add.sql
+++ b/DBADashDB/dbo/Stored Procedures/InstanceTags_Add.sql
@@ -1,8 +1,8 @@
 ﻿CREATE PROC InstanceTags_Add(
 	@Instance SYSNAME,
 	@InstanceID INT,
-	@TagName VARCHAR(50),
-	@TagValue VARCHAR(128),
+	@TagName NVARCHAR(50),
+	@TagValue NVARCHAR(128),
 	@TagID INT OUT
 )
 AS

--- a/DBADashDB/dbo/Stored Procedures/InstanceTags_Del.sql
+++ b/DBADashDB/dbo/Stored Procedures/InstanceTags_Del.sql
@@ -1,8 +1,8 @@
 ﻿CREATE PROC dbo.InstanceTags_Del(
 	@Instance SYSNAME,
 	@InstanceID INT,
-	@TagName VARCHAR(50),
-	@TagValue VARCHAR(50)
+	@TagName NVARCHAR(50),
+	@TagValue NVARCHAR(128)
 )
 AS
 DECLARE @TagID INT 


### PR DESCRIPTION
This bug was causing tags longer than 50 characters to not be found when attempting to delete. The UI would indicate it was removed, but it was not. Re-adding the tag would result in a PK violation exception.

![image](https://github.com/user-attachments/assets/3d076181-80bd-44ea-8820-7e64ebb119d0)

Fixing the datatype length fixed the issue. Changing the datatypes from `varchar` to `nvarchar` was not necessary for the fix, but included the change anyway since that's what is used in the `dbo.Tag` table.

Tested both procs after the change and confirmed app is now behaving as expected.