### PR TITLE
Data Retention - ClosedAlert table

### DIFF
--- a/DBADashDB/Alert/Tables/ClosedAlerts.sql
+++ b/DBADashDB/Alert/Tables/ClosedAlerts.sql
@@ -24,3 +24,4 @@
 	CONSTRAINT PK_ClosedAlerts PRIMARY KEY(AlertID)
 )
 GO
+CREATE NONCLUSTERED INDEX IX_Alert_ClosedAlerts_ClosedDate ON Alert.ClosedAlerts(ClosedDate)

--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -804,6 +804,7 @@
     <Build Include="Alert\Procedures\CollectionDatesAlert_Upd.sql" />
     <Build Include="Alert\Procedures\NotificationLog_Get.sql" />
     <Build Include="dbo\User Defined Types\BigIDs.sql" />
+    <Build Include="dbo\Stored Procedures\PurgeClosedAlerts.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -1147,41 +1147,42 @@ WHEN NOT MATCHED BY TARGET THEN
 						   N'PVS_PREALLOCATE',N'REDO_THREAD_PENDING_WORK'
                          )
 GO
-INSERT INTO dbo.DataRetention
-(
+INSERT INTO dbo.DataRetention(
+	SchemaName,
     TableName,
     RetentionDays
 )
-SELECT t.TableName,t.RetentionDays
-FROM (VALUES('ObjectExecutionStats',120),
-				('Waits',120),
-				('DBIOStats',120),
-				('CPU',365),
-				('SlowQueries',120),
-				('AzureDBElasticPoolResourceStats',120),
-				('AzureDBResourceStats',120),
-				('CustomChecksHistory',120),
-				('DBIOStats_60MIN',730),
-				('CPU_60MIN',730),
-				('ObjectExecutionStats_60MIN',730),
-				('AzureDBElasticPoolResourceStats_60MIN',730),
-				('AzureDBResourceStats_60MIN',730),
-				('Waits_60MIN',730),
-				('PerformanceCounters', 180),
-				('PerformanceCounters_60MIN',730),
-				('JobStats_60MIN',730),
-				('JobHistory',8),
-				('RunningQueries',30),
-				('CollectionErrorLog',14),
-				('MemoryUsage',30),
-				('SessionWaits',30),
-				('IdentityColumnsHistory',730),
-				('TableSize',730)
-				) AS t(TableName,RetentionDays)
+SELECT t.SchemaName,t.TableName,t.RetentionDays
+FROM (VALUES('dbo','ObjectExecutionStats',120),
+				('dbo','Waits',120),
+				('dbo','DBIOStats',120),
+				('dbo','CPU',365),
+				('dbo','SlowQueries',120),
+				('dbo','AzureDBElasticPoolResourceStats',120),
+				('dbo','AzureDBResourceStats',120),
+				('dbo','CustomChecksHistory',120),
+				('dbo','DBIOStats_60MIN',730),
+				('dbo','CPU_60MIN',730),
+				('dbo','ObjectExecutionStats_60MIN',730),
+				('dbo','AzureDBElasticPoolResourceStats_60MIN',730),
+				('dbo','AzureDBResourceStats_60MIN',730),
+				('dbo','Waits_60MIN',730),
+				('dbo','PerformanceCounters', 180),
+				('dbo','PerformanceCounters_60MIN',730),
+				('dbo','JobStats_60MIN',730),
+				('dbo','JobHistory',8),
+				('dbo','RunningQueries',30),
+				('dbo','CollectionErrorLog',14),
+				('dbo','MemoryUsage',30),
+				('dbo','SessionWaits',30),
+				('dbo','IdentityColumnsHistory',730),
+				('dbo','TableSize',730),
+				('Alert','ClosedAlerts',180)
+				) AS t(SchemaName,TableName,RetentionDays)
 WHERE NOT EXISTS(SELECT 1 
 				FROM dbo.DataRetention DR
 				WHERE DR.TableName = T.TableName
-				AND DR.SchemaName = 'dbo')
+				AND DR.SchemaName = T.SchemaName)
 
 DELETE dbo.OSLoadedModulesStatus
 WHERE IsSystem=1

--- a/DBADashDB/dbo/Stored Procedures/PurgeClosedAlerts.sql
+++ b/DBADashDB/dbo/Stored Procedures/PurgeClosedAlerts.sql
@@ -1,0 +1,23 @@
+﻿CREATE PROC dbo.PurgeClosedAlerts(
+	@BatchSize INT=5000,
+	@KeepNotes BIT=1
+)
+AS
+
+DECLARE @RetentionDays INT 
+
+SELECT @RetentionDays = ISNULL((SELECT RetentionDays
+								FROM dbo.DataRetention
+								WHERE TableName = 'ClosedAlerts'
+								AND SchemaName = 'Alert'
+								),14)
+WHILE (1=1)
+BEGIN
+	DELETE TOP(@BatchSize)
+	FROM Alert.ClosedAlerts
+	WHERE ClosedDate < DATEADD(d,-@RetentionDays,GETUTCDATE())
+	AND (Notes IS NULL OR @KeepNotes=0) /* Keep alerts that have notes by default */
+	
+	IF @@ROWCOUNT=0
+			BREAK
+END

--- a/DBADashDB/dbo/Stored Procedures/PurgeData.sql
+++ b/DBADashDB/dbo/Stored Procedures/PurgeData.sql
@@ -1,4 +1,6 @@
-﻿CREATE PROC dbo.PurgeData
+﻿CREATE PROC dbo.PurgeData(
+	@Force BIT=0 /* Option to force purge of non-partitioned tables which usually run once per day */
+)
 AS
 SET NOCOUNT ON
 SET XACT_ABORT ON
@@ -75,7 +77,7 @@ UPDATE dbo.Settings
 WHERE SettingName = 'PurgeCollectionErrorLog_StartDate'
 AND SettingValue < DATEADD(d,-1,GETUTCDATE())
 
-IF @@ROWCOUNT =1
+IF @@ROWCOUNT =1 OR @Force=1
 BEGIN
 	PRINT 'Cleanup CollectionErrorLog'
 	EXEC dbo.PurgeCollectionErrorLog
@@ -95,7 +97,7 @@ UPDATE dbo.Settings
 WHERE SettingName = 'PurgeQueryPlans_StartDate'
 AND SettingValue < DATEADD(d,-1,GETUTCDATE())
 
-IF @@ROWCOUNT =1
+IF @@ROWCOUNT =1 OR @Force=1
 BEGIN
 	PRINT 'Cleanup QueryPlans'
 	EXEC dbo.PurgeQueryPlans
@@ -114,7 +116,7 @@ UPDATE dbo.Settings
 WHERE SettingName = 'PurgeQueryText_StartDate'
 AND SettingValue < DATEADD(d,-1,GETUTCDATE())
 
-IF @@ROWCOUNT =1
+IF @@ROWCOUNT =1 OR @Force=1
 BEGIN
 	PRINT 'Cleanup QueryText'
 	EXEC dbo.PurgeQueryText
@@ -133,7 +135,7 @@ UPDATE dbo.Settings
 WHERE SettingName = 'PurgeBlockingSnapshotSummary_StartDate'
 AND SettingValue < DATEADD(d,-1,GETUTCDATE())
 
-IF @@ROWCOUNT =1
+IF @@ROWCOUNT =1 OR @Force=1
 BEGIN
 	PRINT 'Cleanup QueryText'
 	EXEC dbo.PurgeBlockingSnapshotSummary
@@ -152,7 +154,7 @@ UPDATE dbo.Settings
 WHERE SettingName = 'PurgeClosedAlerts_StartDate'
 AND SettingValue < DATEADD(d,-1,GETUTCDATE())
 
-IF @@ROWCOUNT =1
+IF @@ROWCOUNT =1 OR @Force=1
 BEGIN
 	PRINT 'Cleanup ClosedAlerts'
 	DECLARE @KeepNotes BIT = 1

--- a/DBADashDB/dbo/Stored Procedures/Settings_Add.sql
+++ b/DBADashDB/dbo/Stored Procedures/Settings_Add.sql
@@ -30,7 +30,8 @@ VALUES	('MemoryDumpCriticalThresholdHrs',48),
 		('GUIDrivePerformanceMaxDrives',NULL),
 		('IdleWarningThresholdForSleepingSessionWithOpenTran',NULL),
 		('IdleCriticalThresholdForSleepingSessionWithOpenTran',NULL),
-		('GUICellToolTipMaxLength',NULL)
+		('GUICellToolTipMaxLength',NULL),
+		('ExcludeClosedAlertsWithNotesFromPurge',CAST(1 AS BIT))
 
 /* If reset, remove any customized settings to be re-inserted with defaults */
 IF @Reset=1
@@ -66,7 +67,9 @@ FROM (VALUES('PurgeCollectionErrorLog_StartDate'),
 			('PurgePartitions_CompletedDate'),
 			('MemoryDumpAckDate'),
 			('PurgeBlockingSnapshotSummary_CompletedDate'),
-			('PurgeBlockingSnapshotSummary_StartDate')
+			('PurgeBlockingSnapshotSummary_StartDate'),
+			('PurgeClosedAlerts_StartDate'),
+			('PurgeClosedAlerts_CompletedDate')
 	  ) T(SettingName)
 WHERE NOT EXISTS(SELECT 1 
 				FROM dbo.Settings S

--- a/DBADashGUI/Options Menu/DataRetention.cs
+++ b/DBADashGUI/Options Menu/DataRetention.cs
@@ -103,7 +103,8 @@ namespace DBADashGUI
         {
             using SqlConnection cn = new(Common.ConnectionString);
             cn.Open();
-            SqlCommand cmd = new("dbo.PurgeData", cn);
+            using SqlCommand cmd = new("dbo.PurgeData", cn) { CommandType = CommandType.StoredProcedure, CommandTimeout = Config.DefaultCommandTimeout };
+            cmd.Parameters.AddWithValue("Force", true);
             cmd.ExecuteNonQuery();
         }
 

--- a/DBADashGUI/Options Menu/RepoSettings.cs
+++ b/DBADashGUI/Options Menu/RepoSettings.cs
@@ -41,7 +41,8 @@ namespace DBADashGUI.Options_Menu
             ("HardDeleteThresholdDays","Remove all the data associated with a (soft) deleted instance a specified number of days after the last collection.",typeof(int?),Config.HardDeleteThresholdDays ),
             ("GUISlowQueriesDrillDownMaxRows", "Max drill down rows for Slow Queries tab", typeof(int),Config.SlowQueriesDrillDownMaxRows),
             ("AlertAutoCloseThresholdMins","Automatically close resolved alerts after a specified period of time (mins)", typeof(int),AlertAutoCloseThresholdMins ),
-            ("AlertMaxNotificationCount " , "Maximum number of alert notifications to send" , typeof(int) , AlertMaxNotificationCount)
+            ("AlertMaxNotificationCount " , "Maximum number of alert notifications to send" , typeof(int) , AlertMaxNotificationCount),
+            ("ExcludeClosedAlertsWithNotesFromPurge","Exclude closed alerts with notes from data retention",typeof(bool),true)
         };
 
         private void Options_Load(object sender, EventArgs e)


### PR DESCRIPTION
* Data Retention - ClosedAlert table

Add options for data retention to Alert.ClosedAlert table.  Option to exclude alerts with notes from data retention.

* Option to force data purge to run for non-partitioned tables

Data purge only runs once per day for non-partitioned tables.  With the Force parameter, the purge can run immediately regardless of the last run date.  This is useful for testing the purge process.  Also, it makes sense to run with `@Force=1` if a user is manually initiating a purge from the GUI.