### PR TITLE
Fix error loading alert configuration

### DIFF
--- a/DBADashGUI/DBADashAlerts/ActiveAlerts.cs
+++ b/DBADashGUI/DBADashAlerts/ActiveAlerts.cs
@@ -152,9 +152,12 @@ namespace DBADashGUI.DBADashAlerts
         private void Configure_Click(object sender, EventArgs e)
         {
             using var frm = new Form() { Width = this.Width / 2, Height = this.Height / 2, Text = @"Alert Configuration" };
-            using var configGrid = new AlertConfig() { Dock = DockStyle.Fill };
+            var configGrid = new AlertConfig() { Dock = DockStyle.Fill };
             frm.Controls.Add(configGrid);
-            configGrid.SetContext(CurrentContext);
+            frm.Load += (_, _) =>
+            {
+                configGrid.SetContext(CurrentContext);
+            };
             frm.ShowDialog();
         }
 


### PR DESCRIPTION
Fix error:
Invoke or BeginInvoke cannot be called on a control until the window handle has been created.