### PR TITLE
Alert fixes

### DIFF
--- a/DBADash/Alert/EmailNotificationChannel.cs
+++ b/DBADash/Alert/EmailNotificationChannel.cs
@@ -63,7 +63,11 @@ namespace DBADash.Alert
 
             using var client = new SmtpClient();
             await client.ConnectAsync(Host, Port, SecureSocketOption);
-            await client.AuthenticateAsync(UserName, Password);
+            if (!string.IsNullOrEmpty(UserName) || !string.IsNullOrEmpty(Password)) // Authenticate if username or password is supplied
+            {
+                await client.AuthenticateAsync(UserName, Password);
+            }
+
             await client.SendAsync(message);
             await client.DisconnectAsync(true);
         }

--- a/DBADashDB/Alert/Procedures/Rule_Del.sql
+++ b/DBADashDB/Alert/Procedures/Rule_Del.sql
@@ -3,6 +3,23 @@
 )
 AS
 SET NOCOUNT ON 
+SET XACT_ABORT ON
+
+DECLARE @AlertIDs BigIDs
+
+BEGIN TRAN
+
+INSERT INTO @AlertIDs(ID)
+SELECT AlertID 
+FROM Alert.ActiveAlerts
+WHERE RuleID = @RuleID
+
+IF @@ROWCOUNT>0 /* Close any existing alerts that reference the rule */
+BEGIN
+	EXEC Alert.ClosedAlerts_Add @AlertIDs=@AlertIDs
+END
 
 DELETE Alert.Rules 
 WHERE RuleID = @RuleID
+
+COMMIT

--- a/DBADashGUI/DBADashAlerts/Rules/AlertRuleBase.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/AlertRuleBase.cs
@@ -212,7 +212,7 @@ namespace DBADashGUI.DBADashAlerts.Rules
             };
             rule.RuleID = ruleID;
             rule.Priority = (Alert.Priorities)priority;
-            rule.ApplyToTag = applyToTagID <= 0 ? null : new DBADashTag()
+            rule.ApplyToTag = applyToTagID <= 0 ? DBADashTag.AllInstancesTag() : new DBADashTag()
             { TagID = applyToTagID, TagName = applyToTag.Split(":")[0], TagValue = applyToTag.Split(":")[1] };
             rule.EvaluationPeriodMins = evaluationPeriodMins;
             rule.IsActive = isActive;


### PR DESCRIPTION
Alert rule Apply To (Tag) display fix
* The Apply To (Tag) is set to {All} when creating a rule but when editing a rule it's blank. Fixed display issue so it shows as {All} when editing.

Fix issue deleting a rule with active alerts
* Close any existing alerts that reference a rule before deleting it.

Email notification channel fix
* Only try to authenticate if a username/password is supplied.  Allow email to work with servers that don't require authentication.
