### PR TITLE
Add Community Tools node at DB level

### DIFF
--- a/DBADashGUI/CommunityTools/CommunityTools.cs
+++ b/DBADashGUI/CommunityTools/CommunityTools.cs
@@ -2,12 +2,15 @@
 using DBADashGUI.CustomReports;
 using DBADashGUI.SchemaCompare;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using DBADash;
 using Microsoft.SqlServer.Management.Smo;
+using System;
 
 namespace DBADashGUI.CommunityTools
 {
-    internal class CommunityTools
+    internal static class CommunityTools
     {
         private const string FirstResponderKitUrl = "https://github.com/BrentOzarULTD/SQL-Server-First-Responder-Kit";
         private const string ErikDarlingUrl = "https://github.com/erikdarlingdata/DarlingData";
@@ -600,6 +603,7 @@ namespace DBADashGUI.CommunityTools
             ReportName = ProcedureExecutionMessage.CommandNames.sp_BlitzIndex.ToString(),
             URL = FirstResponderKitUrl,
             Description = "SQL Server Index Analysis Stored Procedure",
+            DatabaseNameParameter = "@DatabaseName",
             Params = new Params
             {
                 ParamList = new List<Param>
@@ -850,6 +854,7 @@ namespace DBADashGUI.CommunityTools
             ReportName = ProcedureExecutionMessage.CommandNames.sp_BlitzCache.ToString(),
             URL = FirstResponderKitUrl,
             Description = "List the most resource-intensive queries from the plan cache",
+            DatabaseNameParameter = "@DatabaseName",
             Params = new Params
             {
                 ParamList = new List<Param>
@@ -1088,6 +1093,7 @@ namespace DBADashGUI.CommunityTools
             ReportName = ProcedureExecutionMessage.CommandNames.sp_BlitzLock.ToString(),
             URL = FirstResponderKitUrl,
             Description = "SQL Server Deadlock Analysis Stored Procedure",
+            DatabaseNameParameter = "@DatabaseName",
             Params = new Params()
             {
                 ParamList = new List<Param>
@@ -1557,6 +1563,7 @@ namespace DBADashGUI.CommunityTools
             URL = ErikDarlingUrl,
             Description = "Extended events capture",
             CancellationMessageWarning = "Cancellation of this report will leave an extended event session running that will require cleanup.",
+            DatabaseNameParameter = "@database_name",
             Params = new Params()
             {
                 ParamList = new List<Param>
@@ -2028,6 +2035,7 @@ namespace DBADashGUI.CommunityTools
             ReportName = ProcedureExecutionMessage.CommandNames.sp_HealthParser.ToString(),
             URL = ErikDarlingUrl,
             Description = "Returns data from system health extended event.",
+            DatabaseNameParameter = "@database_name",
             Params = new Params()
             {
                 ParamList = new()
@@ -2122,6 +2130,7 @@ namespace DBADashGUI.CommunityTools
             ReportName = ProcedureExecutionMessage.CommandNames.sp_QuickieStore.ToString(),
             URL = ErikDarlingUrl,
             Description = "Query store analysis",
+            DatabaseNameParameter = "@database_name",
             Params = new Params()
             {
                 ParamList = new()
@@ -2304,5 +2313,8 @@ namespace DBADashGUI.CommunityTools
             sp_HealthParser,
             sp_QuickieStore
         };
+
+        public static List<DirectExecutionReport> DatabaseLevelCommunityTools =>
+            CommunityToolsList.Where(x => x.DatabaseNameParameter != null).ToList();
     }
 }

--- a/DBADashGUI/CommunityTools/DirectExecutionReport.cs
+++ b/DBADashGUI/CommunityTools/DirectExecutionReport.cs
@@ -8,5 +8,6 @@ namespace DBADashGUI.CommunityTools
 {
     internal class DirectExecutionReport : CustomReports.CustomReport
     {
+        public string DatabaseNameParameter { get; set; }
     }
 }

--- a/DBADashGUI/CustomReports/CustomReport.cs
+++ b/DBADashGUI/CustomReports/CustomReport.cs
@@ -45,14 +45,14 @@ namespace DBADashGUI.CustomReports
         /// </summary>
         [JsonIgnore]
         public IEnumerable<Param> UserParams => Params == null ? new List<Param>() : Params.ParamList.Where(p =>
-                                                                                                                                                                                                                                    !SystemParamNames.Contains(p.ParamName.ToUpper()));
+                                                                                                                                                                                                                                            !SystemParamNames.Contains(p.ParamName.ToUpper()));
 
         /// <summary>
         /// Parameters for the stored procedure that are supplied automatically based on context
         /// </summary>
         [JsonIgnore]
         public IEnumerable<Param> SystemParams => Params == null ? new List<Param>() : Params.ParamList.Where(p =>
-                                                                                                                                    SystemParamNames.Contains(p.ParamName.ToUpper()));
+                                                                                                                                            SystemParamNames.Contains(p.ParamName.ToUpper()));
 
         [JsonIgnore]
         public bool IsRootLevel => Params != null && Params.ParamList.Any(p => p.ParamName.ToUpper() == "@INSTANCEIDS");
@@ -72,9 +72,9 @@ namespace DBADashGUI.CustomReports
         /// If report has @FromDate & @ToDate parameters, the global date/time filter should be visible and date range supplied to the report
         /// </summary>
         [JsonIgnore]
-        public bool TimeFilterSupported => Params.ParamList.Any(p =>
-                                                                                                                                                                                                                                    p.ParamName.Equals("@FromDate", StringComparison.CurrentCultureIgnoreCase) ||
-                                                                                                                                                                                                                                    p.ParamName.Equals("@ToDate", StringComparison.CurrentCultureIgnoreCase));
+        public bool TimeFilterSupported => Params != null && Params.ParamList.Any(p =>
+                                                                                                                                                                                                                                            p.ParamName.Equals("@FromDate", StringComparison.CurrentCultureIgnoreCase) ||
+                                                                                                                                                                                                                                            p.ParamName.Equals("@ToDate", StringComparison.CurrentCultureIgnoreCase));
 
         /// <summary>
         /// Save customizations

--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -923,6 +923,7 @@ namespace DBADashGUI.CustomReports
             this.context = _context;
             report = _context.Report;
             customParams = sqlParams ?? report.GetCustomSqlParameters();
+            SetContextParametersForDirectExecutionReport();
             tsParams.Enabled = customParams.Count > 0;
             tsConfigure.Visible = report.CanEditReport;
             SetStatus(report.Description, report.Description, DBADashUser.SelectedTheme.ForegroundColor);
@@ -944,6 +945,28 @@ namespace DBADashGUI.CustomReports
             if (AutoLoad)
             {
                 RefreshData();
+            }
+        }
+
+        private void SetContextParametersForDirectExecutionReport() // Set DatabaseName
+        {
+            if (report is not DirectExecutionReport dxReport) return;
+            if (string.IsNullOrEmpty(context.DatabaseName)) return;
+            foreach (var p in customParams.Where(p =>
+                         p.Param.ParameterName.Equals(dxReport.DatabaseNameParameter,
+                             StringComparison.InvariantCultureIgnoreCase)))
+            {
+                p.Param.Value = context.DatabaseName;
+                p.UseDefaultValue = false;
+            }
+            // Some reports have a parameter to get all databases that we need to turn off
+            foreach (var p in customParams.Where(p =>
+                         string.Equals(p.Param.ParameterName, "@GetAllDatabases") ||
+                         string.Equals(p.Param.ParameterName, "@get_all_databases",
+                             StringComparison.OrdinalIgnoreCase)))
+            {
+                p.Param.Value = false;
+                p.UseDefaultValue = false;
             }
         }
 

--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -488,9 +488,9 @@ namespace DBADashGUI
                             new SQLTreeItem("Checks", SQLTreeItem.TreeType.DBAChecks)
                             }
                         );
+                    AzureNode.Nodes.Add(azureDBNode);
                     azureDBNode.AddDatabaseFolders();
                     azureDBNode.AddInstanceActionsContextMenu();
-                    AzureNode.Nodes.Add(azureDBNode);
                 }
                 else
                 {

--- a/DBADashGUI/SQLTreeItem.cs
+++ b/DBADashGUI/SQLTreeItem.cs
@@ -644,6 +644,7 @@ namespace DBADashGUI
             var nSeq = NewFolder("Sequences", "SO", true);
             var nTriggers = NewFolder("Triggers", "TA,TR", true);
             AddReportsFolder(CustomReports.CustomReports.GetCustomReports().DatabaseLevelReports);
+            AddCommunityTools();
             nTypes.Nodes.Add(nTableTypes);
             nTypes.Nodes.Add(nDataTypes);
             nTypes.Nodes.Add(nUserDefinedTypes);
@@ -956,7 +957,12 @@ namespace DBADashGUI
             if (!DBADashUser.CommunityScripts) return;
             var communityTools = new SQLTreeItem("Community Tools", SQLTreeItem.TreeType.CommunityToolsFolder);
             var agent = Context.CollectAgent;
-            foreach (var n in CommunityTools.CommunityTools.CommunityToolsList.OrderBy(tool=>tool.ReportName).Select(tool => new SQLTreeItem(tool.ProcedureName, SQLTreeItem.TreeType.CommunityTool)
+
+            var toolsList = DatabaseID > 0
+                ? CommunityTools.CommunityTools.DatabaseLevelCommunityTools
+                : CommunityTools.CommunityTools.CommunityToolsList;
+
+            foreach (var n in toolsList.OrderBy(tool => tool.ReportName).Select(tool => new SQLTreeItem(tool.ProcedureName, SQLTreeItem.TreeType.CommunityTool)
             {
                 Report = tool
             }))


### PR DESCRIPTION
For scripts that can execute at database level, allow the script to be executed under the database node, automatically providing the context database.