### PR TITLE
CollectionDates Alert fix

### DIFF
--- a/DBADashDB/Alert/Procedures/CollectionDatesAlert_Upd.sql
+++ b/DBADashDB/Alert/Procedures/CollectionDatesAlert_Upd.sql
@@ -40,7 +40,7 @@ SELECT 	I.InstanceID,
 		R.Priority,	
 		R.AlertKey,
 		CDS.Reference,
-		CASE WHEN Calc.UseCriticalStatus=1 AND CDS.CriticalThreshold<R.Threshold THEN CDS.CriticalThreshold ELSE R.Threshold END AS Threshold,
+		ISNULL(CASE WHEN Calc.UseCriticalStatus=1 AND (CDS.CriticalThreshold<R.Threshold OR R.Threshold IS NULL) THEN CDS.CriticalThreshold ELSE R.Threshold END,0) AS Threshold,
 		R.RuleID,
 		CDS.SnapshotAge
 FROM Alert.Rules R 


### PR DESCRIPTION
Fix issue if use critical status is set and no threshold is specified.  In this case, the critical status threshold (daily check threshold) should be used rather than the alert threshold.  This will fix the Cannot insert the value NULL into column 'Threshold' error. Added ISNULL check just in case.
#1240