### PR TITLE
Security Scan workflow fix

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   scan:
     name: Security Scanning
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Change to windows-latest to fix:
Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30.