### PR TITLE
Column Height Fix

### DIFF
--- a/DBADashGUI/AgentJobs/AgentJobsControl.Designer.cs
+++ b/DBADashGUI/AgentJobs/AgentJobsControl.Designer.cs
@@ -167,7 +167,6 @@ namespace DBADashGUI.AgentJobs
             dgvJobs.ResultSetName = null;
             dgvJobs.RowHeadersVisible = false;
             dgvJobs.RowHeadersWidth = 51;
-            dgvJobs.RowTemplate.Height = 24;
             dgvJobs.Size = new System.Drawing.Size(2197, 216);
             dgvJobs.TabIndex = 0;
             dgvJobs.CellContentClick += DgvJobs_CellContentClick;
@@ -529,7 +528,6 @@ namespace DBADashGUI.AgentJobs
             dgvJobHistory.ResultSetName = null;
             dgvJobHistory.RowHeadersVisible = false;
             dgvJobHistory.RowHeadersWidth = 51;
-            dgvJobHistory.RowTemplate.Height = 24;
             dgvJobHistory.Size = new System.Drawing.Size(2197, 200);
             dgvJobHistory.TabIndex = 4;
             dgvJobHistory.CellContentClick += DgvJobHistory_CellContentClick;

--- a/DBADashGUI/AgentJobs/JobDDLHistory.Designer.cs
+++ b/DBADashGUI/AgentJobs/JobDDLHistory.Designer.cs
@@ -93,7 +93,6 @@ namespace DBADashGUI.Changes
             this.dgv.Name = "dgv";
             this.dgv.ReadOnly = true;
             this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
             this.dgv.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             this.dgv.Size = new System.Drawing.Size(1017, 183);
             this.dgv.TabIndex = 0;

--- a/DBADashGUI/AgentJobs/JobDiff.Designer.cs
+++ b/DBADashGUI/AgentJobs/JobDiff.Designer.cs
@@ -102,7 +102,6 @@ namespace DBADashGUI
             dgvJobs.ReadOnly = true;
             dgvJobs.RowHeadersVisible = false;
             dgvJobs.RowHeadersWidth = 51;
-            dgvJobs.RowTemplate.Height = 24;
             dgvJobs.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             dgvJobs.Size = new System.Drawing.Size(1338, 329);
             dgvJobs.TabIndex = 0;

--- a/DBADashGUI/AgentJobs/JobStats.Designer.cs
+++ b/DBADashGUI/AgentJobs/JobStats.Designer.cs
@@ -194,7 +194,6 @@ namespace DBADashGUI.AgentJobs
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(904, 327);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/Bak/BackupsControl.Designer.cs
+++ b/DBADashGUI/Bak/BackupsControl.Designer.cs
@@ -308,7 +308,6 @@ namespace DBADashGUI.Backups
             dgvSummary.ResultSetName = null;
             dgvSummary.RowHeadersVisible = false;
             dgvSummary.RowHeadersWidth = 51;
-            dgvSummary.RowTemplate.Height = 24;
             dgvSummary.Size = new System.Drawing.Size(1947, 260);
             dgvSummary.TabIndex = 0;
             dgvSummary.CellContentClick += DgvSummary_CellContentClick;

--- a/DBADashGUI/Changes/Alerts.Designer.cs
+++ b/DBADashGUI/Changes/Alerts.Designer.cs
@@ -95,7 +95,6 @@ namespace DBADashGUI.Changes
             dgvAlertsConfig.ResultSetName = null;
             dgvAlertsConfig.RowHeadersVisible = false;
             dgvAlertsConfig.RowHeadersWidth = 51;
-            dgvAlertsConfig.RowTemplate.Height = 24;
             dgvAlertsConfig.Size = new System.Drawing.Size(667, 339);
             dgvAlertsConfig.TabIndex = 0;
             // 
@@ -219,7 +218,6 @@ namespace DBADashGUI.Changes
             dgvAlerts.ResultSetName = null;
             dgvAlerts.RowHeadersVisible = false;
             dgvAlerts.RowHeadersWidth = 51;
-            dgvAlerts.RowTemplate.Height = 24;
             dgvAlerts.Size = new System.Drawing.Size(667, 336);
             dgvAlerts.TabIndex = 0;
             dgvAlerts.CellContentClick += DgvAlerts_CellContentClick;

--- a/DBADashGUI/Changes/AzureDBResourceGovernance.Designer.cs
+++ b/DBADashGUI/Changes/AzureDBResourceGovernance.Designer.cs
@@ -76,7 +76,6 @@ namespace DBADashGUI.Changes
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(897, 661);
             dgv.TabIndex = 0;
             // 

--- a/DBADashGUI/Changes/AzureServiceObjectivesHistory.Designer.cs
+++ b/DBADashGUI/Changes/AzureServiceObjectivesHistory.Designer.cs
@@ -120,7 +120,6 @@ namespace DBADashGUI.Changes
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(1344, 444);
             dgv.TabIndex = 0;
             // 
@@ -407,7 +406,6 @@ namespace DBADashGUI.Changes
             dgvPool.ResultSetName = null;
             dgvPool.RowHeadersVisible = false;
             dgvPool.RowHeadersWidth = 51;
-            dgvPool.RowTemplate.Height = 24;
             dgvPool.Size = new System.Drawing.Size(1344, 439);
             dgvPool.TabIndex = 1;
             // 

--- a/DBADashGUI/Changes/DBConfiguration.Designer.cs
+++ b/DBADashGUI/Changes/DBConfiguration.Designer.cs
@@ -110,7 +110,6 @@ namespace DBADashGUI.Changes
             dgvConfig.ResultSetName = null;
             dgvConfig.RowHeadersVisible = false;
             dgvConfig.RowHeadersWidth = 51;
-            dgvConfig.RowTemplate.Height = 24;
             dgvConfig.Size = new System.Drawing.Size(994, 290);
             dgvConfig.TabIndex = 0;
             // 
@@ -247,7 +246,6 @@ namespace DBADashGUI.Changes
             dgvConfigHistory.ResultSetName = null;
             dgvConfigHistory.RowHeadersVisible = false;
             dgvConfigHistory.RowHeadersWidth = 51;
-            dgvConfigHistory.RowTemplate.Height = 24;
             dgvConfigHistory.Size = new System.Drawing.Size(994, 286);
             dgvConfigHistory.TabIndex = 1;
             // 

--- a/DBADashGUI/Changes/DBOptions.Designer.cs
+++ b/DBADashGUI/Changes/DBOptions.Designer.cs
@@ -131,7 +131,6 @@ namespace DBADashGUI.Changes
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(839, 321);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;
@@ -256,7 +255,6 @@ namespace DBADashGUI.Changes
             dgvHistory.ResultSetName = null;
             dgvHistory.RowHeadersVisible = false;
             dgvHistory.RowHeadersWidth = 51;
-            dgvHistory.RowTemplate.Height = 24;
             dgvHistory.Size = new System.Drawing.Size(839, 225);
             dgvHistory.TabIndex = 0;
             // 

--- a/DBADashGUI/Changes/Drivers.Designer.cs
+++ b/DBADashGUI/Changes/Drivers.Designer.cs
@@ -58,7 +58,6 @@ namespace DBADashGUI.Changes
             this.dgvDrivers.ReadOnly = true;
             this.dgvDrivers.RowHeadersVisible = false;
             this.dgvDrivers.RowHeadersWidth = 51;
-            this.dgvDrivers.RowTemplate.Height = 24;
             this.dgvDrivers.Size = new System.Drawing.Size(630, 419);
             this.dgvDrivers.TabIndex = 0;
             // 

--- a/DBADashGUI/Changes/HardwareChanges.Designer.cs
+++ b/DBADashGUI/Changes/HardwareChanges.Designer.cs
@@ -189,7 +189,6 @@ namespace DBADashGUI
             dgvHistory.ResultSetName = null;
             dgvHistory.RowHeadersVisible = false;
             dgvHistory.RowHeadersWidth = 51;
-            dgvHistory.RowTemplate.Height = 24;
             dgvHistory.Size = new System.Drawing.Size(850, 364);
             dgvHistory.TabIndex = 0;
             // 
@@ -414,7 +413,6 @@ namespace DBADashGUI
             dgvHardware.ResultSetName = null;
             dgvHardware.RowHeadersVisible = false;
             dgvHardware.RowHeadersWidth = 51;
-            dgvHardware.RowTemplate.Height = 24;
             dgvHardware.Size = new System.Drawing.Size(850, 363);
             dgvHardware.TabIndex = 0;
             dgvHardware.RowsAdded += DgvHardware_RowsAdded;

--- a/DBADashGUI/Changes/QueryStore.Designer.cs
+++ b/DBADashGUI/Changes/QueryStore.Designer.cs
@@ -76,7 +76,6 @@ namespace DBADashGUI.Changes
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(940, 572);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContent_Click;

--- a/DBADashGUI/Changes/ResourceGovernor.Designer.cs
+++ b/DBADashGUI/Changes/ResourceGovernor.Designer.cs
@@ -99,7 +99,6 @@ namespace DBADashGUI.Changes
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(895, 452);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/Changes/SQLPatching.Designer.cs
+++ b/DBADashGUI/Changes/SQLPatching.Designer.cs
@@ -290,7 +290,6 @@ namespace DBADashGUI
             dgvVersion.ResultSetName = null;
             dgvVersion.RowHeadersVisible = false;
             dgvVersion.RowHeadersWidth = 51;
-            dgvVersion.RowTemplate.Height = 24;
             dgvVersion.Size = new System.Drawing.Size(1205, 402);
             dgvVersion.TabIndex = 0;
             dgvVersion.CellContentClick += DgvVersion_CellContentClick;

--- a/DBADashGUI/Changes/TraceFlagHistory.Designer.cs
+++ b/DBADashGUI/Changes/TraceFlagHistory.Designer.cs
@@ -189,7 +189,6 @@ namespace DBADashGUI.Changes
             dgvFlags.ResultSetName = null;
             dgvFlags.RowHeadersVisible = false;
             dgvFlags.RowHeadersWidth = 51;
-            dgvFlags.RowTemplate.Height = 24;
             dgvFlags.Size = new System.Drawing.Size(676, 217);
             dgvFlags.TabIndex = 0;
             // 

--- a/DBADashGUI/Checks/CustomChecks.Designer.cs
+++ b/DBADashGUI/Checks/CustomChecks.Designer.cs
@@ -77,7 +77,6 @@ namespace DBADashGUI.Checks
             dgvCustom.ReadOnly = true;
             dgvCustom.RowHeadersVisible = false;
             dgvCustom.RowHeadersWidth = 51;
-            dgvCustom.RowTemplate.Height = 24;
             dgvCustom.Size = new System.Drawing.Size(801, 505);
             dgvCustom.TabIndex = 0;
             dgvCustom.CellContentClick += DgvCustom_CellContentClick;

--- a/DBADashGUI/Checks/Summary.Designer.cs
+++ b/DBADashGUI/Checks/Summary.Designer.cs
@@ -155,7 +155,6 @@ namespace DBADashGUI
             dgvSummary.ResultSetName = null;
             dgvSummary.RowHeadersVisible = false;
             dgvSummary.RowHeadersWidth = 51;
-            dgvSummary.RowTemplate.Height = 24;
             dgvSummary.Size = new System.Drawing.Size(1800, 119);
             dgvSummary.TabIndex = 0;
             dgvSummary.CellContentClick += DgvSummary_CellContentClick;

--- a/DBADashGUI/CollectionDates/CollectionDates.Designer.cs
+++ b/DBADashGUI/CollectionDates/CollectionDates.Designer.cs
@@ -141,7 +141,6 @@ namespace DBADashGUI.CollectionDates
             dgvCollectionDates.ReadOnly = true;
             dgvCollectionDates.RowHeadersVisible = false;
             dgvCollectionDates.RowHeadersWidth = 51;
-            dgvCollectionDates.RowTemplate.Height = 24;
             dgvCollectionDates.Size = new System.Drawing.Size(1357, 457);
             dgvCollectionDates.TabIndex = 3;
             dgvCollectionDates.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/CollectionDates/CollectionErrors.Designer.cs
+++ b/DBADashGUI/CollectionDates/CollectionErrors.Designer.cs
@@ -101,7 +101,6 @@ namespace DBADashGUI.CollectionDates
             dgvDBADashErrors.ReadOnly = true;
             dgvDBADashErrors.RowHeadersVisible = false;
             dgvDBADashErrors.RowHeadersWidth = 51;
-            dgvDBADashErrors.RowTemplate.Height = 24;
             dgvDBADashErrors.Size = new System.Drawing.Size(829, 521);
             dgvDBADashErrors.TabIndex = 2;
             dgvDBADashErrors.CellContentClick += DgvDBADashErrors_CellContentClick;

--- a/DBADashGUI/DBFiles/DBFilesControl.Designer.cs
+++ b/DBADashGUI/DBFiles/DBFilesControl.Designer.cs
@@ -193,7 +193,6 @@ namespace DBADashGUI.DBFiles
             dgvFiles.RowHeadersDefaultCellStyle = dataGridViewCellStyle16;
             dgvFiles.RowHeadersVisible = false;
             dgvFiles.RowHeadersWidth = 51;
-            dgvFiles.RowTemplate.Height = 24;
             dgvFiles.Size = new System.Drawing.Size(1616, 308);
             dgvFiles.TabIndex = 0;
             dgvFiles.CellContentClick += DgvFiles_CellContentClick;

--- a/DBADashGUI/DBFiles/SpaceTracking.Designer.cs
+++ b/DBADashGUI/DBFiles/SpaceTracking.Designer.cs
@@ -108,7 +108,6 @@ namespace DBADashGUI
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(516, 939);
             dgv.TabIndex = 1;
             dgv.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/DBFiles/TempDBConfig.Designer.cs
+++ b/DBADashGUI/DBFiles/TempDBConfig.Designer.cs
@@ -100,7 +100,6 @@ namespace DBADashGUI.DBFiles
             dgvTempDB.ReadOnly = true;
             dgvTempDB.RowHeadersVisible = false;
             dgvTempDB.RowHeadersWidth = 51;
-            dgvTempDB.RowTemplate.Height = 24;
             dgvTempDB.Size = new System.Drawing.Size(959, 549);
             dgvTempDB.TabIndex = 0;
             dgvTempDB.RowsAdded += DgvTempDB_RowsAdded;

--- a/DBADashGUI/HA/AG.Designer.cs
+++ b/DBADashGUI/HA/AG.Designer.cs
@@ -59,7 +59,6 @@ namespace DBADashGUI.HA
             dgv.ReadOnly = true;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(752, 523);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/HA/LogShippingControl.Designer.cs
+++ b/DBADashGUI/HA/LogShippingControl.Designer.cs
@@ -133,7 +133,6 @@ namespace DBADashGUI.LogShipping
             dgvLogShipping.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
             dgvLogShipping.RowHeadersVisible = false;
             dgvLogShipping.RowHeadersWidth = 51;
-            dgvLogShipping.RowTemplate.Height = 24;
             dgvLogShipping.Size = new System.Drawing.Size(698, 276);
             dgvLogShipping.TabIndex = 0;
             dgvLogShipping.CellContentClick += DgvLogShipping_CellContentClick;
@@ -376,7 +375,6 @@ namespace DBADashGUI.LogShipping
             dgvSummary.ResultSetName = null;
             dgvSummary.RowHeadersVisible = false;
             dgvSummary.RowHeadersWidth = 51;
-            dgvSummary.RowTemplate.Height = 24;
             dgvSummary.Size = new System.Drawing.Size(698, 184);
             dgvSummary.TabIndex = 3;
             dgvSummary.CellContentClick += DgvSummary_CellContentClick;

--- a/DBADashGUI/HA/Mirroring.Designer.cs
+++ b/DBADashGUI/HA/Mirroring.Designer.cs
@@ -75,7 +75,6 @@ namespace DBADashGUI.HA
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(549, 422);
             dgv.TabIndex = 0;
             dgv.RowsAdded += Dgv_RowsAdded;

--- a/DBADashGUI/Info.Designer.cs
+++ b/DBADashGUI/Info.Designer.cs
@@ -50,7 +50,6 @@
             this.dgv.ReadOnly = true;
             this.dgv.RowHeadersVisible = false;
             this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
             this.dgv.Size = new System.Drawing.Size(850, 607);
             this.dgv.TabIndex = 0;
             // 

--- a/DBADashGUI/Main.Designer.cs
+++ b/DBADashGUI/Main.Designer.cs
@@ -1095,7 +1095,6 @@ namespace DBADashGUI
             gvHistory.Name = "gvHistory";
             gvHistory.RowHeadersVisible = false;
             gvHistory.RowHeadersWidth = 51;
-            gvHistory.RowTemplate.Height = 24;
             gvHistory.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             gvHistory.Size = new System.Drawing.Size(186, 7);
             gvHistory.TabIndex = 0;

--- a/DBADashGUI/Performance/AzureSummary.Designer.cs
+++ b/DBADashGUI/Performance/AzureSummary.Designer.cs
@@ -212,7 +212,6 @@ namespace DBADashGUI.Performance
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(1455, 752);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;
@@ -902,7 +901,6 @@ namespace DBADashGUI.Performance
             dgvPool.ResultSetName = null;
             dgvPool.RowHeadersVisible = false;
             dgvPool.RowHeadersWidth = 51;
-            dgvPool.RowTemplate.Height = 24;
             dgvPool.Size = new System.Drawing.Size(1455, 440);
             dgvPool.TabIndex = 5;
             dgvPool.CellContentClick += DgvPool_CellContentClick;

--- a/DBADashGUI/Performance/CompletedRPCBatchEvent.Designer.cs
+++ b/DBADashGUI/Performance/CompletedRPCBatchEvent.Designer.cs
@@ -56,7 +56,6 @@ namespace DBADashGUI.Performance
             this.dgv.ReadOnly = true;
             this.dgv.RowHeadersVisible = false;
             this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
             this.dgv.Size = new System.Drawing.Size(395, 851);
             this.dgv.TabIndex = 1;
             // 

--- a/DBADashGUI/Performance/MemoryUsage.Designer.cs
+++ b/DBADashGUI/Performance/MemoryUsage.Designer.cs
@@ -80,7 +80,6 @@ namespace DBADashGUI.Performance
             this.dgv.ReadOnly = true;
             this.dgv.RowHeadersVisible = false;
             this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
             this.dgv.ShowCellToolTips = false;
             this.dgv.Size = new System.Drawing.Size(870, 402);
             this.dgv.TabIndex = 0;
@@ -299,7 +298,6 @@ namespace DBADashGUI.Performance
             this.dgvConfig.ReadOnly = true;
             this.dgvConfig.RowHeadersVisible = false;
             this.dgvConfig.RowHeadersWidth = 51;
-            this.dgvConfig.RowTemplate.Height = 24;
             this.dgvConfig.Size = new System.Drawing.Size(870, 402);
             this.dgvConfig.TabIndex = 0;
             // 

--- a/DBADashGUI/Performance/ObjectExecutionSummary.Designer.cs
+++ b/DBADashGUI/Performance/ObjectExecutionSummary.Designer.cs
@@ -109,7 +109,6 @@ namespace DBADashGUI.Performance
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(1262, 297);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/Performance/RunningQueries.Designer.cs
+++ b/DBADashGUI/Performance/RunningQueries.Designer.cs
@@ -142,7 +142,6 @@ namespace DBADashGUI.Performance
             dgv.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(1090, 376);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;
@@ -532,7 +531,7 @@ namespace DBADashGUI.Performance
             // tsStatus
             // 
             tsStatus.Name = "tsStatus";
-            tsStatus.Size = new System.Drawing.Size(814, 20);
+            tsStatus.Size = new System.Drawing.Size(1003, 20);
             tsStatus.Spring = true;
             tsStatus.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -568,7 +567,6 @@ namespace DBADashGUI.Performance
             dgvSessionWaits.ResultSetName = null;
             dgvSessionWaits.RowHeadersVisible = false;
             dgvSessionWaits.RowHeadersWidth = 51;
-            dgvSessionWaits.RowTemplate.Height = 24;
             dgvSessionWaits.Size = new System.Drawing.Size(1090, 134);
             dgvSessionWaits.TabIndex = 0;
             dgvSessionWaits.CellContentClick += DgvSessionWaits_CellContentClick;

--- a/DBADashGUI/Performance/SlowQueries.Designer.cs
+++ b/DBADashGUI/Performance/SlowQueries.Designer.cs
@@ -267,7 +267,6 @@ namespace DBADashGUI
             dgvSummary.ReadOnly = true;
             dgvSummary.RowHeadersVisible = false;
             dgvSummary.RowHeadersWidth = 51;
-            dgvSummary.RowTemplate.Height = 24;
             dgvSummary.Size = new System.Drawing.Size(1829, 485);
             dgvSummary.TabIndex = 0;
             dgvSummary.CellContentClick += DgvSummary_CellContentClick;
@@ -1333,7 +1332,6 @@ namespace DBADashGUI
             dgvSlow.ReadOnly = true;
             dgvSlow.RowHeadersVisible = false;
             dgvSlow.RowHeadersWidth = 51;
-            dgvSlow.RowTemplate.Height = 24;
             dgvSlow.Size = new System.Drawing.Size(1829, 807);
             dgvSlow.TabIndex = 4;
             dgvSlow.CellContentClick += DgvSlow_CellContentClick;

--- a/DBADashGUI/Performance/WaitsSummary.Designer.cs
+++ b/DBADashGUI/Performance/WaitsSummary.Designer.cs
@@ -134,7 +134,6 @@ namespace DBADashGUI.Performance
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(708, 318);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;

--- a/DBADashGUI/Pickers/SelectPerformanceCounters.Designer.cs
+++ b/DBADashGUI/Pickers/SelectPerformanceCounters.Designer.cs
@@ -65,7 +65,6 @@
             dgvCounters.Name = "dgvCounters";
             dgvCounters.RowHeadersVisible = false;
             dgvCounters.RowHeadersWidth = 51;
-            dgvCounters.RowTemplate.Height = 24;
             dgvCounters.Size = new System.Drawing.Size(1020, 756);
             dgvCounters.TabIndex = 0;
             // 

--- a/DBADashGUI/SchemaCompare/DBDiff.Designer.cs
+++ b/DBADashGUI/SchemaCompare/DBDiff.Designer.cs
@@ -175,7 +175,6 @@
             gvDiff.Name = "gvDiff";
             gvDiff.ReadOnly = true;
             gvDiff.RowHeadersWidth = 51;
-            gvDiff.RowTemplate.Height = 24;
             gvDiff.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             gvDiff.Size = new System.Drawing.Size(937, 465);
             gvDiff.TabIndex = 9;

--- a/DBADashGUI/SchemaCompare/SchemaSnapshots.Designer.cs
+++ b/DBADashGUI/SchemaCompare/SchemaSnapshots.Designer.cs
@@ -151,7 +151,6 @@
             gvSnapshots.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
             gvSnapshots.RowHeadersVisible = false;
             gvSnapshots.RowHeadersWidth = 51;
-            gvSnapshots.RowTemplate.Height = 24;
             gvSnapshots.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
             gvSnapshots.Size = new System.Drawing.Size(2019, 748);
             gvSnapshots.TabIndex = 0;
@@ -245,7 +244,6 @@
             gvSnapshotsDetail.ReadOnly = true;
             gvSnapshotsDetail.RowHeadersVisible = false;
             gvSnapshotsDetail.RowHeadersWidth = 51;
-            gvSnapshotsDetail.RowTemplate.Height = 24;
             gvSnapshotsDetail.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
             gvSnapshotsDetail.Size = new System.Drawing.Size(2019, 490);
             gvSnapshotsDetail.TabIndex = 0;
@@ -315,7 +313,6 @@
             dgvInstanceSummary.ReadOnly = true;
             dgvInstanceSummary.RowHeadersVisible = false;
             dgvInstanceSummary.RowHeadersWidth = 51;
-            dgvInstanceSummary.RowTemplate.Height = 24;
             dgvInstanceSummary.Size = new System.Drawing.Size(2019, 228);
             dgvInstanceSummary.TabIndex = 3;
             dgvInstanceSummary.CellContentClick += DgvInstanceSummary_CellContentClick;

--- a/DBADashGUI/Tagging/Tags.Designer.cs
+++ b/DBADashGUI/Tagging/Tags.Designer.cs
@@ -215,7 +215,6 @@ namespace DBADashGUI.Tagging
             dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.RowTemplate.Height = 24;
             dgv.Size = new System.Drawing.Size(917, 155);
             dgv.TabIndex = 9;
             // 
@@ -289,7 +288,6 @@ namespace DBADashGUI.Tagging
             dgvTags.ResultSetName = null;
             dgvTags.RowHeadersVisible = false;
             dgvTags.RowHeadersWidth = 51;
-            dgvTags.RowTemplate.Height = 24;
             dgvTags.Size = new System.Drawing.Size(917, 158);
             dgvTags.TabIndex = 12;
             dgvTags.CellMouseDoubleClick += DgvTags_CellMouseDoubleClick;
@@ -408,7 +406,6 @@ namespace DBADashGUI.Tagging
             dgvReport.ResultSetName = null;
             dgvReport.RowHeadersVisible = false;
             dgvReport.RowHeadersWidth = 51;
-            dgvReport.RowTemplate.Height = 24;
             dgvReport.Size = new System.Drawing.Size(917, 466);
             dgvReport.TabIndex = 0;
             dgvReport.CellContentClick += DgvReport_CellContentClick;

--- a/DBADashServiceConfig/ScheduleConfig.Designer.cs
+++ b/DBADashServiceConfig/ScheduleConfig.Designer.cs
@@ -58,7 +58,6 @@ namespace DBADashServiceConfig
             this.dgv.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.dgv.Name = "dgv";
             this.dgv.RowHeadersWidth = 51;
-            this.dgv.RowTemplate.Height = 24;
             this.dgv.Size = new System.Drawing.Size(729, 687);
             this.dgv.TabIndex = 0;
             this.dgv.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.Dgv_CellContentClick);

--- a/DBADashServiceConfig/ServiceConfig.Designer.cs
+++ b/DBADashServiceConfig/ServiceConfig.Designer.cs
@@ -1379,7 +1379,6 @@ namespace DBADashServiceConfig
             dgvConnections.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             dgvConnections.Name = "dgvConnections";
             dgvConnections.RowHeadersWidth = 51;
-            dgvConnections.RowTemplate.Height = 24;
             dgvConnections.Size = new System.Drawing.Size(1067, 308);
             dgvConnections.TabIndex = 23;
             dgvConnections.CellContentClick += DgvConnections_CellContentClick;


### PR DESCRIPTION
If the column height is too short, checkboxes won't be visible.  A height of 24 causes problems in some systems. #1140