### PR TITLE
DB Space History improvements

### DIFF
--- a/DBADashGUI/DBFiles/DBFilesControl.Designer.cs
+++ b/DBADashGUI/DBFiles/DBFilesControl.Designer.cs
@@ -30,38 +30,39 @@ namespace DBADashGUI.DBFiles
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle15 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle13 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle14 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle33 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle47 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle48 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle34 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle35 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle36 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle37 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle38 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle39 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle40 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle41 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle42 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle43 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle44 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle45 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle46 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DBFilesControl));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle16 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle21 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle22 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle23 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle24 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle25 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle26 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle27 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle28 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle29 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle30 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle31 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle49 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle50 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle51 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle52 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle53 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle54 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle55 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle56 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle57 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle58 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle59 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle60 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle61 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle62 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle63 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle64 = new System.Windows.Forms.DataGridViewCellStyle();
             dgvFiles = new DBADashDataGridView();
             Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             Database = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -145,6 +146,8 @@ namespace DBADashGUI.DBFiles
             dataGridViewTextBoxColumn29 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             dataGridViewTextBoxColumn30 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStats = new System.Windows.Forms.ToolStripStatusLabel();
+            tsSep = new System.Windows.Forms.ToolStripStatusLabel();
             lblInfo = new System.Windows.Forms.ToolStripStatusLabel();
             ((System.ComponentModel.ISupportInitialize)dgvFiles).BeginInit();
             toolStrip1.SuspendLayout();
@@ -155,32 +158,41 @@ namespace DBADashGUI.DBFiles
             // 
             dgvFiles.AllowUserToAddRows = false;
             dgvFiles.AllowUserToDeleteRows = false;
+            dgvFiles.AllowUserToOrderColumns = true;
             dgvFiles.BackgroundColor = System.Drawing.Color.White;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 9F);
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            dgvFiles.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle33.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle33.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle33.Font = new System.Drawing.Font("Segoe UI", 9F);
+            dataGridViewCellStyle33.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle33.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle33.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle33.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            dgvFiles.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle33;
             dgvFiles.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dgvFiles.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { Instance, Database, FileLevel_FileName, colType, FileLevel_PhysicalName, FileLevel_FileSizeMB, FileLevel_FileUsedMB, FileLevel_FileFreeMB, FileLevel_FilePctFree, FileLevel_Growth, FileLevel_GrowthPct, FileLevel_MaxSizeMB, FileGroup, SizeMB, FilegroupUsedMB, FilegroupFreeMB, FilegroupPctFree, FilegroupMaxSize, FilegroupPctMaxSize, FilegroupUsedPctMaxSize, NumberOfFiles, FilegroupAutogrow, ExcludedReason, MaxSizeExcludedReason, ReadOnly, DBReadOnly, Standby, State, ConfiguredLevel, FileSnapshotAge, History, Configure });
+            dataGridViewCellStyle47.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle47.BackColor = System.Drawing.Color.FromArgb(241, 241, 246);
+            dataGridViewCellStyle47.Font = new System.Drawing.Font("Segoe UI", 9F);
+            dataGridViewCellStyle47.ForeColor = System.Drawing.Color.FromArgb(0, 79, 131);
+            dataGridViewCellStyle47.SelectionBackColor = System.Drawing.Color.FromArgb(211, 211, 216);
+            dataGridViewCellStyle47.SelectionForeColor = System.Drawing.Color.FromArgb(0, 79, 131);
+            dataGridViewCellStyle47.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            dgvFiles.DefaultCellStyle = dataGridViewCellStyle47;
             dgvFiles.Dock = System.Windows.Forms.DockStyle.Fill;
             dgvFiles.EnableHeadersVisualStyles = false;
-            dgvFiles.Location = new System.Drawing.Point(0, 31);
+            dgvFiles.Location = new System.Drawing.Point(0, 27);
             dgvFiles.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             dgvFiles.Name = "dgvFiles";
             dgvFiles.ReadOnly = true;
             dgvFiles.ResultSetID = 0;
             dgvFiles.ResultSetName = null;
-            dataGridViewCellStyle15.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle15.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle15.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle15.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle15.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle15.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            dgvFiles.RowHeadersDefaultCellStyle = dataGridViewCellStyle15;
+            dataGridViewCellStyle48.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle48.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle48.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle48.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle48.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle48.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            dgvFiles.RowHeadersDefaultCellStyle = dataGridViewCellStyle48;
             dgvFiles.RowHeadersVisible = false;
             dgvFiles.RowHeadersWidth = 51;
             dgvFiles.Size = new System.Drawing.Size(1616, 304);
@@ -238,8 +250,8 @@ namespace DBADashGUI.DBFiles
             // FileLevel_FileSizeMB
             // 
             FileLevel_FileSizeMB.DataPropertyName = "FileSizeMB";
-            dataGridViewCellStyle2.Format = "N1";
-            FileLevel_FileSizeMB.DefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle34.Format = "N1";
+            FileLevel_FileSizeMB.DefaultCellStyle = dataGridViewCellStyle34;
             FileLevel_FileSizeMB.HeaderText = "File Size (MB)";
             FileLevel_FileSizeMB.MinimumWidth = 6;
             FileLevel_FileSizeMB.Name = "FileLevel_FileSizeMB";
@@ -250,8 +262,8 @@ namespace DBADashGUI.DBFiles
             // FileLevel_FileUsedMB
             // 
             FileLevel_FileUsedMB.DataPropertyName = "FileUsedMB";
-            dataGridViewCellStyle3.Format = "N1";
-            FileLevel_FileUsedMB.DefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle35.Format = "N1";
+            FileLevel_FileUsedMB.DefaultCellStyle = dataGridViewCellStyle35;
             FileLevel_FileUsedMB.HeaderText = "File Used (MB)";
             FileLevel_FileUsedMB.MinimumWidth = 6;
             FileLevel_FileUsedMB.Name = "FileLevel_FileUsedMB";
@@ -262,8 +274,8 @@ namespace DBADashGUI.DBFiles
             // FileLevel_FileFreeMB
             // 
             FileLevel_FileFreeMB.DataPropertyName = "FileFreeMB";
-            dataGridViewCellStyle4.Format = "N1";
-            FileLevel_FileFreeMB.DefaultCellStyle = dataGridViewCellStyle4;
+            dataGridViewCellStyle36.Format = "N1";
+            FileLevel_FileFreeMB.DefaultCellStyle = dataGridViewCellStyle36;
             FileLevel_FileFreeMB.HeaderText = "File Free (MB)";
             FileLevel_FileFreeMB.MinimumWidth = 6;
             FileLevel_FileFreeMB.Name = "FileLevel_FileFreeMB";
@@ -274,8 +286,8 @@ namespace DBADashGUI.DBFiles
             // FileLevel_FilePctFree
             // 
             FileLevel_FilePctFree.DataPropertyName = "FilePctFree";
-            dataGridViewCellStyle5.Format = "P1";
-            FileLevel_FilePctFree.DefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewCellStyle37.Format = "P1";
+            FileLevel_FilePctFree.DefaultCellStyle = dataGridViewCellStyle37;
             FileLevel_FilePctFree.HeaderText = "File Free %";
             FileLevel_FilePctFree.MinimumWidth = 6;
             FileLevel_FilePctFree.Name = "FileLevel_FilePctFree";
@@ -286,8 +298,8 @@ namespace DBADashGUI.DBFiles
             // FileLevel_Growth
             // 
             FileLevel_Growth.DataPropertyName = "GrowthMB";
-            dataGridViewCellStyle6.Format = "#,##0.#";
-            FileLevel_Growth.DefaultCellStyle = dataGridViewCellStyle6;
+            dataGridViewCellStyle38.Format = "#,##0.#";
+            FileLevel_Growth.DefaultCellStyle = dataGridViewCellStyle38;
             FileLevel_Growth.HeaderText = "Growth (MB)";
             FileLevel_Growth.MinimumWidth = 6;
             FileLevel_Growth.Name = "FileLevel_Growth";
@@ -308,8 +320,8 @@ namespace DBADashGUI.DBFiles
             // FileLevel_MaxSizeMB
             // 
             FileLevel_MaxSizeMB.DataPropertyName = "MaxSizeMB";
-            dataGridViewCellStyle7.Format = "#,##0.#";
-            FileLevel_MaxSizeMB.DefaultCellStyle = dataGridViewCellStyle7;
+            dataGridViewCellStyle39.Format = "#,##0.#";
+            FileLevel_MaxSizeMB.DefaultCellStyle = dataGridViewCellStyle39;
             FileLevel_MaxSizeMB.HeaderText = "Max Size (MB)";
             FileLevel_MaxSizeMB.MinimumWidth = 6;
             FileLevel_MaxSizeMB.Name = "FileLevel_MaxSizeMB";
@@ -329,8 +341,8 @@ namespace DBADashGUI.DBFiles
             // SizeMB
             // 
             SizeMB.DataPropertyName = "FilegroupSizeMB";
-            dataGridViewCellStyle8.Format = "N1";
-            SizeMB.DefaultCellStyle = dataGridViewCellStyle8;
+            dataGridViewCellStyle40.Format = "N1";
+            SizeMB.DefaultCellStyle = dataGridViewCellStyle40;
             SizeMB.HeaderText = "Filegroup Size (MB)";
             SizeMB.MinimumWidth = 6;
             SizeMB.Name = "SizeMB";
@@ -340,9 +352,9 @@ namespace DBADashGUI.DBFiles
             // FilegroupUsedMB
             // 
             FilegroupUsedMB.DataPropertyName = "FilegroupUsedMB";
-            dataGridViewCellStyle9.Format = "N1";
-            dataGridViewCellStyle9.NullValue = null;
-            FilegroupUsedMB.DefaultCellStyle = dataGridViewCellStyle9;
+            dataGridViewCellStyle41.Format = "N1";
+            dataGridViewCellStyle41.NullValue = null;
+            FilegroupUsedMB.DefaultCellStyle = dataGridViewCellStyle41;
             FilegroupUsedMB.HeaderText = "Filegroup Used (MB)";
             FilegroupUsedMB.MinimumWidth = 6;
             FilegroupUsedMB.Name = "FilegroupUsedMB";
@@ -352,8 +364,8 @@ namespace DBADashGUI.DBFiles
             // FilegroupFreeMB
             // 
             FilegroupFreeMB.DataPropertyName = "FilegroupFreeMB";
-            dataGridViewCellStyle10.Format = "N1";
-            FilegroupFreeMB.DefaultCellStyle = dataGridViewCellStyle10;
+            dataGridViewCellStyle42.Format = "N1";
+            FilegroupFreeMB.DefaultCellStyle = dataGridViewCellStyle42;
             FilegroupFreeMB.HeaderText = "Filegroup Free (MB)";
             FilegroupFreeMB.MinimumWidth = 6;
             FilegroupFreeMB.Name = "FilegroupFreeMB";
@@ -363,9 +375,9 @@ namespace DBADashGUI.DBFiles
             // FilegroupPctFree
             // 
             FilegroupPctFree.DataPropertyName = "FilegroupPctFree";
-            dataGridViewCellStyle11.Format = "P1";
-            dataGridViewCellStyle11.NullValue = null;
-            FilegroupPctFree.DefaultCellStyle = dataGridViewCellStyle11;
+            dataGridViewCellStyle43.Format = "P1";
+            dataGridViewCellStyle43.NullValue = null;
+            FilegroupPctFree.DefaultCellStyle = dataGridViewCellStyle43;
             FilegroupPctFree.HeaderText = "Filegroup Free %";
             FilegroupPctFree.MinimumWidth = 6;
             FilegroupPctFree.Name = "FilegroupPctFree";
@@ -375,8 +387,8 @@ namespace DBADashGUI.DBFiles
             // FilegroupMaxSize
             // 
             FilegroupMaxSize.DataPropertyName = "FilegroupMaxSizeMB";
-            dataGridViewCellStyle12.Format = "N0";
-            FilegroupMaxSize.DefaultCellStyle = dataGridViewCellStyle12;
+            dataGridViewCellStyle44.Format = "N0";
+            FilegroupMaxSize.DefaultCellStyle = dataGridViewCellStyle44;
             FilegroupMaxSize.HeaderText = "Filegroup Max Size (MB)";
             FilegroupMaxSize.MinimumWidth = 6;
             FilegroupMaxSize.Name = "FilegroupMaxSize";
@@ -386,8 +398,8 @@ namespace DBADashGUI.DBFiles
             // FilegroupPctMaxSize
             // 
             FilegroupPctMaxSize.DataPropertyName = "FilegroupPctOfMaxSize";
-            dataGridViewCellStyle13.Format = "P1";
-            FilegroupPctMaxSize.DefaultCellStyle = dataGridViewCellStyle13;
+            dataGridViewCellStyle45.Format = "P1";
+            FilegroupPctMaxSize.DefaultCellStyle = dataGridViewCellStyle45;
             FilegroupPctMaxSize.HeaderText = "Filegroup % Of Max Size";
             FilegroupPctMaxSize.MinimumWidth = 6;
             FilegroupPctMaxSize.Name = "FilegroupPctMaxSize";
@@ -397,8 +409,8 @@ namespace DBADashGUI.DBFiles
             // FilegroupUsedPctMaxSize
             // 
             FilegroupUsedPctMaxSize.DataPropertyName = "FilegroupUsedPctOfMaxSize";
-            dataGridViewCellStyle14.Format = "P1";
-            FilegroupUsedPctMaxSize.DefaultCellStyle = dataGridViewCellStyle14;
+            dataGridViewCellStyle46.Format = "P1";
+            FilegroupUsedPctMaxSize.DefaultCellStyle = dataGridViewCellStyle46;
             FilegroupUsedPctMaxSize.HeaderText = "Filegroup Used % Max Size";
             FilegroupUsedPctMaxSize.MinimumWidth = 6;
             FilegroupUsedPctMaxSize.Name = "FilegroupUsedPctMaxSize";
@@ -525,7 +537,7 @@ namespace DBADashGUI.DBFiles
             toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, statusFilterToolStrip1, tsConfigure, tsLevel, tsType, tsTrigger, tsClearFilter });
             toolStrip1.Location = new System.Drawing.Point(0, 0);
             toolStrip1.Name = "toolStrip1";
-            toolStrip1.Size = new System.Drawing.Size(1616, 31);
+            toolStrip1.Size = new System.Drawing.Size(1616, 27);
             toolStrip1.TabIndex = 3;
             toolStrip1.Text = "toolStrip1";
             // 
@@ -535,7 +547,7 @@ namespace DBADashGUI.DBFiles
             tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
             tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsRefresh.Name = "tsRefresh";
-            tsRefresh.Size = new System.Drawing.Size(29, 28);
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
             tsRefresh.Text = "Refresh";
             tsRefresh.Click += TsRefresh_Click;
             // 
@@ -545,7 +557,7 @@ namespace DBADashGUI.DBFiles
             tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
             tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsCopy.Name = "tsCopy";
-            tsCopy.Size = new System.Drawing.Size(29, 28);
+            tsCopy.Size = new System.Drawing.Size(29, 24);
             tsCopy.Text = "Copy";
             tsCopy.Click += TsCopy_Click;
             // 
@@ -555,7 +567,7 @@ namespace DBADashGUI.DBFiles
             tsExcel.Image = Properties.Resources.excel16x16;
             tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsExcel.Name = "tsExcel";
-            tsExcel.Size = new System.Drawing.Size(29, 28);
+            tsExcel.Size = new System.Drawing.Size(29, 24);
             tsExcel.Text = "Export Excel";
             tsExcel.Click += TsExcel_Click;
             // 
@@ -574,7 +586,7 @@ namespace DBADashGUI.DBFiles
             statusFilterToolStrip1.NAVisible = true;
             statusFilterToolStrip1.OK = true;
             statusFilterToolStrip1.OKVisible = true;
-            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 28);
+            statusFilterToolStrip1.Size = new System.Drawing.Size(67, 24);
             statusFilterToolStrip1.Text = "ALL";
             statusFilterToolStrip1.Warning = true;
             statusFilterToolStrip1.WarningVisible = true;
@@ -587,7 +599,7 @@ namespace DBADashGUI.DBFiles
             tsConfigure.Image = Properties.Resources.SettingsOutline_16x;
             tsConfigure.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsConfigure.Name = "tsConfigure";
-            tsConfigure.Size = new System.Drawing.Size(34, 28);
+            tsConfigure.Size = new System.Drawing.Size(34, 24);
             tsConfigure.Text = "Configure";
             // 
             // configureDatabaseThresholdsToolStripMenuItem
@@ -618,7 +630,7 @@ namespace DBADashGUI.DBFiles
             tsLevel.Image = (System.Drawing.Image)resources.GetObject("tsLevel.Image");
             tsLevel.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsLevel.Name = "tsLevel";
-            tsLevel.Size = new System.Drawing.Size(57, 28);
+            tsLevel.Size = new System.Drawing.Size(57, 24);
             tsLevel.Text = "Level";
             // 
             // tsFilegroup
@@ -645,7 +657,7 @@ namespace DBADashGUI.DBFiles
             tsType.Image = (System.Drawing.Image)resources.GetObject("tsType.Image");
             tsType.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsType.Name = "tsType";
-            tsType.Size = new System.Drawing.Size(54, 28);
+            tsType.Size = new System.Drawing.Size(54, 24);
             tsType.Text = "Type";
             // 
             // rOWSToolStripMenuItem
@@ -698,7 +710,7 @@ namespace DBADashGUI.DBFiles
             tsTrigger.Image = Properties.Resources.ProjectSystemModelRefresh_16x;
             tsTrigger.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsTrigger.Name = "tsTrigger";
-            tsTrigger.Size = new System.Drawing.Size(151, 28);
+            tsTrigger.Size = new System.Drawing.Size(151, 24);
             tsTrigger.Text = "Trigger Collection";
             tsTrigger.Visible = false;
             tsTrigger.Click += TsTrigger_Click;
@@ -709,7 +721,7 @@ namespace DBADashGUI.DBFiles
             tsClearFilter.Image = Properties.Resources.Eraser_16x;
             tsClearFilter.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsClearFilter.Name = "tsClearFilter";
-            tsClearFilter.Size = new System.Drawing.Size(104, 28);
+            tsClearFilter.Size = new System.Drawing.Size(104, 24);
             tsClearFilter.Text = "Clear Filter";
             // 
             // dataGridViewTextBoxColumn1
@@ -753,8 +765,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn5
             // 
             dataGridViewTextBoxColumn5.DataPropertyName = "FileSizeMB";
-            dataGridViewCellStyle16.Format = "N1";
-            dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle16;
+            dataGridViewCellStyle49.Format = "N1";
+            dataGridViewTextBoxColumn5.DefaultCellStyle = dataGridViewCellStyle49;
             dataGridViewTextBoxColumn5.HeaderText = "File Size (MB)";
             dataGridViewTextBoxColumn5.MinimumWidth = 6;
             dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
@@ -765,8 +777,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn6
             // 
             dataGridViewTextBoxColumn6.DataPropertyName = "FileUsedMB";
-            dataGridViewCellStyle17.Format = "N1";
-            dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle17;
+            dataGridViewCellStyle50.Format = "N1";
+            dataGridViewTextBoxColumn6.DefaultCellStyle = dataGridViewCellStyle50;
             dataGridViewTextBoxColumn6.HeaderText = "File Used (MB)";
             dataGridViewTextBoxColumn6.MinimumWidth = 6;
             dataGridViewTextBoxColumn6.Name = "dataGridViewTextBoxColumn6";
@@ -777,8 +789,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn7
             // 
             dataGridViewTextBoxColumn7.DataPropertyName = "FileFreeMB";
-            dataGridViewCellStyle18.Format = "N1";
-            dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle18;
+            dataGridViewCellStyle51.Format = "N1";
+            dataGridViewTextBoxColumn7.DefaultCellStyle = dataGridViewCellStyle51;
             dataGridViewTextBoxColumn7.HeaderText = "File Free (MB)";
             dataGridViewTextBoxColumn7.MinimumWidth = 6;
             dataGridViewTextBoxColumn7.Name = "dataGridViewTextBoxColumn7";
@@ -789,8 +801,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn8
             // 
             dataGridViewTextBoxColumn8.DataPropertyName = "FilePctFree";
-            dataGridViewCellStyle19.Format = "P1";
-            dataGridViewTextBoxColumn8.DefaultCellStyle = dataGridViewCellStyle19;
+            dataGridViewCellStyle52.Format = "P1";
+            dataGridViewTextBoxColumn8.DefaultCellStyle = dataGridViewCellStyle52;
             dataGridViewTextBoxColumn8.HeaderText = "File Free %";
             dataGridViewTextBoxColumn8.MinimumWidth = 6;
             dataGridViewTextBoxColumn8.Name = "dataGridViewTextBoxColumn8";
@@ -801,8 +813,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn9
             // 
             dataGridViewTextBoxColumn9.DataPropertyName = "GrowthMB";
-            dataGridViewCellStyle20.Format = "#,##0.#";
-            dataGridViewTextBoxColumn9.DefaultCellStyle = dataGridViewCellStyle20;
+            dataGridViewCellStyle53.Format = "#,##0.#";
+            dataGridViewTextBoxColumn9.DefaultCellStyle = dataGridViewCellStyle53;
             dataGridViewTextBoxColumn9.HeaderText = "Growth (MB)";
             dataGridViewTextBoxColumn9.MinimumWidth = 6;
             dataGridViewTextBoxColumn9.Name = "dataGridViewTextBoxColumn9";
@@ -813,8 +825,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn10
             // 
             dataGridViewTextBoxColumn10.DataPropertyName = "MaxSizeMB";
-            dataGridViewCellStyle21.Format = "#,##0.#";
-            dataGridViewTextBoxColumn10.DefaultCellStyle = dataGridViewCellStyle21;
+            dataGridViewCellStyle54.Format = "#,##0.#";
+            dataGridViewTextBoxColumn10.DefaultCellStyle = dataGridViewCellStyle54;
             dataGridViewTextBoxColumn10.HeaderText = "Max Size (MB)";
             dataGridViewTextBoxColumn10.MinimumWidth = 6;
             dataGridViewTextBoxColumn10.Name = "dataGridViewTextBoxColumn10";
@@ -825,8 +837,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn11
             // 
             dataGridViewTextBoxColumn11.DataPropertyName = "filegroup_name";
-            dataGridViewCellStyle22.Format = "#,##0.#";
-            dataGridViewTextBoxColumn11.DefaultCellStyle = dataGridViewCellStyle22;
+            dataGridViewCellStyle55.Format = "#,##0.#";
+            dataGridViewTextBoxColumn11.DefaultCellStyle = dataGridViewCellStyle55;
             dataGridViewTextBoxColumn11.HeaderText = "Filegroup";
             dataGridViewTextBoxColumn11.MinimumWidth = 6;
             dataGridViewTextBoxColumn11.Name = "dataGridViewTextBoxColumn11";
@@ -837,8 +849,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn12
             // 
             dataGridViewTextBoxColumn12.DataPropertyName = "FilegroupSizeMB";
-            dataGridViewCellStyle23.Format = "N1";
-            dataGridViewTextBoxColumn12.DefaultCellStyle = dataGridViewCellStyle23;
+            dataGridViewCellStyle56.Format = "N1";
+            dataGridViewTextBoxColumn12.DefaultCellStyle = dataGridViewCellStyle56;
             dataGridViewTextBoxColumn12.HeaderText = "Filegroup Size (MB)";
             dataGridViewTextBoxColumn12.MinimumWidth = 6;
             dataGridViewTextBoxColumn12.Name = "dataGridViewTextBoxColumn12";
@@ -849,9 +861,9 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn13
             // 
             dataGridViewTextBoxColumn13.DataPropertyName = "FilegroupUsedMB";
-            dataGridViewCellStyle24.Format = "N1";
-            dataGridViewCellStyle24.NullValue = null;
-            dataGridViewTextBoxColumn13.DefaultCellStyle = dataGridViewCellStyle24;
+            dataGridViewCellStyle57.Format = "N1";
+            dataGridViewCellStyle57.NullValue = null;
+            dataGridViewTextBoxColumn13.DefaultCellStyle = dataGridViewCellStyle57;
             dataGridViewTextBoxColumn13.HeaderText = "Filegroup Used (MB)";
             dataGridViewTextBoxColumn13.MinimumWidth = 6;
             dataGridViewTextBoxColumn13.Name = "dataGridViewTextBoxColumn13";
@@ -861,8 +873,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn14
             // 
             dataGridViewTextBoxColumn14.DataPropertyName = "FilegroupFreeMB";
-            dataGridViewCellStyle25.Format = "N1";
-            dataGridViewTextBoxColumn14.DefaultCellStyle = dataGridViewCellStyle25;
+            dataGridViewCellStyle58.Format = "N1";
+            dataGridViewTextBoxColumn14.DefaultCellStyle = dataGridViewCellStyle58;
             dataGridViewTextBoxColumn14.HeaderText = "Filegroup Free (MB)";
             dataGridViewTextBoxColumn14.MinimumWidth = 6;
             dataGridViewTextBoxColumn14.Name = "dataGridViewTextBoxColumn14";
@@ -872,9 +884,9 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn15
             // 
             dataGridViewTextBoxColumn15.DataPropertyName = "FilegroupPctFree";
-            dataGridViewCellStyle26.Format = "P1";
-            dataGridViewCellStyle26.NullValue = null;
-            dataGridViewTextBoxColumn15.DefaultCellStyle = dataGridViewCellStyle26;
+            dataGridViewCellStyle59.Format = "P1";
+            dataGridViewCellStyle59.NullValue = null;
+            dataGridViewTextBoxColumn15.DefaultCellStyle = dataGridViewCellStyle59;
             dataGridViewTextBoxColumn15.HeaderText = "Filegroup Free %";
             dataGridViewTextBoxColumn15.MinimumWidth = 6;
             dataGridViewTextBoxColumn15.Name = "dataGridViewTextBoxColumn15";
@@ -884,9 +896,9 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn16
             // 
             dataGridViewTextBoxColumn16.DataPropertyName = "FilegroupNumberOfFiles";
-            dataGridViewCellStyle27.Format = "P1";
-            dataGridViewCellStyle27.NullValue = null;
-            dataGridViewTextBoxColumn16.DefaultCellStyle = dataGridViewCellStyle27;
+            dataGridViewCellStyle60.Format = "P1";
+            dataGridViewCellStyle60.NullValue = null;
+            dataGridViewTextBoxColumn16.DefaultCellStyle = dataGridViewCellStyle60;
             dataGridViewTextBoxColumn16.HeaderText = "Filegroup Number of Files";
             dataGridViewTextBoxColumn16.MinimumWidth = 6;
             dataGridViewTextBoxColumn16.Name = "dataGridViewTextBoxColumn16";
@@ -896,8 +908,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn17
             // 
             dataGridViewTextBoxColumn17.DataPropertyName = "ExcludedReason";
-            dataGridViewCellStyle28.Format = "N0";
-            dataGridViewTextBoxColumn17.DefaultCellStyle = dataGridViewCellStyle28;
+            dataGridViewCellStyle61.Format = "N0";
+            dataGridViewTextBoxColumn17.DefaultCellStyle = dataGridViewCellStyle61;
             dataGridViewTextBoxColumn17.HeaderText = "Excluded Reason";
             dataGridViewTextBoxColumn17.MinimumWidth = 6;
             dataGridViewTextBoxColumn17.Name = "dataGridViewTextBoxColumn17";
@@ -907,8 +919,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn18
             // 
             dataGridViewTextBoxColumn18.DataPropertyName = "is_read_only";
-            dataGridViewCellStyle29.Format = "P1";
-            dataGridViewTextBoxColumn18.DefaultCellStyle = dataGridViewCellStyle29;
+            dataGridViewCellStyle62.Format = "P1";
+            dataGridViewTextBoxColumn18.DefaultCellStyle = dataGridViewCellStyle62;
             dataGridViewTextBoxColumn18.HeaderText = "Read Only";
             dataGridViewTextBoxColumn18.MinimumWidth = 6;
             dataGridViewTextBoxColumn18.Name = "dataGridViewTextBoxColumn18";
@@ -918,8 +930,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn19
             // 
             dataGridViewTextBoxColumn19.DataPropertyName = "is_db_read_only";
-            dataGridViewCellStyle30.Format = "P1";
-            dataGridViewTextBoxColumn19.DefaultCellStyle = dataGridViewCellStyle30;
+            dataGridViewCellStyle63.Format = "P1";
+            dataGridViewTextBoxColumn19.DefaultCellStyle = dataGridViewCellStyle63;
             dataGridViewTextBoxColumn19.HeaderText = "DB ReadOnly";
             dataGridViewTextBoxColumn19.MinimumWidth = 6;
             dataGridViewTextBoxColumn19.Name = "dataGridViewTextBoxColumn19";
@@ -929,8 +941,8 @@ namespace DBADashGUI.DBFiles
             // dataGridViewTextBoxColumn20
             // 
             dataGridViewTextBoxColumn20.DataPropertyName = "is_in_standby";
-            dataGridViewCellStyle31.Format = "P1";
-            dataGridViewTextBoxColumn20.DefaultCellStyle = dataGridViewCellStyle31;
+            dataGridViewCellStyle64.Format = "P1";
+            dataGridViewTextBoxColumn20.DefaultCellStyle = dataGridViewCellStyle64;
             dataGridViewTextBoxColumn20.HeaderText = "Standby";
             dataGridViewTextBoxColumn20.MinimumWidth = 6;
             dataGridViewTextBoxColumn20.Name = "dataGridViewTextBoxColumn20";
@@ -1024,18 +1036,30 @@ namespace DBADashGUI.DBFiles
             // statusStrip1
             // 
             statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblInfo });
-            statusStrip1.Location = new System.Drawing.Point(0, 335);
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStats, tsSep, lblInfo });
+            statusStrip1.Location = new System.Drawing.Point(0, 331);
             statusStrip1.Name = "statusStrip1";
             statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
-            statusStrip1.Size = new System.Drawing.Size(1616, 22);
+            statusStrip1.Size = new System.Drawing.Size(1616, 26);
             statusStrip1.TabIndex = 4;
             statusStrip1.Text = "statusStrip1";
+            // 
+            // lblStats
+            // 
+            lblStats.Name = "lblStats";
+            lblStats.Size = new System.Drawing.Size(51, 20);
+            lblStats.Text = "{Stats}";
+            // 
+            // tsSep
+            // 
+            tsSep.Name = "tsSep";
+            tsSep.Size = new System.Drawing.Size(13, 20);
+            tsSep.Text = "|";
             // 
             // lblInfo
             // 
             lblInfo.Name = "lblInfo";
-            lblInfo.Size = new System.Drawing.Size(0, 16);
+            lblInfo.Size = new System.Drawing.Size(0, 20);
             // 
             // DBFilesControl
             // 
@@ -1142,5 +1166,7 @@ namespace DBADashGUI.DBFiles
         private System.Windows.Forms.ToolStripStatusLabel lblInfo;
         private System.Windows.Forms.ToolStripButton tsTrigger;
         private System.Windows.Forms.ToolStripButton tsClearFilter;
+        private System.Windows.Forms.ToolStripStatusLabel lblStats;
+        private System.Windows.Forms.ToolStripStatusLabel tsSep;
     }
 }

--- a/DBADashGUI/DBFiles/DBFilesControl.resx
+++ b/DBADashGUI/DBFiles/DBFilesControl.resx
@@ -220,45 +220,45 @@
   <data name="statusFilterToolStrip1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAHbSURBVDhPjZK9SwJxHMbvT6m9SYKWs8EabogKc1CijLpB
-        HCKkLE6pqJBeDSsqzV6Iiny7osFBe6FwKiFoMGgqSIgg3Bz95vPr7tK7hr7wLMc9n+/zfO84/VyFT6NP
-        a7ulj+UQQV+5INPzdbh0lz2JKq8ZJ70r84VQpPw0JlG8s4eCphamdXcz01mgmwryOL3cbJezWZlXbD8D
-        89vKeuXc5qAwb6Gca5heZxaoOB+kz9sler8M0P2Bm/a8rZRZ66XiXahSB8HmtKOf9iyCZlQFgCqAjqR2
-        BkESZmadq7GxWW/WA1QIkqAOuwkOhs6IDUOmb0jrX3sDKLcjMgjq4CY4LIdL48Xa7bEOqwEgB7rqUuAZ
-        vo4GUM0QYKikAhAZJhUAaQCfvEWNNjNNxDfq5IrMseeNVg+5whmaiN3XCc99yfwvwHO8aoCoAL3Zc5T7
-        BUipw5J5xEH2xdF/A+zzMTIPB0lK5m84fyoRFbenqckpGFL8BcD2pv5JEjfT5E/mB9i/4JP3y21eJ5nE
-        TmMVndk0OEuCFEH8R2bGTMkXvC8VqQh+kSVBHQ2kGBEbm2GWEg+lqbPHBsX+MwxSTYI6uAmLr1SA0Bmx
-        sdlgrh3cBIfF12GqXhrCwbTO2nDcNxpvR7NQRXnOAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAHVSURBVDhPjZLLSwJRGMX9U3LvSoI22sJauAiLcqFEFjUL
+        aREhWTFKRYXYyzCj0uxBVORrihYutAeJKxMEFwWtChIiCHcu/eJcmts406ILZ3O55/ed883odKpzG72I
+        V7cO6h/rYYK+iiGm57tovZA/j6vf85M9kExP4Vij6hUpaRugkLGDKTLeznQZ6KMnaYZe7vca+bxk0pjf
+        NiLNK7uToiYLFd0T9Lq4QrVgiD4f1uj9JkCl43E6nO6k3NYg1QrhZgsEk7NOFx1arNwoCwBZAJ2K3QyC
+        JMzMOntFNlltVgNkCJKgDtsJFobOiA1DbmiM91fuACruCwyCOtgJFqvDpvFQOT3R068BSIHelhS4w9fh
+        AGVswFBJBiAyTMoqHOCTdklvN9NscrtF7tgyu9f3e8gdzdFsotQi3PvS5V+A52xTA5EBarPntPgLEDMn
+        dfOkkxyrU/8GOIIJMk+ESEyX73X+TCou7C2QYdiqSfEXANMNrjkSdrLkT5dH2L/gk44aXdPDZBRsGoja
+        bBxdIqsYQ/wK/xPnpWuTLxNrWv0CS4I6HPRjRGxMhllMPdbnLyttHMAh0lEDdbATFv+nAoTOiI3JGrPy
+        YCdYLL4OU7rMhIXxzorzDRpvR7NCmeS8AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="tsLevel.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
-        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
-        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
-        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
-        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
-        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
-        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
-        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
-        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
-        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIFSURBVDhPpZLtS1NhGMbPPxJmmlYSgqHiKzGU1EDxg4iK
+        YKyG2WBogqMYJQOtCEVRFBGdTBCJfRnkS4VaaWNT5sqx1BUxRXxDHYxAJLvkusEeBaPAB+5z4Jzn+t3X
+        /aLhnEfjo8m+dCoa+7/C3O2Hqe0zDC+8KG+cRZHZhdzaaWTVTCLDMIY0vfM04Nfh77/G/sEhwpEDbO3t
+        I7TxE8urEVy99fT/AL5gWDLrTB/hnF4XsW0khCu5ln8DmJliT2AXrcNBsU1gj/MH4nMeKwBrPktM28xM
+        cX79DFKrHHD5d9D26hvicx4pABt2lpg10zYzU0zr7+e3xXGcrkEB2O2TNec9nJFwB3alZn5jZorfeDZh
+        6Q3g8s06BeCoKF4MRURoH1+BY2oNCbeb0TIclIYxOhzf8frTOuo7FxCbbVIAzpni0iceEc8vhzEwGkJD
+        lx83ymxifejdKjRNk/8PWnyIyTQqAJek0jqHwfEVscu31baIu8+90sTE4nY025dQ2/5FIPpnXlzKuK8A
+        HBUzHot52djqQ6HZhfR7IwK4mKpHtvEDMqvfCiQ6zaAAXM8x94aIWTNrLLG4kVUzgaTSPlzLtyJOZxbb
+        1wtfyg4Q+AfA3aZlButjSfxGcUJBk4g5tuP3haQKRKXcUQDOmbvNTpPOJeFFjordZmbWTNvMTHFUcpUC
+        nOccAdABIDXXE1nzAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="tsType.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
-        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
-        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
-        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
-        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
-        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
-        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
-        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
-        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
-        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAAIFSURBVDhPpZLtS1NhGMbPPxJmmlYSgqHiKzGU1EDxg4iK
+        YKyG2WBogqMYJQOtCEVRFBGdTBCJfRnkS4VaaWNT5sqx1BUxRXxDHYxAJLvkusEeBaPAB+5z4Jzn+t3X
+        /aLhnEfjo8m+dCoa+7/C3O2Hqe0zDC+8KG+cRZHZhdzaaWTVTCLDMIY0vfM04Nfh77/G/sEhwpEDbO3t
+        I7TxE8urEVy99fT/AL5gWDLrTB/hnF4XsW0khCu5ln8DmJliT2AXrcNBsU1gj/MH4nMeKwBrPktM28xM
+        cX79DFKrHHD5d9D26hvicx4pABt2lpg10zYzU0zr7+e3xXGcrkEB2O2TNec9nJFwB3alZn5jZorfeDZh
+        6Q3g8s06BeCoKF4MRURoH1+BY2oNCbeb0TIclIYxOhzf8frTOuo7FxCbbVIAzpni0iceEc8vhzEwGkJD
+        lx83ymxifejdKjRNk/8PWnyIyTQqAJek0jqHwfEVscu31baIu8+90sTE4nY025dQ2/5FIPpnXlzKuK8A
+        HBUzHot52djqQ6HZhfR7IwK4mKpHtvEDMqvfCiQ6zaAAXM8x94aIWTNrLLG4kVUzgaTSPlzLtyJOZxbb
+        1wtfyg4Q+AfA3aZlButjSfxGcUJBk4g5tuP3haQKRKXcUQDOmbvNTpPOJeFFjordZmbWTNvMTHFUcpUC
+        nOccAdABIDXXE1nzAAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/DBADashGUI/DBFiles/DBSpaceHistory.Designer.cs
+++ b/DBADashGUI/DBFiles/DBSpaceHistory.Designer.cs
@@ -31,11 +31,13 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DBSpaceHistory));
             chart1 = new LiveCharts.WinForms.CartesianChart();
             toolStrip1 = new System.Windows.Forms.ToolStrip();
-            tsDateRange = new DateRangeToolStripMenuItem();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            tsDateGroup = new System.Windows.Forms.ToolStripDropDownButton();
             toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
             smoothLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             pointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            tsRefresh = new System.Windows.Forms.ToolStripButton();
             tsFileGroup = new System.Windows.Forms.ToolStripDropDownButton();
             tsFile = new System.Windows.Forms.ToolStripDropDownButton();
             tsUnits = new System.Windows.Forms.ToolStripDropDownButton();
@@ -43,8 +45,7 @@
             gBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             tBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             tsGrid = new System.Windows.Forms.ToolStripButton();
-            tsCopy = new System.Windows.Forms.ToolStripButton();
-            tsExcel = new System.Windows.Forms.ToolStripButton();
+            tsDateRange = new DateRangeToolStripMenuItem();
             splitContainer1 = new System.Windows.Forms.SplitContainer();
             dgv = new System.Windows.Forms.DataGridView();
             toolStrip1.SuspendLayout();
@@ -69,28 +70,50 @@
             // toolStrip1
             // 
             toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsDateRange, toolStripDropDownButton1, tsRefresh, tsFileGroup, tsFile, tsUnits, tsGrid, tsCopy, tsExcel });
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, tsDateGroup, toolStripDropDownButton1, tsFileGroup, tsFile, tsUnits, tsGrid, tsDateRange });
             toolStrip1.Location = new System.Drawing.Point(0, 0);
             toolStrip1.Name = "toolStrip1";
             toolStrip1.Size = new System.Drawing.Size(1134, 27);
             toolStrip1.TabIndex = 3;
             toolStrip1.Text = "toolStrip1";
             // 
-            // tsDateRange
+            // tsRefresh
             // 
-            tsDateRange.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            tsDateRange.DefaultTimeSpan = System.TimeSpan.Parse("90.00:00:00");
-            tsDateRange.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            tsDateRange.Font = new System.Drawing.Font("Segoe UI", 9F);
-            tsDateRange.Image = (System.Drawing.Image)resources.GetObject("tsDateRange.Image");
-            tsDateRange.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsDateRange.MaximumTimeSpan = System.TimeSpan.Parse("10675199.02:48:05.4775807");
-            tsDateRange.MinimumTimeSpan = System.TimeSpan.Parse("1.00:00:00");
-            tsDateRange.Name = "tsDateRange";
-            tsDateRange.SelectedTimeSpan = System.TimeSpan.Parse("90.00:00:00");
-            tsDateRange.Size = new System.Drawing.Size(95, 24);
-            tsDateRange.Text = "90 Days";
-            tsDateRange.DateRangeChanged += DateRangeChanged;
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
+            // 
+            // tsCopy
+            // 
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy Grid";
+            tsCopy.Click += TsCopy_Click;
+            // 
+            // tsExcel
+            // 
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export to Excel";
+            tsExcel.Click += TsExcel_Click;
+            // 
+            // tsDateGroup
+            // 
+            tsDateGroup.Image = Properties.Resources.Time_16x;
+            tsDateGroup.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsDateGroup.Name = "tsDateGroup";
+            tsDateGroup.Size = new System.Drawing.Size(120, 24);
+            tsDateGroup.Text = "Date Group";
             // 
             // toolStripDropDownButton1
             // 
@@ -121,16 +144,6 @@
             pointsToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             pointsToolStripMenuItem.Text = "Points";
             pointsToolStripMenuItem.Click += PointsToolStripMenuItem_Click;
-            // 
-            // tsRefresh
-            // 
-            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsRefresh.Name = "tsRefresh";
-            tsRefresh.Size = new System.Drawing.Size(29, 24);
-            tsRefresh.Text = "Refresh";
-            tsRefresh.Click += TsRefresh_Click;
             // 
             // tsFileGroup
             // 
@@ -193,28 +206,24 @@
             tsGrid.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsGrid.Name = "tsGrid";
             tsGrid.Size = new System.Drawing.Size(29, 24);
-            tsGrid.Text = "Toggle Grid";
+            tsGrid.Text = "Toggle Grid/Chart";
             tsGrid.Click += TsGrid_Click;
             // 
-            // tsCopy
+            // tsDateRange
             // 
-            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
-            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsCopy.Name = "tsCopy";
-            tsCopy.Size = new System.Drawing.Size(29, 24);
-            tsCopy.Text = "Copy Grid";
-            tsCopy.Click += TsCopy_Click;
-            // 
-            // tsExcel
-            // 
-            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsExcel.Image = Properties.Resources.excel16x16;
-            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsExcel.Name = "tsExcel";
-            tsExcel.Size = new System.Drawing.Size(29, 24);
-            tsExcel.Text = "Export to Excel";
-            tsExcel.Click += TsExcel_Click;
+            tsDateRange.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsDateRange.DefaultTimeSpan = System.TimeSpan.Parse("01:00:00");
+            tsDateRange.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
+            tsDateRange.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            tsDateRange.Image = (System.Drawing.Image)resources.GetObject("tsDateRange.Image");
+            tsDateRange.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsDateRange.MaximumTimeSpan = System.TimeSpan.Parse("10675199.02:48:05.4775807");
+            tsDateRange.MinimumTimeSpan = System.TimeSpan.Parse("01:00:00");
+            tsDateRange.Name = "tsDateRange";
+            tsDateRange.SelectedTimeSpan = System.TimeSpan.Parse("90.00:00:00");
+            tsDateRange.Size = new System.Drawing.Size(99, 24);
+            tsDateRange.Text = "90 Days";
+            tsDateRange.DateRangeChanged += DateRangeChanged;
             // 
             // splitContainer1
             // 
@@ -291,6 +300,7 @@
         private System.Windows.Forms.ToolStripMenuItem mBToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem gBToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem tBToolStripMenuItem;
+        private System.Windows.Forms.ToolStripDropDownButton tsDateGroup;
         private DateRangeToolStripMenuItem tsDateRange;
     }
 }

--- a/DBADashGUI/DBFiles/DBSpaceHistory.resx
+++ b/DBADashGUI/DBFiles/DBSpaceHistory.resx
@@ -121,16 +121,6 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="tsDateRange.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADlSURBVDhPrZO9DYMwFIQzQbbxAhQUVAzAOGxAR80EzECU
-        MAUJCyRprqB50YdIRBxbUX4snWTZd5/8nu3NxhuSnKRa0iBpWsScNef7H0PSVlIzjqNVVWVFUViaprOY
-        s8YeHryhcN+2rWVZZmVZWtft7DicZjFnjT08eJ8gUNnI89wO+94u52tQ7OFZIM097DgadD+cJEkQgncp
-        xwGoqY8j+uYQAOElQxbAQJOo0zfGAHjJkAUw0Wma5RtjALxkyL4FrBUDREuIyS8h2sSY/CZGrzGkl2v8
-        +SH95SmvIN99pvX49DvfAN2c2o86NEGQAAAAAElFTkSuQmCC
-</value>
-  </data>
   <data name="tsUnits.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -140,6 +130,16 @@
         GoC0OnWpODq8zqyRxMDGvYdyRtbIx8B6f6Py2HmT/xKJDVRqjY/ytAhm/FwI1FtdKg23gjCOaITdFz8X
         An3rIoiSYDL+Z2BzrDl3gMmiPwPAmrHu3IEksG6sXVkAwPlHAZVovu93VKKpfp4ISreGcqlKAwAAAABJ
         RU5ErkJggg==
+</value>
+  </data>
+  <data name="tsDateRange.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADlSURBVDhPrZO9DYMwFIQzQbbxAhQUVAzAOGxAR80EzECU
+        MAUJCyRprqB50YdIRBxbUX4snWTZd5/8nu3NxhuSnKRa0iBpWsScNef7H0PSVlIzjqNVVWVFUViaprOY
+        s8YeHryhcN+2rWVZZmVZWtft7DicZjFnjT08eJ8gUNnI89wO+94u52tQ7OFZIM097DgadD+cJEkQgncp
+        xwGoqY8j+uYQAOElQxbAQJOo0zfGAHjJkAUw0Wma5RtjALxkyL4FrBUDREuIyS8h2sSY/CZGrzGkl2v8
+        +SH95SmvIN99pvX49DvfAN2c2o86NEGQAAAAAElFTkSuQmCC
 </value>
   </data>
 </root>

--- a/DBADashGUI/DateHelper.cs
+++ b/DBADashGUI/DateHelper.cs
@@ -26,7 +26,7 @@ namespace DBADashGUI
                 { 720, "12hrs" },
                 { 1440, "1 Day" },
                 { 2880, "2 Days" },
-                { 10880, "7 Days" },
+                { 10080, "7 Days" },
                 { 20160, "14 Days" }
             };
 

--- a/DBADashGUI/DateRangeToolStripMenuItem.cs
+++ b/DBADashGUI/DateRangeToolStripMenuItem.cs
@@ -27,6 +27,8 @@ namespace DBADashGUI
         public DateTime DateFromUtc => DateFrom.AppTimeZoneToUtc();
         public DateTime DateToUtc => DateTo.AppTimeZoneToUtc();
 
+        public TimeSpan ActualTimeSpan => SelectedTimeSpan ?? DateTo.Subtract(DateFrom);
+
         public TimeSpan MinimumTimeSpan { get; set; } = TimeSpan.MinValue;
 
         public TimeSpan MaximumTimeSpan { get; set; } = TimeSpan.MaxValue;

--- a/DBADashGUI/Drives/DriveControl.Designer.cs
+++ b/DBADashGUI/Drives/DriveControl.Designer.cs
@@ -37,6 +37,7 @@
             lnkHistory = new System.Windows.Forms.LinkLabel();
             pbSpace = new CustomProgressBar();
             lblUpdated = new System.Windows.Forms.Label();
+            lnkFiles = new System.Windows.Forms.LinkLabel();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             ((System.ComponentModel.ISupportInitialize)picStatus).BeginInit();
             SuspendLayout();
@@ -45,26 +46,27 @@
             // 
             pictureBox1.Image = Properties.Resources.Hard_Drive;
             pictureBox1.Location = new System.Drawing.Point(0, 0);
+            pictureBox1.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             pictureBox1.Name = "pictureBox1";
-            pictureBox1.Size = new System.Drawing.Size(47, 52);
+            pictureBox1.Size = new System.Drawing.Size(54, 69);
             pictureBox1.TabIndex = 1;
             pictureBox1.TabStop = false;
             // 
             // lblDriveLabel
             // 
             lblDriveLabel.AutoSize = true;
-            lblDriveLabel.Location = new System.Drawing.Point(55, 0);
+            lblDriveLabel.Location = new System.Drawing.Point(63, 0);
             lblDriveLabel.Name = "lblDriveLabel";
-            lblDriveLabel.Size = new System.Drawing.Size(23, 15);
+            lblDriveLabel.Size = new System.Drawing.Size(27, 20);
             lblDriveLabel.TabIndex = 2;
             lblDriveLabel.Text = "C:\\";
             // 
             // lblFree
             // 
             lblFree.AutoSize = true;
-            lblFree.Location = new System.Drawing.Point(55, 44);
+            lblFree.Location = new System.Drawing.Point(63, 59);
             lblFree.Name = "lblFree";
-            lblFree.Size = new System.Drawing.Size(89, 15);
+            lblFree.Size = new System.Drawing.Size(115, 20);
             lblFree.TabIndex = 3;
             lblFree.Text = "0GB free of 0GB";
             // 
@@ -72,9 +74,9 @@
             // 
             lnkThreshold.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             lnkThreshold.AutoSize = true;
-            lnkThreshold.Location = new System.Drawing.Point(383, 0);
+            lnkThreshold.Location = new System.Drawing.Point(438, 0);
             lnkThreshold.Name = "lnkThreshold";
-            lnkThreshold.Size = new System.Drawing.Size(60, 15);
+            lnkThreshold.Size = new System.Drawing.Size(74, 20);
             lnkThreshold.TabIndex = 28;
             lnkThreshold.TabStop = true;
             lnkThreshold.Text = "Configure";
@@ -83,9 +85,10 @@
             // picStatus
             // 
             picStatus.Image = Properties.Resources.StatusAnnotations_Warning_32xLG_color;
-            picStatus.Location = new System.Drawing.Point(19, 46);
+            picStatus.Location = new System.Drawing.Point(22, 61);
+            picStatus.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             picStatus.Name = "picStatus";
-            picStatus.Size = new System.Drawing.Size(28, 30);
+            picStatus.Size = new System.Drawing.Size(32, 40);
             picStatus.TabIndex = 30;
             picStatus.TabStop = false;
             picStatus.Visible = false;
@@ -93,9 +96,9 @@
             // lblThresholds
             // 
             lblThresholds.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            lblThresholds.Location = new System.Drawing.Point(82, 0);
+            lblThresholds.Location = new System.Drawing.Point(94, 0);
             lblThresholds.Name = "lblThresholds";
-            lblThresholds.Size = new System.Drawing.Size(296, 16);
+            lblThresholds.Size = new System.Drawing.Size(338, 21);
             lblThresholds.TabIndex = 32;
             lblThresholds.Text = "Warning: 20%, Critical 10%";
             lblThresholds.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -104,9 +107,9 @@
             // 
             lnkHistory.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             lnkHistory.AutoSize = true;
-            lnkHistory.Location = new System.Drawing.Point(398, 44);
+            lnkHistory.Location = new System.Drawing.Point(455, 59);
             lnkHistory.Name = "lnkHistory";
-            lnkHistory.Size = new System.Drawing.Size(45, 15);
+            lnkHistory.Size = new System.Drawing.Size(56, 20);
             lnkHistory.TabIndex = 33;
             lnkHistory.TabStop = true;
             lnkHistory.Text = "History";
@@ -117,10 +120,11 @@
             pbSpace.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             pbSpace.BackColor = System.Drawing.Color.RoyalBlue;
             pbSpace.ForeColor = System.Drawing.Color.LightBlue;
-            pbSpace.Location = new System.Drawing.Point(58, 19);
+            pbSpace.Location = new System.Drawing.Point(66, 25);
+            pbSpace.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             pbSpace.MarqueeAnimationSpeed = 100000000;
             pbSpace.Name = "pbSpace";
-            pbSpace.Size = new System.Drawing.Size(386, 22);
+            pbSpace.Size = new System.Drawing.Size(441, 29);
             pbSpace.TabIndex = 31;
             pbSpace.Value = 50;
             // 
@@ -130,16 +134,29 @@
             lblUpdated.AutoSize = true;
             lblUpdated.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, 0);
             lblUpdated.ForeColor = System.Drawing.Color.Black;
-            lblUpdated.Location = new System.Drawing.Point(55, 59);
+            lblUpdated.Location = new System.Drawing.Point(63, 79);
             lblUpdated.Name = "lblUpdated";
-            lblUpdated.Size = new System.Drawing.Size(121, 15);
+            lblUpdated.Size = new System.Drawing.Size(146, 20);
             lblUpdated.TabIndex = 34;
             lblUpdated.Text = "Updated minutes ago";
             // 
+            // lnkFiles
+            // 
+            lnkFiles.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            lnkFiles.AutoSize = true;
+            lnkFiles.Location = new System.Drawing.Point(411, 59);
+            lnkFiles.Name = "lnkFiles";
+            lnkFiles.Size = new System.Drawing.Size(38, 20);
+            lnkFiles.TabIndex = 35;
+            lnkFiles.TabStop = true;
+            lnkFiles.Text = "Files";
+            lnkFiles.LinkClicked += Files_LinkClicked;
+            // 
             // DriveControl
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(lnkFiles);
             Controls.Add(lblUpdated);
             Controls.Add(lnkHistory);
             Controls.Add(lblThresholds);
@@ -149,8 +166,9 @@
             Controls.Add(lblFree);
             Controls.Add(lblDriveLabel);
             Controls.Add(pictureBox1);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             Name = "DriveControl";
-            Size = new System.Drawing.Size(446, 76);
+            Size = new System.Drawing.Size(510, 101);
             Load += DriveControl_Load;
             ((System.ComponentModel.ISupportInitialize)pictureBox1).EndInit();
             ((System.ComponentModel.ISupportInitialize)picStatus).EndInit();
@@ -168,5 +186,6 @@
         private System.Windows.Forms.Label lblThresholds;
         private System.Windows.Forms.LinkLabel lnkHistory;
         private System.Windows.Forms.Label lblUpdated;
+        private System.Windows.Forms.LinkLabel lnkFiles;
     }
 }

--- a/DBADashGUI/Drives/DriveHistory.Designer.cs
+++ b/DBADashGUI/Drives/DriveHistory.Designer.cs
@@ -35,14 +35,14 @@ namespace DBADashGUI.Drives
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             chart1 = new LiveCharts.WinForms.CartesianChart();
             toolStrip1 = new System.Windows.Forms.ToolStrip();
+            tsRefresh = new System.Windows.Forms.ToolStripButton();
+            tsExcel = new System.Windows.Forms.ToolStripButton();
+            tsCopy = new System.Windows.Forms.ToolStripButton();
             toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
             smoothLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             pointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            tsRefresh = new System.Windows.Forms.ToolStripButton();
             tsChart = new System.Windows.Forms.ToolStripButton();
             tsGrid = new System.Windows.Forms.ToolStripButton();
-            tsExcel = new System.Windows.Forms.ToolStripButton();
-            tsCopy = new System.Windows.Forms.ToolStripButton();
             tsClearFilter = new System.Windows.Forms.ToolStripButton();
             tsDateRange = new DateRangeToolStripMenuItem();
             lblInsufficientData = new System.Windows.Forms.Label();
@@ -65,12 +65,42 @@ namespace DBADashGUI.Drives
             // toolStrip1
             // 
             toolStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripDropDownButton1, tsRefresh, tsChart, tsGrid, tsExcel, tsCopy, tsClearFilter, tsDateRange });
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { tsRefresh, tsCopy, tsExcel, toolStripDropDownButton1, tsChart, tsGrid, tsClearFilter, tsDateRange });
             toolStrip1.Location = new System.Drawing.Point(0, 0);
             toolStrip1.Name = "toolStrip1";
             toolStrip1.Size = new System.Drawing.Size(1134, 27);
             toolStrip1.TabIndex = 3;
             toolStrip1.Text = "toolStrip1";
+            // 
+            // tsRefresh
+            // 
+            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
+            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsRefresh.Name = "tsRefresh";
+            tsRefresh.Size = new System.Drawing.Size(29, 24);
+            tsRefresh.Text = "Refresh";
+            tsRefresh.Click += TsRefresh_Click;
+            // 
+            // tsExcel
+            // 
+            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsExcel.Image = Properties.Resources.excel16x16;
+            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsExcel.Name = "tsExcel";
+            tsExcel.Size = new System.Drawing.Size(29, 24);
+            tsExcel.Text = "Export to Excel";
+            tsExcel.Click += TsExcel_Click;
+            // 
+            // tsCopy
+            // 
+            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
+            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsCopy.Name = "tsCopy";
+            tsCopy.Size = new System.Drawing.Size(29, 24);
+            tsCopy.Text = "Copy Data";
+            tsCopy.Click += TsCopy_Click;
             // 
             // toolStripDropDownButton1
             // 
@@ -100,16 +130,6 @@ namespace DBADashGUI.Drives
             pointsToolStripMenuItem.Text = "Points";
             pointsToolStripMenuItem.Click += PointsToolStripMenuItem_Click;
             // 
-            // tsRefresh
-            // 
-            tsRefresh.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsRefresh.Image = Properties.Resources._112_RefreshArrow_Green_16x16_72;
-            tsRefresh.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsRefresh.Name = "tsRefresh";
-            tsRefresh.Size = new System.Drawing.Size(29, 24);
-            tsRefresh.Text = "Refresh";
-            tsRefresh.Click += TsRefresh_Click;
-            // 
             // tsChart
             // 
             tsChart.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
@@ -131,26 +151,6 @@ namespace DBADashGUI.Drives
             tsGrid.Text = "View Grid";
             tsGrid.Click += TsGrid_Click;
             // 
-            // tsExcel
-            // 
-            tsExcel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsExcel.Image = Properties.Resources.excel16x16;
-            tsExcel.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsExcel.Name = "tsExcel";
-            tsExcel.Size = new System.Drawing.Size(29, 24);
-            tsExcel.Text = "Export to Excel";
-            tsExcel.Click += TsExcel_Click;
-            // 
-            // tsCopy
-            // 
-            tsCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            tsCopy.Image = Properties.Resources.ASX_Copy_blue_16x;
-            tsCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-            tsCopy.Name = "tsCopy";
-            tsCopy.Size = new System.Drawing.Size(29, 24);
-            tsCopy.Text = "Copy Data";
-            tsCopy.Click += TsCopy_Click;
-            // 
             // tsClearFilter
             // 
             tsClearFilter.Enabled = false;
@@ -165,14 +165,14 @@ namespace DBADashGUI.Drives
             tsDateRange.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             tsDateRange.DefaultTimeSpan = System.TimeSpan.Parse("7.00:00:00");
             tsDateRange.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
-            tsDateRange.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            tsDateRange.Font = new System.Drawing.Font("Segoe UI", 9F);
             tsDateRange.Image = (System.Drawing.Image)resources.GetObject("tsDateRange.Image");
             tsDateRange.ImageTransparentColor = System.Drawing.Color.Magenta;
             tsDateRange.MaximumTimeSpan = System.TimeSpan.Parse("10675199.02:48:05.4775807");
             tsDateRange.MinimumTimeSpan = System.TimeSpan.Parse("1.00:00:00");
             tsDateRange.Name = "tsDateRange";
             tsDateRange.SelectedTimeSpan = System.TimeSpan.Parse("7.00:00:00");
-            tsDateRange.Size = new System.Drawing.Size(90, 24);
+            tsDateRange.Size = new System.Drawing.Size(87, 24);
             tsDateRange.Text = "7 Days";
             tsDateRange.DateRangeChanged += DateRangeChanged;
             // 

--- a/DBADashGUI/Drives/DrivesControl.cs
+++ b/DBADashGUI/Drives/DrivesControl.cs
@@ -132,6 +132,8 @@ namespace DBADashGUI.Drives
                 dgv.Columns.Add(new DataGridViewTextBoxColumn() { Name = "ChangedDriveSize30Days", DataPropertyName = "ChangeDriveSize30Days", HeaderText = "Drive Size 30 Days Change (GB+-)", Width = 100, AutoSizeMode = DataGridViewAutoSizeColumnMode.None, DefaultCellStyle = new DataGridViewCellStyle() { Format = "+#,##0.0GB;-#,##0.0GB;-" } });
                 dgv.Columns.Add(new DataGridViewTextBoxColumn() { Name = "ChangedDriveSize90Days", DataPropertyName = "ChangeDriveSize90Days", HeaderText = "Drive Size 90 Days Change (GB+-)", Width = 100, AutoSizeMode = DataGridViewAutoSizeColumnMode.None, DefaultCellStyle = new DataGridViewCellStyle() { Format = "+#,##0.0GB;-#,##0.0GB;-" } });
             }
+
+            dgv.Columns.Add(new DataGridViewLinkColumn() { Name = "Files", HeaderText = "Files", UseColumnTextForLinkValue = true, Text = "Files", LinkColor = DashColors.LinkColor });
             dgv.Columns.Add(new DataGridViewLinkColumn() { Name = "History", HeaderText = "History", UseColumnTextForLinkValue = true, Text = "History", LinkColor = DashColors.LinkColor });
             dgv.Columns.Add(new DataGridViewLinkColumn() { Name = "Configure", HeaderText = "Configure", UseColumnTextForLinkValue = true, Text = "Configure", LinkColor = DashColors.LinkColor });
             dgv.CellContentClick += Dgv_CellContentClick;
@@ -178,23 +180,32 @@ namespace DBADashGUI.Drives
 
         private void Dgv_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
-            if (e.RowIndex >= 0)
+            if (e.RowIndex < 0) return;
+            var row = (DataRowView)dgv.Rows[e.RowIndex].DataBoundItem;
+            var label = (row["Label"] == DBNull.Value ? "" : (string)row["Label"]);
+            var instanceId = (int)row["InstanceID"];
+            var driveId = (int)row["DriveID"];
+            var instanceName = (string)row["InstanceDisplayName"];
+            var driveLetter = (string)row["Name"];
+
+            switch (dgv.Columns[e.ColumnIndex].Name)
             {
-                if (dgv.Columns[e.ColumnIndex].Name == "Configure")
+                case "Configure":
+                    Configure(instanceId, driveId);
+                    break;
+                case "History":
                 {
-                    var row = (DataRowView)dgv.Rows[e.RowIndex].DataBoundItem;
-                    Configure((int)row["InstanceID"], (int)row["DriveID"]);
-                }
-                else if (dgv.Columns[e.ColumnIndex].Name == "History")
-                {
-                    var row = (DataRowView)dgv.Rows[e.RowIndex].DataBoundItem;
                     var frm = new DriveHistoryView
                     {
                         DriveID = (int)row["DriveID"],
-                        Text = row["Instance"] + " | " + (string)row["Name"] + " " + (row["Label"] == DBNull.Value ? "" : (string)row["Label"])
+                        Text = @$"{instanceName} | {driveLetter} {label}"
                     };
                     frm.Show();
+                    break;
                 }
+                case "Files":
+                    DriveControl.ShowFilesForDrive(driveLetter, label, instanceId, instanceName,this);
+                    break;
             }
         }
 

--- a/DBADashGUI/ExtensionMethods.cs
+++ b/DBADashGUI/ExtensionMethods.cs
@@ -878,5 +878,35 @@ namespace DBADashGUI
             var reversedBytes = bytes.Reverse().ToArray();
             return BitConverter.ToInt64(reversedBytes, 0);
         }
+
+        public static string DateFormatString(this TimeSpan ts)
+        {
+            return ts.TotalMinutes < 1440 ? DBADashUser.TimeFormatString : DBADashUser.DateTimeFormatString;
+        }
+
+        /// <summary>
+        /// Cycles through panel visibility states: Both Visible -> Panel1 Hidden -> Panel2 Hidden -> Both Visible
+        /// </summary>
+        /// <param name="splitContainer">The SplitContainer to toggle</param>
+        public static void TogglePanels(this SplitContainer splitContainer)
+        {
+            if (!splitContainer.Panel1Collapsed && !splitContainer.Panel2Collapsed)
+            {
+                // Both visible -> Hide Panel1
+                splitContainer.Panel1Collapsed = true;
+            }
+            else if (splitContainer.Panel1Collapsed && !splitContainer.Panel2Collapsed)
+            {
+                // Panel1 hidden, Panel2 visible -> Hide Panel2, Show Panel1
+                splitContainer.Panel1Collapsed = false;
+                splitContainer.Panel2Collapsed = true;
+            }
+            else
+            {
+                // Panel2 hidden -> Show both panels
+                splitContainer.Panel1Collapsed = false;
+                splitContainer.Panel2Collapsed = false;
+            }
+        }
     }
 }

--- a/DBADashGUI/Performance/DateRange.cs
+++ b/DBADashGUI/Performance/DateRange.cs
@@ -16,7 +16,7 @@ namespace DBADashGUI.Performance
 
         public static bool CurrentDateRangeSupportsDayOfWeekFilter => DurationMins >= 10080;
 
-        public static string DateFormatString => DateRange.DurationMins < 1440 ? DBADashUser.TimeFormatString : DBADashUser.DateTimeFormatString;
+        public static string DateFormatString => TimeSpan.DateFormatString();
 
         public static TimeSpan? SelectedTimeSpan => _selectedTimeSpan;
 


### PR DESCRIPTION
DB Space History - Allow more granular visibility of growth as it is captured every hour by default and was previously limited to daily.  Change grid toggle to cycle through chart, chart+grid and grid only.  #1493

Drives - Add Files link.  Add link from drive control to show database files associated with the drive.

