### PR TITLE
Improve deploy process

### DIFF
--- a/DBADash/Upgrade/DBValidations.cs
+++ b/DBADash/Upgrade/DBValidations.cs
@@ -73,7 +73,7 @@ ELSE IF NOT EXISTS(SELECT *
             )
         AND DB_ID()>4
 BEGIN
-	SELECT '0.0.0.0' AS Version,@DeployInProgress AS DeployInProgress
+	SELECT '0.0.0.0' AS Version,1 AS DeployInProgress
 END
 ELSE
 BEGIN
@@ -92,8 +92,11 @@ END
                 version = (string)rdr["Version"];
                 deployInProgress = (bool)rdr["DeployInProgress"];
             }
-            version ??= "0.0.0.1";
-
+            else // First time deployment is likely in progress
+            {
+                deployInProgress = true;
+                version = "0.0.0.1";
+            }
             return (Version.Parse(version), deployInProgress);
         }
 

--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -841,6 +841,7 @@
     <Build Include="dbo\Functions\DatabaseSettingsUnpivot_Get.sql" />
     <Build Include="dbo\Stored Procedures\DeletedDatabases_Get.sql" />
     <Build Include="dbo\Stored Procedures\NewDatabases_Get.sql" />
+    <Build Include="Database.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/DBADashDB/Database.sql
+++ b/DBADashDB/Database.sql
@@ -1,0 +1,8 @@
+﻿/* 
+	Extended property indicates that a DB deployment is in progress, causing the GUI to pause and wait for it's completion 
+	Set to 'N' in post deployment script.  
+	Also set in the app code when an upgrade is initiated.
+*/
+EXECUTE sp_addextendedproperty
+		@name = N'IsDBUpgradeInProgress',
+		@value = 'Y';

--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -2069,3 +2069,9 @@ BEGIN
 					)
 	DROP TABLE dbo.LogRestoresTemp
 END
+/* 
+	Update extended property to indicate that a DB deployment is no longer in progress, allowing the GUI to continue loading.
+*/
+EXECUTE sp_updateextendedproperty
+		@name = N'IsDBUpgradeInProgress',
+		@value = 'N';


### PR DESCRIPTION
The dacpac deployment would remove the extended property before the upgrade was complete - allowing the GUI to connect before the version is upgraded. The property is now part of the dacpac.  IsDBUpgradeInProgress is initially set to 'Y' and updated to 'N' at the end of the post deployment script.  The deploy process also sets it to 'Y' before starting the deploy.