### PR TITLE
Running Queries - Arithmetic overflow error fix

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/RunningQueries_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/RunningQueries_Upd.sql
@@ -177,7 +177,7 @@ BEGIN
 			MAX(CASE WHEN calc.TransactionDurationMs<0 THEN 0 ELSE calc.TransactionDurationMs END) AS OldestTransactionMs,
 			SUM(CASE WHEN R.tempdb_alloc_page_count < R.tempdb_dealloc_page_count THEN 0 ELSE (R.tempdb_alloc_page_count - R.tempdb_dealloc_page_count) END) AS TempDBCurrentPageCount
     FROM @RunningQueriesDD R 
-    CROSS APPLY(SELECT ISNULL(total_elapsed_time,DATEDIFF_BIG(ms,ISNULL(start_time_utc,last_request_start_time_utc),R.SnapshotDateUTC)) AS Duration,
+    CROSS APPLY(SELECT ISNULL(CAST(total_elapsed_time AS BIGINT),DATEDIFF_BIG(ms,ISNULL(start_time_utc,last_request_start_time_utc),R.SnapshotDateUTC)) AS Duration,
 						DATEDIFF_BIG(ms,R.transaction_begin_time_utc,R.SnapshotDateUTC) AS TransactionDurationMs,
                         CASE WHEN wait_resource LIKE '2:%' 
 			                    OR wait_resource LIKE 'PAGE 2:%'

--- a/DBADashDB/dbo/Views/RunningQueriesInfo.sql
+++ b/DBADashDB/dbo/Views/RunningQueriesInfo.sql
@@ -94,7 +94,7 @@ SELECT Q.InstanceID,
     Q.tempdb_alloc_page_count /128.0 AS tempdb_allocations_mb 
 FROM dbo.RunningQueries Q
 JOIN dbo.Instances I ON Q.InstanceID = I.InstanceID
-CROSS APPLY(SELECT ISNULL(Q.total_elapsed_time,CASE WHEN Q.start_time_utc < Q.SnapshotDateUTC OR Q.start_time_utc IS NULL  THEN DATEDIFF_BIG(ms,ISNULL(Q.start_time_utc,Q.last_request_start_time_utc),Q.SnapshotDateUTC) ELSE 0 END) AS Duration,
+CROSS APPLY(SELECT ISNULL(CAST(Q.total_elapsed_time AS BIGINT),CASE WHEN Q.start_time_utc < Q.SnapshotDateUTC OR Q.start_time_utc IS NULL  THEN DATEDIFF_BIG(ms,ISNULL(Q.start_time_utc,Q.last_request_start_time_utc),Q.SnapshotDateUTC) ELSE 0 END) AS Duration,
                    CASE WHEN Q.transaction_begin_time_utc<Q.SnapshotDateUTC OR Q.transaction_begin_time_utc IS NULL THEN DATEDIFF_BIG(ms,Q.transaction_begin_time_utc,Q.SnapshotDateUTC) ELSE 0 END AS transaction_duration_ms) calc
 CROSS APPLY dbo.MillisecondsToHumanDuration (calc.Duration) HD
 CROSS APPLY dbo.SplitWaitResource(Q.wait_resource) waitR


### PR DESCRIPTION
Fix `Arithmetic overflow error converting expression to data type int.` error that occurs due to data type conversion to int with the inclusion of total_elapsed_time into the duration calculation.
Note: int is the correct data type returned from the DMV, but the calculated duration can sometimes exceed int max value.   Exceeding int max in the calculation only seems to happen for a brief period - the issues are rare.