### PR TITLE
Update max supported compatibility level for Azure DB

### DIFF
--- a/DBADashDB/dbo/Views/InstanceInfo.sql
+++ b/DBADashDB/dbo/Views/InstanceInfo.sql
@@ -95,7 +95,7 @@ SELECT I.InstanceID,
 	DATEDIFF(mi,DATEADD(mi,I.UTCOffset,I.sqlserver_start_time),os.SnapshotDate) AS sqlserver_uptime,
 	CASE WHEN tDB.value_in_use=1 AND tDB.value=1 THEN CAST(1 AS BIT) WHEN tDB.configuration_id=1589 THEN CAST(0 AS BIT) ELSE NULL END AS IsTempDBMetadataMemoryOptimized,
 	CASE WHEN I.EditionID=1674378470 -- AzureDB or Azure Managed Instance
-            THEN 150 ELSE TRY_CAST(I.ProductMajorVersion AS INT)*10 END AS MaxSupportedCompatibilityLevel,
+            THEN 170 ELSE TRY_CAST(I.ProductMajorVersion AS INT)*10 END AS MaxSupportedCompatibilityLevel,
     I.InstanceDisplayName,
     I.ShowInSummary,
     I.InstanceGroupName,


### PR DESCRIPTION
Max supported compatibility level changed from 150 to 170.