### PR TITLE
Running Queries / Slow Queries improvements

### DIFF
--- a/DBADashGUI/Config.cs
+++ b/DBADashGUI/Config.cs
@@ -39,6 +39,7 @@ namespace DBADashGUI
         public static int CriticalWaitCriticalThreshold;
         public static int CriticalWaitWarningThreshold;
         public static int? HardDeleteThresholdDays;
+        public static int SlowQueriesDrillDownMaxRows;
 
         static Config()
         {
@@ -104,6 +105,7 @@ namespace DBADashGUI
             CriticalWaitCriticalThreshold = settings.GetValueAsInt("CriticalWaitCriticalThreshold", -1);
             CriticalWaitWarningThreshold = settings.GetValueAsInt("CriticalWaitWarningThreshold", -1);
             HardDeleteThresholdDays = settings.GetValueAsNullableInt("HardDeleteThresholdDays");
+            SlowQueriesDrillDownMaxRows = settings.GetValueAsInt("GUISlowQueriesDrillDownMaxRows", 1000);
         }
 
         public static void ResetDefaults()

--- a/DBADashGUI/Main.Designer.cs
+++ b/DBADashGUI/Main.Designer.cs
@@ -1550,7 +1550,6 @@ namespace DBADashGUI
             // 
             // slowQueries1
             // 
-            slowQueries1.DBName = "";
             slowQueries1.Dock = System.Windows.Forms.DockStyle.Fill;
             slowQueries1.Location = new System.Drawing.Point(3, 3);
             slowQueries1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);

--- a/DBADashGUI/Options Menu/RepoSettings.cs
+++ b/DBADashGUI/Options Menu/RepoSettings.cs
@@ -35,7 +35,8 @@ namespace DBADashGUI.Options_Menu
             ("MinIOPsThreshold","Minimum IOPs threshold.  Below this threshold, the latency thresholds don't apply. Performance summary tab.",typeof(int), Config.MinIOPsThreshold),
             ("CriticalWaitCriticalThreshold","Critical wait ms/sec critical threshold.  Performance summary tab.",typeof(int), Config.CriticalWaitCriticalThreshold),
             ("CriticalWaitWarningThreshold","Critical wait ms/sec warning threshold. Performance summary tab.",typeof(int), Config.CriticalWaitWarningThreshold),
-            ("HardDeleteThresholdDays","Remove all the data associated with a (soft) deleted instance a specified number of days after the last collection.",typeof(int?),Config.HardDeleteThresholdDays )
+            ("HardDeleteThresholdDays","Remove all the data associated with a (soft) deleted instance a specified number of days after the last collection.",typeof(int?),Config.HardDeleteThresholdDays ),
+            ("GUISlowQueriesDrillDownMaxRows", "Max drill down rows for Slow Queries tab", typeof(int),Config.SlowQueriesDrillDownMaxRows),
         };
 
         private void Options_Load(object sender, EventArgs e)

--- a/DBADashGUI/Performance/RunningQueries.cs
+++ b/DBADashGUI/Performance/RunningQueries.cs
@@ -13,7 +13,6 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
-using OpenTK.Graphics;
 
 namespace DBADashGUI.Performance
 {
@@ -23,7 +22,7 @@ namespace DBADashGUI.Performance
         {
             InitializeComponent();
             dgv.RegisterClearFilter(tsClearFilter);
-            dgv.GridFilterChanged += (sender, e) =>
+            dgv.GridFilterChanged += (_, _) =>
             {
                 if (!dgv.HasFilter)
                 {
@@ -298,19 +297,17 @@ namespace DBADashGUI.Performance
         /// <summary>Get running query snapshots associated with a specified session id between two dates (for associating RPC/Batch completed events with running queries)</summary>
         private static DataTable RunningQueriesForSession(int sessionID, DateTime fromDate, DateTime toDate, int instanceID)
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("RunningQueriesForSession_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
-            {
-                cmd.Parameters.AddWithValue("SessionID", sessionID);
-                cmd.Parameters.Add(new SqlParameter("SnapshotDateFrom", fromDate) { DbType = DbType.DateTime2 });
-                cmd.Parameters.Add(new SqlParameter("SnapshotDateTo", toDate) { DbType = DbType.DateTime2 });
-                cmd.Parameters.AddWithValue("InstanceID", instanceID);
-                DataTable dt = new();
-                da.Fill(dt);
-                ApplyTableModifications(dt);
-                return dt;
-            }
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("RunningQueriesForSession_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            cmd.Parameters.AddWithValue("SessionID", sessionID);
+            cmd.Parameters.Add(new SqlParameter("SnapshotDateFrom", fromDate) { DbType = DbType.DateTime2 });
+            cmd.Parameters.Add(new SqlParameter("SnapshotDateTo", toDate) { DbType = DbType.DateTime2 });
+            cmd.Parameters.AddWithValue("InstanceID", instanceID);
+            DataTable dt = new();
+            da.Fill(dt);
+            ApplyTableModifications(dt);
+            return dt;
         }
 
         private static void ApplyTableModifications(DataTable dt)
@@ -326,79 +323,71 @@ namespace DBADashGUI.Performance
 
         private static DataTable RunningQueriesForJob(Guid JobId, DateTime fromDate, DateTime toDate, int instanceID)
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("RunningQueriesForJob_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
-            {
-                cmd.Parameters.AddWithValue("JobID", JobId);
-                cmd.Parameters.Add(new SqlParameter("SnapshotDateFrom", fromDate) { DbType = DbType.DateTime2 });
-                cmd.Parameters.Add(new SqlParameter("SnapshotDateTo", toDate) { DbType = DbType.DateTime2 });
-                cmd.Parameters.AddWithValue("InstanceID", instanceID);
-                DataTable dt = new();
-                da.Fill(dt);
-                ApplyTableModifications(dt);
-                return dt;
-            }
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("RunningQueriesForJob_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            cmd.Parameters.AddWithValue("JobID", JobId);
+            cmd.Parameters.Add(new SqlParameter("SnapshotDateFrom", fromDate) { DbType = DbType.DateTime2 });
+            cmd.Parameters.Add(new SqlParameter("SnapshotDateTo", toDate) { DbType = DbType.DateTime2 });
+            cmd.Parameters.AddWithValue("InstanceID", instanceID);
+            DataTable dt = new();
+            da.Fill(dt);
+            ApplyTableModifications(dt);
+            return dt;
         }
 
         /// <summary>Get last running query snapshot summary data for all servers</summary>
         private DataTable RunningQueriesServerSummary()
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("dbo.RunningQueriesServerSummary_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
-            {
-                var dt = new DataTable();
-                cmd.Parameters.AddWithValue("InstanceIDs", string.Join(",", InstanceIDs));
-                cmd.Parameters.AddWithValue("ShowHidden", InstanceIDs.Count == 1 || Common.ShowHidden);
-                da.Fill(dt);
-                DateHelper.ConvertUTCToAppTimeZone(ref dt);
-                dt.Columns["SnapshotDateUTC"].ColumnName = "SnapshotDate";
-                return dt;
-            }
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("dbo.RunningQueriesServerSummary_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            var dt = new DataTable();
+            cmd.Parameters.AddWithValue("InstanceIDs", string.Join(",", InstanceIDs));
+            cmd.Parameters.AddWithValue("ShowHidden", InstanceIDs.Count == 1 || Common.ShowHidden);
+            da.Fill(dt);
+            DateHelper.ConvertUTCToAppTimeZone(ref dt);
+            dt.Columns["SnapshotDateUTC"].ColumnName = "SnapshotDate";
+            return dt;
         }
 
         /// <summary>Get a list of running query snapshots for the specified instance</summary>
         private DataTable RunningQueriesSummary()
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("dbo.RunningQueriesSummary_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
-            {
-                var dt = new DataTable();
-                cmd.Parameters.AddWithValue("InstanceID", InstanceID);
-                cmd.Parameters.AddWithValue("FromDate", DateRange.FromUTC);
-                cmd.Parameters.AddWithValue("ToDate", DateRange.ToUTC);
-                cmd.Parameters.AddWithValue("MaxRows", Properties.Settings.Default.RunningQueriesSummaryMaxRows);
-                da.Fill(dt);
-                DateHelper.ConvertUTCToAppTimeZone(ref dt);
-                dt.Columns["SnapshotDateUTC"].ColumnName = "SnapshotDate";
-                return dt;
-            }
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("dbo.RunningQueriesSummary_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            var dt = new DataTable();
+            cmd.Parameters.AddWithValue("InstanceID", InstanceID);
+            cmd.Parameters.AddWithValue("FromDate", DateRange.FromUTC);
+            cmd.Parameters.AddWithValue("ToDate", DateRange.ToUTC);
+            cmd.Parameters.AddWithValue("MaxRows", Properties.Settings.Default.RunningQueriesSummaryMaxRows);
+            da.Fill(dt);
+            DateHelper.ConvertUTCToAppTimeZone(ref dt);
+            dt.Columns["SnapshotDateUTC"].ColumnName = "SnapshotDate";
+            return dt;
         }
 
         /// <summary>Get running queries snapshot data for the specified snapshot date. skip parameter is used to return next snapshot (1) or previous snapshot (-1)</summary>
         private DataTable RunningQueriesSnapshot(ref DateTime snapshotDate, int skip = 0)
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("dbo.RunningQueries_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("dbo.RunningQueries_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            var dt = new DataTable();
+            cmd.Parameters.AddWithValue("InstanceID", InstanceID);
+            var pSnapshotDate = cmd.Parameters.AddWithValue("SnapshotDate", snapshotDate);
+            cmd.Parameters.AddWithValue("Skip", skip);
+            pSnapshotDate.SqlDbType = SqlDbType.DateTime2;
+            pSnapshotDate.Direction = ParameterDirection.InputOutput;
+            if (snapshotDate == DateTime.MaxValue)
             {
-                var dt = new DataTable();
-                cmd.Parameters.AddWithValue("InstanceID", InstanceID);
-                var pSnapshotDate = cmd.Parameters.AddWithValue("SnapshotDate", snapshotDate);
-                cmd.Parameters.AddWithValue("Skip", skip);
-                pSnapshotDate.SqlDbType = SqlDbType.DateTime2;
-                pSnapshotDate.Direction = ParameterDirection.InputOutput;
-                if (snapshotDate == DateTime.MaxValue)
-                {
-                    pSnapshotDate.Value = DBNull.Value;
-                }
-                da.Fill(dt);
-                snapshotDate = Convert.ToDateTime(pSnapshotDate.Value);
-                ApplyTableModifications(dt);
-                return dt;
+                pSnapshotDate.Value = DBNull.Value;
             }
+            da.Fill(dt);
+            snapshotDate = Convert.ToDateTime(pSnapshotDate.Value);
+            ApplyTableModifications(dt);
+            return dt;
         }
 
         /// <summary>Load a running queries snapshot for the specified date. skip parameter is used to return next snapshot (1) or previous snapshot (-1) </summary>
@@ -885,33 +874,29 @@ namespace DBADashGUI.Performance
         /// <summary>Get session level wait stats for a specified session or for all sessions</summary>
         private static DataTable GetSessionWaits(int InstanceID, short? SessionID, DateTime? SnapshotDateUTC, DateTime? LoginTimeUTC)
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("dbo.SessionWaits_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
-            {
-                cmd.Parameters.AddWithValue("InstanceID", InstanceID);
-                cmd.Parameters.AddWithValue("SessionID", SessionID);
-                cmd.Parameters.Add(new SqlParameter("SnapshotDateUTC", SnapshotDateUTC) { DbType = DbType.DateTime2 });
-                cmd.Parameters.AddWithValue("LoginTimeUTC", LoginTimeUTC);
-                var dt = new DataTable();
-                da.Fill(dt);
-                return dt;
-            }
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("dbo.SessionWaits_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            cmd.Parameters.AddWithValue("InstanceID", InstanceID);
+            cmd.Parameters.AddWithValue("SessionID", SessionID);
+            cmd.Parameters.Add(new SqlParameter("SnapshotDateUTC", SnapshotDateUTC) { DbType = DbType.DateTime2 });
+            cmd.Parameters.AddWithValue("LoginTimeUTC", LoginTimeUTC);
+            var dt = new DataTable();
+            da.Fill(dt);
+            return dt;
         }
 
         /// <summary>Get session level wait stats for the specified snapshot over all sessions.</summary>
         private static DataTable GetSessionWaitSummary(int InstanceID, DateTime? SnapshotDateUTC)
         {
-            using (var cn = new SqlConnection(Common.ConnectionString))
-            using (var cmd = new SqlCommand("dbo.SessionWaitsSummary_Get", cn) { CommandType = CommandType.StoredProcedure })
-            using (var da = new SqlDataAdapter(cmd))
-            {
-                cmd.Parameters.AddWithValue("InstanceID", InstanceID);
-                cmd.Parameters.Add(new SqlParameter("SnapshotDateUTC", SnapshotDateUTC) { DbType = DbType.DateTime2 });
-                var dt = new DataTable();
-                da.Fill(dt);
-                return dt;
-            }
+            using var cn = new SqlConnection(Common.ConnectionString);
+            using var cmd = new SqlCommand("dbo.SessionWaitsSummary_Get", cn) { CommandType = CommandType.StoredProcedure };
+            using var da = new SqlDataAdapter(cmd);
+            cmd.Parameters.AddWithValue("InstanceID", InstanceID);
+            cmd.Parameters.Add(new SqlParameter("SnapshotDateUTC", SnapshotDateUTC) { DbType = DbType.DateTime2 });
+            var dt = new DataTable();
+            da.Fill(dt);
+            return dt;
         }
 
         private void TsSessionWaitCopy_Click(object sender, EventArgs e)

--- a/DBADashGUI/Performance/RunningQueries.cs
+++ b/DBADashGUI/Performance/RunningQueries.cs
@@ -13,6 +13,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
+using OpenTK.Graphics;
 
 namespace DBADashGUI.Performance
 {
@@ -32,11 +33,12 @@ namespace DBADashGUI.Performance
             };
         }
 
+        private DBADashContext CurrentContext;
         private string PersistedSort;
         private string PersistedFilter;
 
         public int InstanceID;
-        private List<int> InstanceIDs;
+        private HashSet<int> InstanceIDs => CurrentContext.InstanceIDs;
         private DateTime currentSnapshotDate;
         private DataTable snapshotDT;
         public DateTime SnapshotDateFrom;
@@ -135,18 +137,15 @@ namespace DBADashGUI.Performance
 
         public void SetContext(DBADashContext _context)
         {
+            if (CurrentContext == _context) return; // Context hasn't changed, don't refresh
             ShowLatestOnNextExecution = false;
-            if (InstanceIDs != null && _context.InstanceIDs.SetEquals(InstanceIDs) && InstanceID == _context.InstanceID) // Context hasn't changed
-            {
-                return;
-            }
+            CurrentContext = _context;
             currentSnapshotDate = DateTime.MinValue;
             dgv.DataSource = null;
-            InstanceIDs = _context.InstanceIDs.ToList();
             InstanceID = _context.InstanceID;
             if (InstanceIDs is { Count: 1 })
             {
-                InstanceID = InstanceIDs[0];
+                InstanceID = InstanceIDs.First();
             }
             RefreshData();
         }

--- a/DBADashGUI/Performance/SlowQueries.cs
+++ b/DBADashGUI/Performance/SlowQueries.cs
@@ -426,8 +426,6 @@ namespace DBADashGUI
             }
         }
 
-        public int pageSize = 1000;
-
         private void DgvSummary_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
             if (e.RowIndex < 0) return;
@@ -613,7 +611,7 @@ namespace DBADashGUI
             {
                 cn.Open();
                 cmd.Parameters.AddWithValue("InstanceIDs", string.Join(",", InstanceIDs));
-                cmd.Parameters.AddWithValue("Top", pageSize);
+                cmd.Parameters.AddWithValue("Top", Config.SlowQueriesDrillDownMaxRows);
                 if (failed)
                 {
                     cmd.Parameters.AddWithValue("ResultFailed", true);
@@ -818,9 +816,10 @@ namespace DBADashGUI
             }
 
             DateHelper.ConvertUTCToAppTimeZone(ref dt);
-            if (dt.Rows.Count == pageSize)
+            if (dt.Rows.Count == Config.SlowQueriesDrillDownMaxRows)
             {
-                lblPageSize.Text = $"Top {pageSize} rows";
+                lblPageSize.Text = $"Top {Config.SlowQueriesDrillDownMaxRows} rows";
+                lblPageSize.ForeColor = DashColors.Fail;
                 lblPageSize.Visible = true;
             }
             else


### PR DESCRIPTION
Improve multi-tasking by not automatically refreshing data on tab load unless the context changes.  
Allow the max drill-down rows to be configurable on the slow queries tab.