### PR TITLE
Plan collection messaging

### DIFF
--- a/DBADash/DBImporter.cs
+++ b/DBADash/DBImporter.cs
@@ -543,12 +543,18 @@ namespace DBADash
 
         private async Task UpdateAsync(string tableName)
         {
-            var procName = (tableName.StartsWith("UserData.") ? "" : "dbo.") + tableName + "_Upd";
-            var paramName = tableName.Replace("UserData.", "");
             var dt = data.Tables[tableName];
             if (dt == null) return;
+            await UpdateCollectionAsync(dt, instanceID, snapshotDate, connectionString, CommandTimeout);
+        }
+
+        public static async Task UpdateCollectionAsync(DataTable dt, int? instanceID, DateTime snapshotDate, string connectionString, int timeOut = 30)
+        {
+            var tableName = dt.TableName;
+            var procName = (tableName.StartsWith("UserData.") ? "" : "dbo.") + tableName + "_Upd";
+            var paramName = tableName.Replace("UserData.", "");
             await using var cn = new SqlConnection(connectionString);
-            await using var cmd = new SqlCommand(procName, cn) { CommandTimeout = CommandTimeout, CommandType = CommandType.StoredProcedure };
+            await using var cmd = new SqlCommand(procName, cn) { CommandTimeout = timeOut, CommandType = CommandType.StoredProcedure };
             await cn.OpenAsync();
             if (dt.Rows.Count > 0)
             {

--- a/DBADash/ExtensionMethods.cs
+++ b/DBADash/ExtensionMethods.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Data.SqlClient;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.IO.Compression;
-using System.IO;
-using Microsoft.Data.SqlClient;
 
 namespace DBADash
 {
@@ -104,5 +105,24 @@ namespace DBADash
         }
 
         public static SqlParameter[] GetParameters(this List<CustomSqlParameter> parameters) => parameters.Where(p => !p.UseDefaultValue).Select(p => p.Param).ToArray();
+
+        public static string ToHexString(this byte[] bytes)
+        {
+            if (bytes == null) return "";
+            var hex = BitConverter.ToString(bytes);
+            return hex.Replace("-", "");
+        }
+
+        public static byte[] ToByteArray(this string hex)
+        {
+            if (hex.StartsWith("0x"))
+            {
+                hex = hex.Remove(0, 2);
+            }
+            return Enumerable.Range(0, hex.Length)
+                .Where(x => x % 2 == 0)
+                .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                .ToArray();
+        }
     }
 }

--- a/DBADash/Messaging/QueryPlanCollectionMessage.cs
+++ b/DBADash/Messaging/QueryPlanCollectionMessage.cs
@@ -1,0 +1,41 @@
+﻿using Serilog;
+using SerilogTimings;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBADash.Messaging
+{
+    public class QueryPlanCollectionMessage : MessageBase
+    {
+        public List<Plan> PlansToCollect { get; set; }
+
+        public string ConnectionID { get; set; }
+
+        public override async Task<DataSet> Process(CollectionConfig cfg, Guid handle, CancellationToken cancellationToken)
+        {
+            using var op = Operation.Begin(
+                "GetPlans from {instance} triggered from message {handle}",
+                ConnectionID,
+                handle);
+            try
+            {
+                var src = await cfg.GetSourceConnectionAsync(ConnectionID);
+                var dt = await Plan.GetPlansAsync(PlansToCollect, src.SourceConnection.ConnectionString);
+                var ds = new DataSet();
+                ds.Tables.Add(dt);
+                op.Complete();
+                return ds;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error processing plan collection message");
+                throw;
+            }
+        }
+    }
+}

--- a/DBADash/Plan.cs
+++ b/DBADash/Plan.cs
@@ -152,7 +152,7 @@ OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid
             using var xr = new XmlTextReader(ms);
             while (xr.Read())
             {
-                if (xr.Name != "StmtSimple") continue;
+                if (xr.Name is not ("StmtSimple" or "StmtCond")) continue;
                 var strHash = xr.GetAttribute("QueryPlanHash");
                 return strHash.ToByteArray();
             }

--- a/DBADash/Plan.cs
+++ b/DBADash/Plan.cs
@@ -1,6 +1,14 @@
-﻿using System;
+﻿using Microsoft.Data.SqlClient;
+using Serilog;
+using System;
 using System.Collections.Generic;
+using System.Data;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 namespace DBADash
 {
@@ -48,6 +56,108 @@ namespace DBADash
         public int GetHashCode(Plan obj)
         {
             return obj.Key.GetHashCode();
+        }
+
+        public static async Task<DataTable> GetPlansAsync(List<Plan> plansToCollect, string ConnectionString)
+        {
+            var plansSQL = GetPlansSQL(plansToCollect);
+            if (string.IsNullOrEmpty(plansSQL)) throw new Exception("Plan collection SQL was null/empty");
+
+            await using var cn = new SqlConnection(ConnectionString);
+            await using var cmd = new SqlCommand(plansSQL, cn);
+            var dt = new DataTable("QueryPlans");
+            await cn.OpenAsync();
+            await using var rdr = await cmd.ExecuteReaderAsync();
+            dt.Load(rdr);
+            if (dt is not { Rows.Count: > 0 }) return dt;
+            dt.Columns.Add("query_plan_hash", typeof(byte[]));
+            dt.Columns.Add("query_plan_compressed", typeof(byte[]));
+            foreach (DataRow r in dt.Rows)
+            {
+                try
+                {
+                    var strPlan = r["query_plan"] == DBNull.Value ? string.Empty : (string)r["query_plan"];
+                    r["query_plan_compressed"] = SMOBaseClass.Zip(strPlan);
+                    var hash = GetPlanHash(strPlan);
+                    r["query_plan_hash"] = hash;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error processing query plans");
+                }
+            }
+
+            dt.Columns.Remove("query_plan");
+
+            var nullRows = dt.Select("query_plan_hash IS NULL");
+
+            // Remove rows with null query plan hash
+            if (nullRows.Length > 0)
+            {
+                Log.Information("Removing {0} rows with NULL query_plan_hash", nullRows.Length);
+                foreach (var row in nullRows)
+                {
+                    row.Delete();
+                }
+
+                dt.AcceptChanges();
+            }
+
+            return dt;
+        }
+
+        ///<summary>
+        ///Generate a SQL query to get the query plan text for running queries. Captured plan handles get cached with a call to CacheCollectedPlans later <br/>
+        ///Limits the cost associated with plan capture - less plans to capture, send and process<br/>
+        ///Note: Caching takes query_plan_hash into account as a statement can get recompiled without the plan handle changing.
+        ///</summary>
+        private static string GetPlansSQL(List<Plan> plansToCollect)
+        {
+            var sb = new StringBuilder();
+            sb.Append(@"DECLARE @plans TABLE(plan_handle VARBINARY(64),statement_start_offset int,statement_end_offset int)
+INSERT INTO @plans(plan_handle,statement_start_offset,statement_end_offset)
+VALUES");
+
+            plansToCollect.ForEach(p => sb.AppendFormat("{3}(0x{0},{1},{2}),", p.PlanHandle.ToHexString(), p.StartOffset, p.EndOffset, Environment.NewLine));
+            if (plansToCollect.Count == 0)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                sb.Remove(sb.Length - 1, 1);
+                sb.AppendLine("OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid polluting the plan cache
+                sb.AppendLine();
+                sb.Append(@"SELECT t.plan_handle,
+        t.statement_start_offset,
+        t.statement_end_offset,
+        pln.dbid,
+        pln.objectid,
+        pln.encrypted,
+        pln.query_plan
+FROM @plans t
+CROSS APPLY sys.dm_exec_text_query_plan(t.plan_handle,t.statement_start_offset,t.statement_end_offset) pln
+OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid polluting the plan cache
+                return sb.ToString();
+            }
+        }
+
+        ///<summary>
+        ///Get the query plan hash from a  string of the plan XML
+        ///</summary>
+        public static byte[] GetPlanHash(string strPlan)
+        {
+            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(strPlan));
+            ms.Position = 0;
+            using var xr = new XmlTextReader(ms);
+            while (xr.Read())
+            {
+                if (xr.Name != "StmtSimple") continue;
+                var strHash = xr.GetAttribute("QueryPlanHash");
+                return strHash.ToByteArray();
+            }
+
+            return Array.Empty<byte>();
         }
     }
 }


### PR DESCRIPTION
In the running queries tab, the View Plan link provides an option to download a query plan.  If the plan is not in the repository database, this link is changed to Find Plan, and a plan collection query is provided.
Instead of providing a script, get the query plan using the plan handle directly from the monitored instance using the messaging feature (if enabled).  The Collection script can still be accessed on the SQL/Plan Handle and Query/Plan hash columns.

GetPlanHash function improvement