### PR TITLE
Service Threads & Config

### DIFF
--- a/DBADashService/SchedulerService.cs
+++ b/DBADashService/SchedulerService.cs
@@ -46,17 +46,8 @@ namespace DBADashService
                 Log.Information("Custom schedules set at agent level");
             }
 
-            var threads = config.ServiceThreads;
-            if (threads < 1)
-            {
-                threads = 10;
-                Log.Logger.Information("Threads {threadCount} (default)", threads);
-            }
-            else
-            {
-                Log.Logger.Information("Threads {threadCount} (user)", threads);
-            }
-
+            var threads = config.GetThreadCount();
+            
             NameValueCollection props = new()
             {
             { "quartz.serializer.type", "binary" },

--- a/DBADashServiceConfig/ServiceConfig.Designer.cs
+++ b/DBADashServiceConfig/ServiceConfig.Designer.cs
@@ -86,6 +86,9 @@ namespace DBADashServiceConfig
             numAlertPollingFrequency = new System.Windows.Forms.NumericUpDown();
             chkProcessAlerts = new System.Windows.Forms.CheckBox();
             groupBox3 = new System.Windows.Forms.GroupBox();
+            chkThreads = new System.Windows.Forms.CheckBox();
+            numThreads = new System.Windows.Forms.NumericUpDown();
+            label23 = new System.Windows.Forms.Label();
             lnkTimeouts = new System.Windows.Forms.LinkLabel();
             bttnCustomCollections = new System.Windows.Forms.Button();
             lblSummaryRefreshCron = new System.Windows.Forms.Label();
@@ -193,6 +196,7 @@ namespace DBADashServiceConfig
             ((System.ComponentModel.ISupportInitialize)numAlertStartupDelay).BeginInit();
             ((System.ComponentModel.ISupportInitialize)numAlertPollingFrequency).BeginInit();
             groupBox3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numThreads).BeginInit();
             ((System.ComponentModel.ISupportInitialize)numBackupRetention).BeginInit();
             ((System.ComponentModel.ISupportInitialize)numIdentityCollectionThreshold).BeginInit();
             groupBox4.SuspendLayout();
@@ -542,7 +546,7 @@ namespace DBADashServiceConfig
             // 
             // bttnAWS
             // 
-            bttnAWS.Location = new System.Drawing.Point(16, 149);
+            bttnAWS.Location = new System.Drawing.Point(15, 176);
             bttnAWS.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             bttnAWS.Name = "bttnAWS";
             bttnAWS.Size = new System.Drawing.Size(197, 55);
@@ -556,7 +560,7 @@ namespace DBADashServiceConfig
             // 
             chkLogInternalPerfCounters.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             chkLogInternalPerfCounters.AutoSize = true;
-            chkLogInternalPerfCounters.Location = new System.Drawing.Point(845, 43);
+            chkLogInternalPerfCounters.Location = new System.Drawing.Point(846, 43);
             chkLogInternalPerfCounters.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             chkLogInternalPerfCounters.Name = "chkLogInternalPerfCounters";
             chkLogInternalPerfCounters.Size = new System.Drawing.Size(259, 24);
@@ -675,9 +679,9 @@ namespace DBADashServiceConfig
             groupBox5.Controls.Add(lblPerformanceCounters);
             groupBox5.Controls.Add(bttnPerformanceCounters);
             groupBox5.Controls.Add(chkLogInternalPerfCounters);
-            groupBox5.Location = new System.Drawing.Point(9, 508);
+            groupBox5.Location = new System.Drawing.Point(8, 533);
             groupBox5.Name = "groupBox5";
-            groupBox5.Size = new System.Drawing.Size(1112, 93);
+            groupBox5.Size = new System.Drawing.Size(1113, 93);
             groupBox5.TabIndex = 42;
             groupBox5.TabStop = false;
             groupBox5.Text = "Performance Counters";
@@ -726,9 +730,9 @@ namespace DBADashServiceConfig
             groupBox7.Controls.Add(label19);
             groupBox7.Controls.Add(numAlertPollingFrequency);
             groupBox7.Controls.Add(chkProcessAlerts);
-            groupBox7.Location = new System.Drawing.Point(9, 418);
+            groupBox7.Location = new System.Drawing.Point(8, 443);
             groupBox7.Name = "groupBox7";
-            groupBox7.Size = new System.Drawing.Size(1112, 84);
+            groupBox7.Size = new System.Drawing.Size(1113, 84);
             groupBox7.TabIndex = 40;
             groupBox7.TabStop = false;
             groupBox7.Text = "Alerts";
@@ -809,6 +813,9 @@ namespace DBADashServiceConfig
             // groupBox3
             // 
             groupBox3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            groupBox3.Controls.Add(chkThreads);
+            groupBox3.Controls.Add(numThreads);
+            groupBox3.Controls.Add(label23);
             groupBox3.Controls.Add(lnkTimeouts);
             groupBox3.Controls.Add(bttnCustomCollections);
             groupBox3.Controls.Add(lblSummaryRefreshCron);
@@ -827,10 +834,40 @@ namespace DBADashServiceConfig
             groupBox3.Controls.Add(chkDefaultIdentityCollection);
             groupBox3.Location = new System.Drawing.Point(8, 19);
             groupBox3.Name = "groupBox3";
-            groupBox3.Size = new System.Drawing.Size(1113, 245);
+            groupBox3.Size = new System.Drawing.Size(1113, 271);
             groupBox3.TabIndex = 38;
             groupBox3.TabStop = false;
             groupBox3.Text = "Miscellaneous";
+            // 
+            // chkThreads
+            // 
+            chkThreads.AutoSize = true;
+            chkThreads.Location = new System.Drawing.Point(407, 142);
+            chkThreads.Name = "chkThreads";
+            chkThreads.Size = new System.Drawing.Size(18, 17);
+            chkThreads.TabIndex = 50;
+            chkThreads.UseVisualStyleBackColor = true;
+            chkThreads.CheckedChanged += Threads_CheckChanged;
+            // 
+            // numThreads
+            // 
+            numThreads.Location = new System.Drawing.Point(286, 137);
+            numThreads.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            numThreads.Minimum = new decimal(new int[] { 1, 0, 0, int.MinValue });
+            numThreads.Name = "numThreads";
+            numThreads.Size = new System.Drawing.Size(114, 27);
+            numThreads.TabIndex = 49;
+            numThreads.Value = new decimal(new int[] { 10, 0, 0, 0 });
+            numThreads.ValueChanged += Threads_ValueChanged;
+            // 
+            // label23
+            // 
+            label23.AutoSize = true;
+            label23.Location = new System.Drawing.Point(16, 139);
+            label23.Name = "label23";
+            label23.Size = new System.Drawing.Size(64, 20);
+            label23.TabIndex = 48;
+            label23.Text = "Threads:";
             // 
             // lnkTimeouts
             // 
@@ -846,7 +883,7 @@ namespace DBADashServiceConfig
             // 
             // bttnCustomCollections
             // 
-            bttnCustomCollections.Location = new System.Drawing.Point(624, 149);
+            bttnCustomCollections.Location = new System.Drawing.Point(623, 176);
             bttnCustomCollections.Name = "bttnCustomCollections";
             bttnCustomCollections.Size = new System.Drawing.Size(197, 55);
             bttnCustomCollections.TabIndex = 46;
@@ -906,7 +943,7 @@ namespace DBADashServiceConfig
             // 
             // lblEncryptionStatus
             // 
-            lblEncryptionStatus.Location = new System.Drawing.Point(421, 209);
+            lblEncryptionStatus.Location = new System.Drawing.Point(420, 236);
             lblEncryptionStatus.Name = "lblEncryptionStatus";
             lblEncryptionStatus.Size = new System.Drawing.Size(197, 27);
             lblEncryptionStatus.TabIndex = 38;
@@ -915,7 +952,7 @@ namespace DBADashServiceConfig
             // 
             // bttnEncryption
             // 
-            bttnEncryption.Location = new System.Drawing.Point(421, 149);
+            bttnEncryption.Location = new System.Drawing.Point(420, 176);
             bttnEncryption.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             bttnEncryption.Name = "bttnEncryption";
             bttnEncryption.Size = new System.Drawing.Size(197, 55);
@@ -935,7 +972,7 @@ namespace DBADashServiceConfig
             // 
             // bttnSchedule
             // 
-            bttnSchedule.Location = new System.Drawing.Point(218, 149);
+            bttnSchedule.Location = new System.Drawing.Point(217, 176);
             bttnSchedule.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             bttnSchedule.Name = "bttnSchedule";
             bttnSchedule.Size = new System.Drawing.Size(197, 55);
@@ -967,7 +1004,7 @@ namespace DBADashServiceConfig
             groupBox4.Controls.Add(label11);
             groupBox4.Controls.Add(chkScanEvery);
             groupBox4.Controls.Add(label10);
-            groupBox4.Location = new System.Drawing.Point(9, 272);
+            groupBox4.Location = new System.Drawing.Point(8, 297);
             groupBox4.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             groupBox4.Name = "groupBox4";
             groupBox4.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
@@ -1966,6 +2003,7 @@ namespace DBADashServiceConfig
             ((System.ComponentModel.ISupportInitialize)numAlertPollingFrequency).EndInit();
             groupBox3.ResumeLayout(false);
             groupBox3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numThreads).EndInit();
             ((System.ComponentModel.ISupportInitialize)numBackupRetention).EndInit();
             ((System.ComponentModel.ISupportInitialize)numIdentityCollectionThreshold).EndInit();
             groupBox4.ResumeLayout(false);
@@ -2148,6 +2186,9 @@ namespace DBADashServiceConfig
         private System.Windows.Forms.Label lblConfigFileAccess;
         private System.Windows.Forms.PictureBox picConfigFileAccess;
         private System.Windows.Forms.Panel pnlConfigFileAccessWarning;
+        private System.Windows.Forms.NumericUpDown numThreads;
+        private System.Windows.Forms.Label label23;
+        private System.Windows.Forms.CheckBox chkThreads;
     }
 }
 

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -885,7 +885,7 @@ namespace DBADashServiceConfig
 
         private void SetConnectionCount()
         {
-            int cnt = collectionConfig.SourceConnections.Count;
+            var cnt = collectionConfig.SourceConnections.Count;
             lnkSourceConnections.Text = "Source Connections: " + cnt;
             if (cnt == 0)
             {
@@ -896,6 +896,7 @@ namespace DBADashServiceConfig
             {
                 lnkSourceConnections.LinkColor = DashColors.Success;
             }
+            UpdateThreadCount();
         }
 
         private bool IsSetFromJson;
@@ -935,6 +936,7 @@ namespace DBADashServiceConfig
                 numAlertStartupDelay.Enabled = collectionConfig.AlertProcessingStartupDelaySeconds != null && collectionConfig.ProcessAlerts;
                 chkAlertStartupDelay.Enabled = collectionConfig.ProcessAlerts;
                 txtAllowedCustomProcs.Text = collectionConfig.AllowedCustomProcs;
+                UpdateThreadCount();
                 UpdateSummaryCron();
                 UpdateScanInterval();
                 SetDgv();
@@ -945,6 +947,13 @@ namespace DBADashServiceConfig
             {
                 IsSetFromJson = false;
             }
+        }
+
+        private void UpdateThreadCount()
+        {
+            numThreads.Value = collectionConfig.GetThreadCount();
+            numThreads.Enabled = collectionConfig.ServiceThreads > 0;
+            chkThreads.Checked = collectionConfig.ServiceThreads > 0;
         }
 
         private void UpdateCustomCollectionCount()
@@ -2617,14 +2626,38 @@ namespace DBADashServiceConfig
             var frm = new TimeoutConfig()
             {
                 AddPartitionsTimeout = collectionConfig.AddPartitionsCommandTimeout,
-                PurgeTimeout= collectionConfig.PurgeDataCommandTimeout,
+                PurgeTimeout = collectionConfig.PurgeDataCommandTimeout,
                 ImportTimeout = collectionConfig.ImportCommandTimeout
             };
-            if(frm.ShowDialog() != DialogResult.OK) return;
+            if (frm.ShowDialog() != DialogResult.OK) return;
             collectionConfig.AddPartitionsCommandTimeout = frm.AddPartitionsTimeout;
             collectionConfig.PurgeDataCommandTimeout = frm.PurgeTimeout;
             collectionConfig.ImportCommandTimeout = frm.ImportTimeout;
             SetJson();
+        }
+
+        private void Threads_CheckChanged(object sender, EventArgs e)
+        {
+            UpdateThreads();
+        }
+
+        private void UpdateThreads()
+        {
+            if (!IsSetFromJson)
+            {
+                collectionConfig.ServiceThreads = chkThreads.Checked ? (int)numThreads.Value : -1;
+                numThreads.Enabled = chkThreads.Checked;
+                SetJson();
+            }
+            if(!chkThreads.Checked)
+            {
+                numThreads.Value = collectionConfig.GetThreadCount();
+            }
+        }
+
+        private void Threads_ValueChanged(object sender, EventArgs e)
+        {
+            UpdateThreads();
         }
     }
 }


### PR DESCRIPTION
Allow thread count to be configured in config tool & make calculated thread count visible. Change the system thread calculation to be smarter.  Instead of being hard coded to 10 it will increase based on the number of source connections and available processors with a min of 10 and max of 100 threads.  The thread count might not always be ideal, but users can override it if needed.