### PR TITLE
Ensure ConnectionID is populated for new connections

### DIFF
--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -396,5 +396,24 @@ namespace DBADash
             }
             throw new ArgumentException($"Unable to find instance with ConnectionID {connectionID}");
         }
+
+
+        /// <summary>
+        /// Get source connection from connection string or ConnectionID.  Returns null if not found
+        /// </summary>
+        public DBADashSource FindSourceConnection(string connectionString, string connectionId)
+        {
+            var source = GetSourceFromConnectionString(connectionString);
+            try
+            {
+                source = GetSourceConnection(connectionId);
+            }
+            catch
+            {
+                // ignore
+            }
+
+            return source;
+        }
     }
 }

--- a/DBADash/DBADashSource.cs
+++ b/DBADash/DBADashSource.cs
@@ -1,4 +1,5 @@
 ﻿using DBADashService;
+using Microsoft.Data.SqlClient;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -210,6 +211,13 @@ namespace DBADash
 
         public DBADashSource()
         {
+        }
+
+        public void SetConnectionIDFromBuilderIfNotSet()
+        {
+            if (SourceConnection.Type != ConnectionType.SQL || !string.IsNullOrEmpty(ConnectionID)) return;
+            var builder = new SqlConnectionStringBuilder(SourceConnection.ConnectionString);
+            ConnectionID = builder.DataSource is "." or "LOCALHOST" ? Environment.MachineName : builder.DataSource;
         }
 
         public string GetGeneratedConnectionID()

--- a/DBADashConfig/Options.cs
+++ b/DBADashConfig/Options.cs
@@ -25,7 +25,8 @@ SetServiceName - Change the name of the DBA Dash service
 Encrypt - Encrypt the config file with a password (--EncryptionPassword)
 Decrypt - Decrypt the config file. --DecryptionPassword can be used if required.
 SetConfigFileBackupRetention - Specify how long to keep config file backups. --RetentionDays
-PopulateConnectionID - Add ConnectionID to source connections without a ConnectionID")]
+PopulateConnectionID - Add ConnectionID to source connections without a ConnectionID
+PopulateConnectionID2 - Add ConnectionID to source connections without a ConnectionID.  If connection fails, set ConnectionID based on Data Source in connection string.")]
         public CommandLineActionOption Option { get; set; }
 
         [Option('r', "Replace", Required = false, HelpText = "Option to replace the existing connection if it already exists", Default = false)]
@@ -123,7 +124,8 @@ PopulateConnectionID - Add ConnectionID to source connections without a Connecti
             RemoveAndDelete,
             Delete,
             Restore,
-            PopulateConnectionID
+            PopulateConnectionID,
+            PopulateConnectionID2
         }
     }
 }

--- a/DBADashConfig/Program.cs
+++ b/DBADashConfig/Program.cs
@@ -115,7 +115,10 @@ try
                       break;
 
                   case CommandLineActionOption.PopulateConnectionID:
-                      Helper.PopulateConnectionID(config, o);
+                      Helper.PopulateConnectionID(config, o,false);
+                      break;
+                  case CommandLineActionOption.PopulateConnectionID2:
+                      Helper.PopulateConnectionID(config, o,true);
                       break;
               }
           });

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -115,7 +115,7 @@ namespace DBADashServiceConfig
                     CollectSessionWaits = chkCollectSessionWaits.Checked,
                     ScriptAgentJobs = chkScriptJobs.Checked,
                     IOCollectionLevel = (DBADashSource.IOCollectionLevels)cboIOLevel.SelectedItem,
-                    WriteToSecondaryDestinations = chkWriteToSecondaryDestinations.Checked,
+                    WriteToSecondaryDestinations = chkWriteToSecondaryDestinations.Checked
                 };
                 src.CustomCollections = src.SourceConnection.Type == ConnectionType.SQL ? CustomCollectionsNew : null;
                 bool validated = ValidateSource(sourceString);
@@ -188,8 +188,11 @@ namespace DBADashServiceConfig
                         src.SlowQueryThresholdMs = -1;
                         src.PersistXESessions = false;
                     }
+                    // Ensure we have a ConnectionID set for SQL connections
+                    src.SetConnectionIDFromBuilderIfNotSet();
 
-                    var existingConnection = collectionConfig.GetSourceFromConnectionString(sourceString);
+                    var existingConnection = collectionConfig.FindSourceConnection(sourceString,src.ConnectionID); // Check if the connection string exists in the config
+
                     if (existingConnection != null)
                     {
                         src.CollectionSchedules = existingConnection.CollectionSchedules;
@@ -210,7 +213,7 @@ namespace DBADashServiceConfig
                             continue;
                         }
                     }
-
+         
                     collectionConfig.SourceConnections.Add(src);
                 }
             }


### PR DESCRIPTION
The ConnectionID is now populated from the Data Source in the connection string if it's not possible to connect to the data source at the time of adding a connection. It's important that the ConnectionID is populated as it's used to report on offline instances and it's required for messaging to work.