### PR TITLE
Service Config Tool - Permissions Helper fix

### DIFF
--- a/DBADashServiceConfig/PermissionsHelper.cs
+++ b/DBADashServiceConfig/PermissionsHelper.cs
@@ -39,7 +39,7 @@ namespace DBADashServiceConfig
         private List<string> ProcedureNames =>
             Connections
                 .SelectMany(src => src.CustomCollections.Values.Select(cc => cc.ProcedureName))
-                .Concat(Config.AllowedCustomProcs.Split(','))
+                .Concat(Config.AllowedCustomProcs?.Split(',') ?? Array.Empty<string>())
                 .Distinct()
                 .ToList();
 

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -2543,8 +2543,15 @@ namespace DBADashServiceConfig
 
         private void ShowPermissionsHelper(List<DBADashSource> sourceConnections)
         {
-            var frm = new PermissionsHelper() { Connections = sourceConnections, Config = collectionConfig };
-            frm.ShowDialog();
+            try
+            {
+                var frm = new PermissionsHelper() { Connections = sourceConnections, Config = collectionConfig };
+                frm.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                CommonShared.ShowExceptionDialog(ex, "Error loading Permissions Helper");
+            }
         }
 
         private void lnkGrant_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
Fix issue loading the permissions helper when no allowed custom procs are specified. #1464