### PR TITLE
Alerts - Allow time range to cross midnight boundary

### DIFF
--- a/DBADash/Alert/NotificationChannelBase.cs
+++ b/DBADash/Alert/NotificationChannelBase.cs
@@ -367,11 +367,6 @@ namespace DBADashGUI.DBADashAlerts
             {
                 yield return new ValidationResult("Channel Name is required");
             }
-
-            foreach (var result in Schedules.SelectMany(schedule => schedule.ValidateSchedule(validationContext)))
-            {
-                yield return result;
-            }
         }
 
         public List<string> Placeholders => new List<string>

--- a/DBADash/Alert/ScheduleBase.cs
+++ b/DBADash/Alert/ScheduleBase.cs
@@ -26,14 +26,6 @@ namespace DBADash.Alert
             return sb.ToString();
         }
 
-        public IEnumerable<ValidationResult> ValidateSchedule(ValidationContext validationContext)
-        {
-            if (TimeFrom > TimeTo)
-            {
-                yield return new ValidationResult("TimeTo should be greater than TimeFrom");
-            }
-        }
-
         [Browsable(false)]
         public bool IsEveryDay => Monday && Tuesday && Wednesday && Thursday && Friday && Saturday && Sunday;
 

--- a/DBADashDB/Alert/Tables/BackoutPeriod.sql
+++ b/DBADashDB/Alert/Tables/BackoutPeriod.sql
@@ -16,9 +16,7 @@
 	Sunday BIT NOT NULL CONSTRAINT DF_Alert_BlackoutPeriod_Sunday DEFAULT(CONVERT(BIT,1)),
 	TimeZone NVARCHAR(128) NOT NULL CONSTRAINT DF_Alert_BlackoutPeriod_TimeZone DEFAULT('UTC'),
 	Notes NVARCHAR(MAX) NULL,
-	CONSTRAINT CK_Alert_BlackoutPeriod_ApplyTo CHECK(NOT (ApplyToInstanceID>0 AND ApplyToTagID>0)),
-	CONSTRAINT CK_Alert_BlackoutPeriod_TimeTo CHECK(TimeTo>TimeFrom)
-	
+	CONSTRAINT CK_Alert_BlackoutPeriod_ApplyTo CHECK(NOT (ApplyToInstanceID>0 AND ApplyToTagID>0))	
 )
 GO
 CREATE UNIQUE NONCLUSTERED INDEX IX_Alert_BlackoutPeriod_InstanceID_StartDate_EndDate_AlertKey 

--- a/DBADashGUI/DBADashAlerts/BlackoutPeriod.cs
+++ b/DBADashGUI/DBADashAlerts/BlackoutPeriod.cs
@@ -139,10 +139,6 @@ namespace DBADashGUI.DBADashAlerts
             {
                 yield return new ValidationResult("End Date must be greater than Start Date");
             }
-            foreach (var result in ValidateSchedule(validationContext))
-            {
-                yield return result;
-            }
         }
     }
 }


### PR DESCRIPTION
Allow time range for alert blackouts and notification contact channel schedules to cross the midnight boundary.  This simplifies configuration. #1269