### PR TITLE
Add option to track Persistent Version Store Metrics

### DIFF
--- a/DBADash/PerformanceCounters.xml
+++ b/DBADash/PerformanceCounters.xml
@@ -41,4 +41,8 @@
 	<Counter object_name="sys.dm_os_nodes" counter_name="*" />
 	<Counter object_name="sys.dm_os_schedulers" counter_name="*" />
 	<Counter object_name="Databases" counter_name="Transactions/sec" instance_name="_Total" />
+	<!-- **** Uncomment to track persistent version store size. **** -->-->
+	<!--<Counter object_name="sys.dm_tran_persistent_version_store_stats" counter_name="Persistent Version Store Size (KB)"/>-->
+	<!--<Counter object_name="sys.dm_tran_persistent_version_store_stats" counter_name="Sum Persistent Version Store Size (KB)"/>-->
+	<!--<Counter object_name="sys.dm_tran_persistent_version_store_stats" counter_name="Max Persistent Version Store Size (KB)"/>-->
 </Counters>


### PR DESCRIPTION
Add option to capture Persistent Version Store Size for each database with ADR enabled.  Option to capture Max/Sum is also available.