### PR TITLE
Community Tools - Persist data when switching tabs

### DIFF
--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -932,6 +932,7 @@ namespace DBADashGUI.CustomReports
 
         public async Task SetContext(DBADashContext _context, List<CustomSqlParameter> sqlParams)
         {
+            if (_context == this.context) return;
             if (this.InvokeRequired)
             {
                 this.Invoke(new Action(() => _ = SetContext(_context, sqlParams)));


### PR DESCRIPTION
Persist data when returning to the same tab unless context has changed.