### PR TITLE
Fix parameter was not supplied bug on Memory tab

### DIFF
--- a/DBADashGUI/Performance/MemoryUsage.cs
+++ b/DBADashGUI/Performance/MemoryUsage.cs
@@ -14,6 +14,7 @@ namespace DBADashGUI.Performance
         public MemoryUsage()
         {
             InitializeComponent();
+            ChartView = ChartViews.Pie; // Update control visibility
         }
 
         private int InstanceID;
@@ -240,6 +241,11 @@ namespace DBADashGUI.Performance
 
         private void ShowMemoryUsageForClerk(string format = "N0")
         {
+            if (string.IsNullOrEmpty(selectedClerk))
+            {
+                MessageBox.Show("Please select a memory clerk to view.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
             ChartView = ChartViews.MemoryClerk;
             chartClerk.Series.Clear();
             var dt = GetMemoryClerkUsage(selectedClerk, dateGrouping, tsAgg.Text, selectedCounter);


### PR DESCRIPTION
The user is allowed to interact with the aggregate filter for the memory clerk line chart before a memory clerk is selected which causes the error. Updated ChartView type when control is created so visibility of the control is set correctly.  Added a validation check for ShowMemoryUsageForClerk which should no longer be triggered without a selected clerk. #1378