### PR TITLE
Running Queries - Implicit Transactions

### DIFF
--- a/DBADash/DBImporter.cs
+++ b/DBADash/DBImporter.cs
@@ -232,6 +232,10 @@ namespace DBADash
                 {
                     dtRunningQueries.Columns.Add("transaction_begin_time_utc", typeof(DateTime));
                 }
+                if (!dtRunningQueries.Columns.Contains("is_implicit_transaction"))
+                {
+                    dtRunningQueries.Columns.Add("is_implicit_transaction", typeof(bool));
+                }
             }
 
             if (data.Tables.Contains("IdentityColumns"))

--- a/DBADashDB/dbo/Stored Procedures/RunningQueriesForJob_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/RunningQueriesForJob_Get.sql
@@ -81,7 +81,8 @@ SELECT InstanceID,
        statement_end_offset,
        context_info,
        transaction_duration_ms,
-       transaction_duration
+       transaction_duration,
+       is_implicit_transaction
 FROM dbo.RunningQueriesInfo Q
 WHERE Q.SnapshotDateUTC >= @SnapshotDateFrom 
 AND Q.SnapshotDateUTC < @SnapshotDateTo

--- a/DBADashDB/dbo/Stored Procedures/RunningQueriesForSession_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/RunningQueriesForSession_Get.sql
@@ -78,7 +78,8 @@ SELECT InstanceID,
        statement_end_offset,
        context_info,
        transaction_duration_ms,
-       transaction_duration
+       transaction_duration,
+       is_implicit_transaction
 FROM dbo.RunningQueriesInfo Q
 WHERE Q.SnapshotDateUTC >= @SnapshotDateFrom 
 AND Q.SnapshotDateUTC < @SnapshotDateTo

--- a/DBADashDB/dbo/Stored Procedures/RunningQueries_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/RunningQueries_Get.sql
@@ -162,7 +162,8 @@ SELECT ' + CASE WHEN @Top IS NULL THEN '' ELSE 'TOP(@Top)' END + '
        statement_end_offset,
        context_info,
        transaction_duration_ms,
-       transaction_duration
+       transaction_duration,
+       is_implicit_transaction
 FROM dbo.RunningQueriesInfo Q
 WHERE Q.InstanceID = @InstanceID
 ' + CASE WHEN @SnapshotDateFrom = @SnapshotDateTo THEN 'AND Q.SnapshotDateUTC = @SnapshotDateFrom' ELSE 'AND Q.SnapshotDateUTC >= @SnapshotDateFrom AND Q.SnapshotDateUTC < @SnapshotDateTo' END + '

--- a/DBADashDB/dbo/Stored Procedures/RunningQueries_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/RunningQueries_Upd.sql
@@ -50,6 +50,7 @@ BEGIN
 						   t.last_request_end_time_utc,
 						   t.context_info,
 						   t.transaction_begin_time_utc,
+						   t.is_implicit_transaction,
 						   ROW_NUMBER() OVER(PARTITION BY t.session_id ORDER BY t.cpu_time DESC) rnum
 					FROM  @RunningQueries t
 	)
@@ -87,7 +88,8 @@ BEGIN
 		login_time_utc,
 		last_request_end_time_utc,
 		context_info,
-		transaction_begin_time_utc
+		transaction_begin_time_utc,
+		is_implicit_transaction
 	)
 	SELECT  SnapshotDateUTC,
 	    session_id,
@@ -121,7 +123,8 @@ BEGIN
 		login_time_utc,
 		last_request_end_time_utc,
 		context_info,
-		transaction_begin_time_utc
+		transaction_begin_time_utc,
+		is_implicit_transaction
 	FROM deDupe
 	WHERE deDupe.rnum=1
 
@@ -251,7 +254,8 @@ BEGIN
 		login_time_utc,
 		last_request_end_time_utc,
 		context_info,
-		transaction_begin_time_utc
+		transaction_begin_time_utc,
+		is_implicit_transaction
     )
     SELECT @InstanceID as InstanceID,
         SnapshotDateUTC,
@@ -286,7 +290,8 @@ BEGIN
 		login_time_utc,
 		last_request_end_time_utc,
 		context_info,
-		transaction_begin_time_utc
+		transaction_begin_time_utc,
+		is_implicit_transaction
     FROM @RunningQueriesDD;
 
 	EXEC dbo.CollectionDates_Upd @InstanceID = @InstanceID,  

--- a/DBADashDB/dbo/Tables/RunningQueries.sql
+++ b/DBADashDB/dbo/Tables/RunningQueries.sql
@@ -33,6 +33,7 @@
     last_request_end_time_utc DATETIME NULL,
     context_info VARBINARY(128) NULL,
     transaction_begin_time_utc DATETIME NULL,
+    is_implicit_transaction BIT NULL,
     CONSTRAINT PK_RunningQueries PRIMARY KEY(InstanceID,SnapshotDateUTC,session_id) WITH (DATA_COMPRESSION = PAGE) ON PS_RunningQueries(SnapshotDateUTC)
 ) ON PS_RunningQueries(SnapshotDateUTC);
 GO

--- a/DBADashDB/dbo/User Defined Types/RunningQueries.sql
+++ b/DBADashDB/dbo/User Defined Types/RunningQueries.sql
@@ -31,5 +31,6 @@
     login_time_utc DATETIME NULL,
     last_request_end_time_utc DATETIME NULL,
     context_info VARBINARY(128) NULL,
-    transaction_begin_time_utc DATETIME NULL
+    transaction_begin_time_utc DATETIME NULL,
+    is_implicit_transaction BIT NULL
 );

--- a/DBADashDB/dbo/Views/RunningQueriesInfo.sql
+++ b/DBADashDB/dbo/Views/RunningQueriesInfo.sql
@@ -84,7 +84,8 @@ SELECT Q.InstanceID,
     Q.context_info,
     Q.transaction_begin_time_utc,
     calc.transaction_duration_ms,
-    TranHD.HumanDuration AS transaction_duration
+    TranHD.HumanDuration AS transaction_duration,
+    Q.is_implicit_transaction
 FROM dbo.RunningQueries Q
 JOIN dbo.Instances I ON Q.InstanceID = I.InstanceID
 CROSS APPLY(SELECT CASE WHEN Q.start_time_utc < Q.SnapshotDateUTC OR Q.start_time_utc IS NULL  THEN DATEDIFF_BIG(ms,ISNULL(Q.start_time_utc,Q.last_request_start_time_utc),Q.SnapshotDateUTC) ELSE 0 END AS Duration,


### PR DESCRIPTION
Capture if a query is using implicit transactions.  Highlight implicit transactions in the GUI.  Hide the column by default unless there are implicit transactions. #1318