### PR TITLE
IdentityColumnsInfo - Implicit conversion/arithmetic overflow bug

### DIFF
--- a/DBADashDB/dbo/Views/IdentityColumnsInfo.sql
+++ b/DBADashDB/dbo/Views/IdentityColumnsInfo.sql
@@ -53,9 +53,9 @@ SELECT	IC.InstanceID,
 FROM dbo.IdentityColumns IC
 JOIN dbo.Instances I ON I.InstanceID = IC.InstanceID
 JOIN dbo.Databases D ON D.DatabaseID = IC.DatabaseID
-OUTER APPLY (SELECT CASE WHEN IC.last_value <0 THEN (ABS(IC.min_ident)-ABS(IC.last_value)) / IC.max_rows ELSE IC.last_value/IC.max_ident END AS pct_ident_used,
+OUTER APPLY (SELECT CASE WHEN IC.last_value <0 THEN (ABS(IC.min_ident)-ABS(CONVERT(decimal(38,0), IC.last_value))) / IC.max_rows ELSE IC.last_value/IC.max_ident END AS pct_ident_used,
 					IC.row_count/IC.max_rows AS pct_rows_used,
-					CASE WHEN IC.last_value < 0 THEN ABS(IC.last_value)+IC.max_ident ELSE IC.max_ident - IC.last_value END AS remaining_ident_count,
+					CASE WHEN IC.last_value < 0 THEN ABS(CONVERT(decimal(38,0), IC.last_value))+IC.max_ident ELSE IC.max_ident - IC.last_value END AS remaining_ident_count,
 					IC.max_rows-IC.row_count AS remaining_row_count
 	
 		) AS calc


### PR DESCRIPTION
Just came across this bug, not sure why it never popped up before, but I suppose it's a bit of a timing issue.

In short: `ABS(-9,223,372,036,854,775,808)` is greater than bigint max, which is `9,223,372,036,854,775,807`. So it needs to be converted to `decimal(38,0)` first, before performing the `ABS()`.

This probably rarely pops up because it would only happen when a table has an identity column seeded with the `bigint` min value and only 1 row has been inserted, which means `last_value` would be `-9,223,372,036,854,775,808`. As soon as a second row is inserted, `last_value` will have incremented to `-9,223,372,036,854,775,807` or higher which doesn't have this problem.