### PR TITLE
Add links for sp_PressureDetector

### DIFF
--- a/DBADashGUI/CommunityTools/CommunityTools.cs
+++ b/DBADashGUI/CommunityTools/CommunityTools.cs
@@ -1798,6 +1798,51 @@ namespace DBADashGUI.CommunityTools
             },
         };
 
+        // Result sets can change order, so define the link columns once with links across all results.
+        private static CustomReportResult GetPressureDetectorResult(string name) => new()
+        {
+            ResultName = name,
+            LinkColumns = new Dictionary<string, LinkColumnInfo>
+            {
+                {
+                    "tempdb_info",
+                    new TextLinkColumnInfo() { TargetColumn = "tempdb_info", TextHandling = CodeEditor.CodeEditorModes.XML }
+                },
+                {
+                    "low_memory",
+                    new TextLinkColumnInfo() { TargetColumn = "low_memory", TextHandling = CodeEditor.CodeEditorModes.XML }
+                },
+                {
+                    "cache_memory",
+                    new TextLinkColumnInfo() { TargetColumn = "cache_memory", TextHandling = CodeEditor.CodeEditorModes.XML }
+                },
+                {
+                    "max_memory_grant_cap",
+                    new TextLinkColumnInfo() { TargetColumn = "max_memory_grant_cap", TextHandling = CodeEditor.CodeEditorModes.XML }
+                },
+                {
+                    "cpu_details_output",
+                    new TextLinkColumnInfo() { TargetColumn = "cpu_details_output", TextHandling = CodeEditor.CodeEditorModes.XML }
+                },
+                {
+                    "cpu_utilization_over_threshold",
+                    new TextLinkColumnInfo() { TargetColumn = "cpu_utilization_over_threshold", TextHandling = CodeEditor.CodeEditorModes.XML }
+                },
+                {
+                    "query_text",
+                    new TextLinkColumnInfo() { TargetColumn = "query_text", TextHandling = CodeEditor.CodeEditorModes.SQL }
+                },
+                {
+                    "query_plan",
+                    new QueryPlanLinkColumnInfo() { TargetColumn = "query_plan" }
+                },
+                {
+                    "live_query_plan",
+                    new QueryPlanLinkColumnInfo() { TargetColumn = "live_query_plan" }
+                },
+            }
+        };
+
         public static DirectExecutionReport sp_PressureDetector = new DirectExecutionReport()
         {
             ProcedureName = ProcedureExecutionMessage.CommandNames.sp_PressureDetector.ToString(),
@@ -1921,7 +1966,23 @@ namespace DBADashGUI.CommunityTools
                         { 100, "100" },
                     }
                 },
-            }
+            },
+            CustomReportResults = new Dictionary<int, CustomReportResult>
+            {
+                { 0, GetPressureDetectorResult("1") },
+                { 1, GetPressureDetectorResult("2") },
+                { 2, GetPressureDetectorResult("3") },
+                { 3, GetPressureDetectorResult("4") },
+                { 4, GetPressureDetectorResult("5") },
+                { 5, GetPressureDetectorResult("6") },
+                { 6, GetPressureDetectorResult("7") },
+                { 7, GetPressureDetectorResult("8") },
+                { 8, GetPressureDetectorResult("9") },
+                { 9, GetPressureDetectorResult("10") },
+                { 10, GetPressureDetectorResult("11") },
+                { 11, GetPressureDetectorResult("12") },
+                { 12, GetPressureDetectorResult("13") }
+            },
         };
 
         public static List<DirectExecutionReport> CommunityToolsList = new()

--- a/DBADashGUI/SchemaCompare/CodeEditor.xaml.cs
+++ b/DBADashGUI/SchemaCompare/CodeEditor.xaml.cs
@@ -1,7 +1,10 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Reflection;
+using System.Text;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Xml;
 using System.Xml.Linq;
 using DBADashGUI.Theme;
 
@@ -75,7 +78,7 @@ namespace DBADashGUI.SchemaCompare
             {
                 try
                 {
-                    txtCode.Text = string.IsNullOrEmpty(_text) ? _text : XDocument.Parse(_text).ToString();
+                    txtCode.Text = FormatXml(_text);
                 }
                 catch
                 {
@@ -98,6 +101,26 @@ namespace DBADashGUI.SchemaCompare
                 SetHighlighting(GetResource(resourceName));
             }
             currentHighlighting = resourceName;
+        }
+
+        public static string FormatXml(string xml)
+        {
+            if (string.IsNullOrWhiteSpace(xml))
+                return xml;
+
+            // Wrapping in a temporary root element to form valid XML in cases where we have multiple root nodes
+            var tempRoot = XElement.Parse($"<root>{xml}</root>");
+
+            var formattedXmlBuilder = new StringBuilder();
+
+            // Getting rid of the temporary root element and formatting the XML
+            foreach (var node in tempRoot.Elements())
+            {
+                var formattedNode = node.ToString(SaveOptions.None);
+                formattedXmlBuilder.AppendLine(formattedNode);
+            }
+
+            return formattedXmlBuilder.ToString();
         }
 
         public CodeEditorModes Mode


### PR DESCRIPTION
Result sets can change order, so define the link columns once with links across all results. Update XML code formatting to account for an XML fragment with multiple root nodes.