### PR TITLE
Connection Dialog fix

### DIFF
--- a/DBADashSharedGUI/DBConnection.cs
+++ b/DBADashSharedGUI/DBConnection.cs
@@ -80,6 +80,10 @@ namespace DBADash
             {
                 builder.IntegratedSecurity = true;
             }
+            else
+            {
+                builder.Remove("Integrated Security");
+            }
             if (!IsPasswordSupported || string.IsNullOrEmpty(txtPassword.Text))
             {
                 builder.Remove("Password");


### PR DESCRIPTION
Fix issue switching between Windows auth & other authentication methods:

Cannot use 'Authentication' with 'Integrated Security'.