### PR TITLE
Custom Report - Add Link Fix

### DIFF
--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -114,6 +114,7 @@ namespace DBADashGUI.CustomReports
                     customReportResult.LinkColumns.Add(col, frm.LinkColumnInfo);
                 }
 
+                previousSchema = null; // Force grids to be re-generated
                 dgv.Columns.Clear();
                 report.Update();
                 ShowTable();


### PR DESCRIPTION
Add Link was broken by a previous update.  The columns were cleared but were no longer added back as it now only re-generates the grids if there has been a schema change.