### PR TITLE
SQS & S3 bug fixes

### DIFF
--- a/DBADash/Messaging/MessageProcessing.cs
+++ b/DBADash/Messaging/MessageProcessing.cs
@@ -167,7 +167,7 @@ namespace DBADash.Messaging
                 var msg = MessageBase.Deserialize(message);
                 if (msg.IsExpired)
                 {
-                    Log.Error("Message {Id} with handle {handle} created at {Created} is expired.", msg.Id, type, handle);
+                    Log.Error("Message {Id} of type {type} with handle {handle} created at {Created} is expired.", msg.Id, type,handle,msg.Created);
                     await SendReplyMessage(handle,
                         (new ResponseMessage()
                         { Type = ResponseMessage.ResponseTypes.Failure, Message = "Message is Expired." }).Serialize(),
@@ -175,7 +175,7 @@ namespace DBADash.Messaging
                 }
                 else if (msg.CollectAgent.AgentIdentifier != DBADashAgent.GetCurrent().AgentIdentifier)
                 {
-                    Log.Error("Message {Id} with handle {handle} created at {Created} is expired.", msg.Id, type, handle);
+                    Log.Information("Message {Id} with handle {handle} needs to be relayed to the remote service {host} via {sqs}", msg.Id, handle,msg.CollectAgent.AgentHostName,msg.CollectAgent.ServiceSQSQueueUrl);
                     // The message needs to be relayed to the remote agent via SQS queue
                     await SendReplyMessage(handle,
                                                (new ResponseMessage()

--- a/DBADash/Messaging/SQSMessageProcessing.cs
+++ b/DBADash/Messaging/SQSMessageProcessing.cs
@@ -66,7 +66,7 @@ namespace DBADash.Messaging
                 {
                     var receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(receiveMessageRequest).ConfigureAwait(false);
 
-                    if (receiveMessageResponse.Messages.Count > 0)
+                    if (receiveMessageResponse is { Messages.Count: > 0 })
                     {
                         foreach (var message in receiveMessageResponse.Messages)
                         {


### PR DESCRIPTION
Fix SQS error: "Object reference not set to an instance of an object." introduced with upgraded NuGet package. 

Fix S3 error: "System.ArgumentNullException: Value cannot be null. (Parameter 'source')" introduced with upgraded NuGet package. 

#1380 