### PR TITLE
Running Jobs link fix

### DIFF
--- a/DBADashGUI/AgentJobs/RunningJobs.cs
+++ b/DBADashGUI/AgentJobs/RunningJobs.cs
@@ -208,9 +208,9 @@ namespace DBADashGUI.AgentJobs
                     JobStepID = -1
                 };
                 JobHistoryForm.ShowSteps = true;
-                JobHistoryForm.SetContext(jobContext);
                 JobHistoryForm.FormClosed += delegate { JobHistoryForm = null; };
                 JobHistoryForm.Show();
+                JobHistoryForm.SetContext(jobContext);
             }
             else if (e.ColumnIndex == dgvRunningJobs.Columns["colRunningTime"]!.Index)
             {


### PR DESCRIPTION
Fix the unhandled exception when clicking the job name on the Running Jobs tab. #1427