### PR TITLE
Job History fix

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/JobHistory_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/JobHistory_Upd.sql
@@ -29,7 +29,7 @@ WHERE NOT EXISTS(SELECT 1 FROM dbo.Jobs J WHERE J.job_id = T.job_id AND J.Instan
 GROUP BY job_id
 
 DECLARE @max_instance_id INT=-1
-SELECT TOP(1) @max_instance_id = MAX(m.instance_id)
+SELECT TOP(1) @max_instance_id = ISNULL(MAX(m.instance_id),-1)
 FROM sys.partitions p
 OUTER APPLY(SELECT MAX(instance_id) AS instance_id
 			FROM dbo.JobHistory 


### PR DESCRIPTION
Fix job history issue on new deployments of DBA Dash.  @max_instance_id should be -1 instead of NULL when there is no data. #1526