### PR TITLE
Fix wait resource parsing for new SQL Server 2022 strings

### DIFF
--- a/DBADashDB/dbo/Functions/SplitWaitResource.sql
+++ b/DBADashDB/dbo/Functions/SplitWaitResource.sql
@@ -41,7 +41,8 @@ WITH wr AS (
 				OR @WaitResource LIKE 'RID: %:%:%:%'
 					THEN SUBSTRING(@WaitResource,wr.sc2+1,wr.sc3-wr.sc2-1) 
 			ELSE NULL END AS INT)AS wait_file_id,
-		TRY_CAST(CASE WHEN @WaitResource LIKE '[0-9]%:%:%' THEN SUBSTRING(@WaitResource,wr.sc2+1,wr.lenwr-wr.sc2) 
+		TRY_CAST(CASE WHEN @WaitResource LIKE '[0-9]%:%:%(%)' THEN SUBSTRING(@WaitResource,wr.sc2+1,wr.ocb1-1-wr.sc2) 
+			WHEN @WaitResource LIKE '[0-9]%:%:%' THEN SUBSTRING(@WaitResource,wr.sc2+1,wr.lenwr-wr.sc2) 
 			WHEN @WaitResource LIKE 'PAGE: [0-9]%:%:%' 
 				OR @WaitResource LIKE 'RID: %:%:%:%'
 				THEN SUBSTRING(@WaitResource,wr.sc3+1,ISNULL(NULLIF(wr.sc4,0)-1,wr.lenwr)-wr.sc3) 

--- a/DBADashGUI/SQL/DecipherWaitResource.sql
+++ b/DBADashGUI/SQL/DecipherWaitResource.sql
@@ -20,7 +20,7 @@
 
 ----------------------------------------------------------
 */
-DECLARE @WaitResource NVARCHAR(128)
+DECLARE @WaitResource NVARCHAR(256)
 
 SELECT @WaitResource='{wait_resource}'
 
@@ -36,7 +36,7 @@ DECLARE @idx1 INT
 DECLARE @idx2 INT
 DECLARE @m_type INT
 DECLARE @PageType VARCHAR(100)
-DECLARE @NormalizedWaitResource NVARCHAR(128)
+DECLARE @NormalizedWaitResource NVARCHAR(256)
 
 IF @WaitResource='0:0:0'
 BEGIN
@@ -96,6 +96,15 @@ BEGIN
 			Strip PAGE: prefix.
 		*/
 		SET @NormalizedWaitResource = SUBSTRING(@NormalizedWaitResource ,7,LEN(@NormalizedWaitResource))
+	END
+	ELSE IF @WaitResource LIKE '[0-9]%:%:%(%)'
+	BEGIN
+		/*  
+			Format: DatabaseID:FileID:PageID (Additial Info)
+			Example: 6:3:749442168 (LATCH 0x000005E1CE68AE98: Class: BUFFER KP: 0 SH: 0 UP: 0 EX: 1 DT: 0 Sublatch: 0 HasWaiters: 1 Task: 0x000001F2D801C8C8 AnyReleasor: 1)
+			Strip (Additional Info)
+		*/
+		SET @NormalizedWaitResource = SUBSTRING(@NormalizedWaitResource ,1,CHARINDEX('(',@NormalizedWaitResource)-1)
 	END
 
 	SELECT @idx1 = CHARINDEX(':',@NormalizedWaitResource)

--- a/DBADashGUI/SQL/DecipherWaitResource.sql
+++ b/DBADashGUI/SQL/DecipherWaitResource.sql
@@ -100,7 +100,7 @@ BEGIN
 	ELSE IF @WaitResource LIKE '[0-9]%:%:%(%)'
 	BEGIN
 		/*  
-			Format: DatabaseID:FileID:PageID (Additial Info)
+			Format: DatabaseID:FileID:PageID (Additional Info)
 			Example: 6:3:749442168 (LATCH 0x000005E1CE68AE98: Class: BUFFER KP: 0 SH: 0 UP: 0 EX: 1 DT: 0 Sublatch: 0 HasWaiters: 1 Task: 0x000001F2D801C8C8 AnyReleasor: 1)
 			Strip (Additional Info)
 		*/


### PR DESCRIPTION
It seems in SQL Server 2022, they have made some changes to the wait resource to include some additional information (sometimes, not always).

Example of one I ran into today:
```
6:3:749442168 (LATCH 0x000005E1CE68AE98: Class: BUFFER KP: 0 SH: 0 UP: 0 EX: 1 DT: 0 Sublatch: 0 HasWaiters: 1 Task: 0x000001F2D801C8C8 AnyReleasor: 1)
```

As a side note, it may be worth looking into updating the `DBADashGUI/SQL/DecipherWaitResource.sql` script to use the new `sys.dm_db_page_info()` system function when available, instead of using `DBCC PAGE`. This was added with SQL Server 2019. I considered making this change, but felt it would be better to have it as a separate PR.

SQL Server 2019 also included a new system function (`sys.fn_PageResCracker`) to split the `page_resource` value, may be worth looking at that as well...though it requires the binary `Page_resource` value, which is not being captured by DBADash, so it's of less use here. 
