### PR TITLE
Fix Identity Columns collection bug

### DIFF
--- a/DBADash/SQL/SQLIdentityColumns.sql
+++ b/DBADash/SQL/SQLIdentityColumns.sql
@@ -23,7 +23,7 @@ OUTER APPLY(SELECT	CASE IC.max_length
 						WHEN 1 THEN POWER(2.,IC.max_length*8) 
 							ELSE POWER(2.,IC.max_length*8-1)-1 
 					END AS max_ident,
-					POWER(2.,IC.max_length*8) AS max_rows,
+					POWER(2E0,IC.max_length*8) AS max_rows,
 					CAST(IC.last_value AS BIGINT) as last_value_big
 			) calc
 OUTER APPLY(SELECT SUM(PS.row_count) row_count


### PR DESCRIPTION
Fix `Arithmetic overflow error converting numeric to data type numeric` error that occurs if database has NUMERIC_ROUNDABORT ON.  Use FLOAT for max_rows which is appropriate for the % rows used calculation. #1182