### PR TITLE
Update SQLDrives.sql

### DIFF
--- a/DBADash/SQL/SQLDrives.sql
+++ b/DBADash/SQL/SQLDrives.sql
@@ -4,23 +4,23 @@ BEGIN
 END
 ELSE IF  SERVERPROPERTY('EngineEdition') = 8
 BEGIN
-	SELECT  dovs.volume_mount_point AS Name,
+	SELECT  UPPER(dovs.volume_mount_point) AS Name,
 			AVG(dovs.total_bytes + dovs.available_bytes) as Capacity, /* Total Bytes = Used for Azure MI */
 			AVG(dovs.available_bytes) as FreeSpace,
 			dovs.logical_volume_name as Label
 	FROM sys.master_files mf
 	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
-	GROUP BY dovs.volume_mount_point,
+	GROUP BY UPPER(dovs.volume_mount_point),
 			 dovs.logical_volume_name;
 END
 ELSE
 BEGIN
-	SELECT  dovs.volume_mount_point AS Name,
+	SELECT  UPPER(dovs.volume_mount_point) AS Name,
 			AVG(dovs.total_bytes) as Capacity,
 			AVG(dovs.available_bytes) as FreeSpace,
 			dovs.logical_volume_name as Label
 	FROM sys.master_files mf
 	CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) dovs
-	GROUP BY dovs.volume_mount_point,
+	GROUP BY UPPER(dovs.volume_mount_point),
 			 dovs.logical_volume_name;
 END


### PR DESCRIPTION
Using UPPER in the SELECT and GROUP BY statements mitigates an issue related to Drive Letter case sensitivity in database file physical paths (e.g., D:\filepath and d:\filepath treated as separate volumes). Issue #1214