### PR TITLE
Fix time zone convert issue on custom reports with multiple results

### DIFF
--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -274,8 +274,6 @@ namespace DBADashGUI.CustomReports
                 {
                     DateHelper.ConvertUTCToAppTimeZone(ref dt, convertCols);
                 }
-
-                i += 1;
             }
         }
 


### PR DESCRIPTION
Counter is incremented twice, skipping conversion of some of the result sets.