### PR TITLE
Query Store top queries fix

### DIFF
--- a/DBADash/SQL/SQLQueryStoreTopQueries.sql
+++ b/DBADash/SQL/SQLQueryStoreTopQueries.sql
@@ -16,6 +16,7 @@ DECLARE @ParallelPlans BIT
 DECLARE @IncludeWaits BIT=1
 DECLARE @MinimumPlanCount INT=1
 */
+SET NUMERIC_ROUNDABORT OFF
 IF NOT EXISTS(
 	SELECT 1 
 	FROM sys.databases 

--- a/DBADashGUI/Performance/QueryStoreTopQueries.cs
+++ b/DBADashGUI/Performance/QueryStoreTopQueries.cs
@@ -166,7 +166,13 @@ namespace DBADashGUI.Performance
 
         private Task ProcessCompletedTopQueriesOrDrillDownMessage(ResponseMessage reply, DataGridView _dgv, List<KeyValuePair<string, PersistedColumnLayout>> layout)
         {
-            lblStatus.InvokeSetStatus(reply.Message, string.Empty, DashColors.Success);
+            lblStatus.InvokeSetStatus(reply.Message, reply.Exception?.ToString(), reply.Type switch
+            {
+                ResponseMessage.ResponseTypes.Success => DashColors.Success,
+                ResponseMessage.ResponseTypes.Progress => DashColors.Information,
+                _ => DashColors.Fail
+            });
+            if (reply.Type != ResponseMessage.ResponseTypes.Success) return Task.CompletedTask;
             Invoke(() =>
             {
                 var ds = reply.Data;


### PR DESCRIPTION
Fix error that occurs if there is a database with NUMERIC_ROUNDABORT ON.

```
Msg 1934, Level 16, State 1, Line 21
SELECT failed because the following SET options have incorrect settings: 'NUMERIC_ROUNDABORT'. Verify that SET options are correct for use with indexed views and/or indexes on computed columns and/or filtered indexes and/or query notifications and/or XML data type methods and/or spatial index operations.
```

Better handling for non-success responses.
#1350