### PR TITLE
GitHub action fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,9 @@ jobs:
         run: | 
           "Wait 5min"
           Start-Sleep -s 300
-
+      - name: Stop services
+        run: |
+          net stop DBADashService
       - name: Output CollectionErrorLog
         shell: powershell
         run: | 

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -151,6 +151,10 @@ jobs:
           "Wait 5min"
           Start-Sleep -s 300
 
+      - name: Stop services
+        run: |
+          net stop DBADashReadFromFolder
+          net stop DBADashWriteToFolder
       - name: Output Log (DBADashWriteToFolder)
         shell: powershell
         run: | 

--- a/.github/workflows/ci_MininalPermissions.yml
+++ b/.github/workflows/ci_MininalPermissions.yml
@@ -128,7 +128,9 @@ jobs:
         run: | 
           "Wait 5min"
           Start-Sleep -s 300
-
+      - name: Stop services
+        run: |
+          net stop DBADashService
       - name: Output CollectionErrorLog
         shell: powershell
         run: | 


### PR DESCRIPTION
Improve workflow reliability by shutting down service before running Pester tests. The test would occasionally fail due to the delete test, with the service still collecting data for the instance we are trying to delete.