### PR TITLE
Fix for Hidden Instances

### DIFF
--- a/DBADashGUI/AgentJobs/RunningJobs.cs
+++ b/DBADashGUI/AgentJobs/RunningJobs.cs
@@ -61,7 +61,7 @@ namespace DBADashGUI.AgentJobs
         public void RefreshData()
         {
             var dt = GetRunningJobs();
-            dgvRunningJobs.DataSource = new DataView(dt,PersistedFilter,PersistedSort, DataViewRowState.CurrentRows);
+            dgvRunningJobs.DataSource = new DataView(dt, PersistedFilter, PersistedSort, DataViewRowState.CurrentRows);
             PersistedFilter = null;
             PersistedSort = null;
         }
@@ -179,7 +179,7 @@ namespace DBADashGUI.AgentJobs
 
                 JobHistoryForm?.Close();
                 JobHistoryForm = new();
-                var jobContext = new DBADashContext() { InstanceID = instanceId, JobID = jobId, InstanceIDs = new HashSet<int>() { instanceId }, RegularInstanceIDs = new HashSet<int>() { instanceId }, JobStepID = -1 };
+                var jobContext = new DBADashContext() { InstanceID = instanceId, JobID = jobId, RegularInstanceIDsWithHidden = new HashSet<int>() { instanceId }, JobStepID = -1 };
                 JobHistoryForm.ShowSteps = true;
                 JobHistoryForm.SetContext(jobContext);
                 JobHistoryForm.FormClosed += delegate { JobHistoryForm = null; };

--- a/DBADashGUI/Checks/Summary.cs
+++ b/DBADashGUI/Checks/Summary.cs
@@ -558,7 +558,7 @@ namespace DBADashGUI
 
         private void ShowCorruptionViewer(string instance, int instanceID)
         {
-            DBADashContext ctx = new() { InstanceIDs = new HashSet<int>() { instanceID }, InstanceID = instanceID, InstanceName = instance };
+            DBADashContext ctx = new() { RegularInstanceIDsWithHidden = new HashSet<int>() { instanceID }, InstanceID = instanceID, InstanceName = instance };
             ShowCorruptionViewer(ctx);
         }
 

--- a/DBADashGUI/CommonData.cs
+++ b/DBADashGUI/CommonData.cs
@@ -3,6 +3,7 @@ using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Runtime.Caching;
 using DBADash;
 
@@ -17,6 +18,7 @@ namespace DBADashGUI
         public static void UpdateInstancesList(string tagIDs = "", bool? Active = true, bool? azureDB = null, string searchString = "", string groupByTag = "")
         {
             Instances = GetInstances(tagIDs, Active, azureDB, searchString, groupByTag);
+            DBADashContext.HiddenInstanceIDs = Instances.Rows.Cast<DataRow>().Where(r => !r.Field<bool>("ShowInSummary")).Select(r => r.Field<int>("InstanceID")).ToHashSet();
         }
 
         public static DataTable GetInstances(string tagIDs = "", bool? Active = true, bool? azureDB = null, string searchString = "", string groupByTag = "")

--- a/DBADashGUI/DBADashContext.cs
+++ b/DBADashGUI/DBADashContext.cs
@@ -9,9 +9,17 @@ namespace DBADashGUI
 {
     public class DBADashContext : ICloneable
     {
-        public HashSet<int> InstanceIDs;
-        public HashSet<int> AzureInstanceIDs;
-        public HashSet<int> RegularInstanceIDs;
+        public HashSet<int> InstanceIDs => new HashSet<int>(RegularInstanceIDs.Union(AzureInstanceIDs));
+        public HashSet<int> AzureInstanceIDs => ShowHiddenInstances ? AzureInstanceIDsWithHidden : new HashSet<int>(AzureInstanceIDsWithHidden.Except(HiddenInstanceIDs));
+        public HashSet<int> RegularInstanceIDs => ShowHiddenInstances ? RegularInstanceIDsWithHidden : new HashSet<int>(RegularInstanceIDsWithHidden.Except(HiddenInstanceIDs));
+
+        public bool ShowHiddenInstances => Common.ShowHidden || InstanceID > 0;
+
+        public HashSet<int> RegularInstanceIDsWithHidden = new();
+        public HashSet<int> AzureInstanceIDsWithHidden = new();
+
+        public static HashSet<int> HiddenInstanceIDs = new();
+
         public string InstanceName { get; set; }
         public string DatabaseName { get; set; }
         public int InstanceID { get; set; }
@@ -41,7 +49,7 @@ namespace DBADashGUI
         {
             get
             {
-                if(_productVersion != null) return _productVersion;
+                if (_productVersion != null) return _productVersion;
                 GetAdditionalInfo();
                 return _productVersion;
             }
@@ -51,7 +59,7 @@ namespace DBADashGUI
         {
             get
             {
-                if(_importAgentID != null || InstanceID <=0) return _importAgentID;
+                if (_importAgentID != null || InstanceID <= 0) return _importAgentID;
                 GetAdditionalInfo();
                 return _importAgentID;
             }
@@ -61,7 +69,7 @@ namespace DBADashGUI
         {
             get
             {
-                if(_collectAgentID != null || InstanceID<=0) return _collectAgentID;
+                if (_collectAgentID != null || InstanceID <= 0) return _collectAgentID;
                 GetAdditionalInfo();
                 return _collectAgentID;
             }
@@ -71,7 +79,7 @@ namespace DBADashGUI
         {
             get
             {
-                if(_connectionID != null) return _connectionID;
+                if (_connectionID != null) return _connectionID;
                 GetAdditionalInfo();
                 return _connectionID;
             }
@@ -81,8 +89,8 @@ namespace DBADashGUI
 
         private void GetAdditionalInfo()
         {
-            if(InstanceID<=0) return;
-            var row =  CommonData.Instances.Select($"InstanceID={InstanceID}").FirstOrDefault();
+            if (InstanceID <= 0) return;
+            var row = CommonData.Instances.Select($"InstanceID={InstanceID}").FirstOrDefault();
             if (row == null) return;
             _collectAgentID = (int)row["CollectAgentID"];
             _importAgentID = (int)row["ImportAgentID"];


### PR DESCRIPTION
Application context now filters the list of instance IDs to exclude hidden instances when required.  This avoids the need for a `@ShowHidden` parameter to be included in reports and ensures consistency in the app. #1111