### PR TITLE
Alerts placeholder updates

### DIFF
--- a/DBADash/Alert/Alert.cs
+++ b/DBADash/Alert/Alert.cs
@@ -56,6 +56,10 @@ namespace DBADash.Alert
         public long AlertID { get; set; }
         public string ConnectionID { get; set; }
 
+        public string InstanceDisplayName { get; set; }
+
+        public string InstanceDisplayNameAndConnectionID => InstanceDisplayName == ConnectionID ? ConnectionID : $"{InstanceDisplayName} ({ConnectionID})";
+
         public Priorities Priority { get; set; }
 
         public string Message { get; set; }

--- a/DBADash/Alert/EmailNotificationChannel.cs
+++ b/DBADash/Alert/EmailNotificationChannel.cs
@@ -52,11 +52,11 @@ namespace DBADash.Alert
         [Category("Email Config")]
         public string To { get; set; }
 
-        [Description($"Optional.  Default: {DefaultEmailSubjectTemplate}.\nPlaceholders: {{Emoji}}, {{AlertKey}}, {{Action}}, {{Instance}}, {{Priority}}, {{Title}}.")]
+        [Description($"Optional.  Default: {DefaultEmailSubjectTemplate}.\nPlaceholders: {{Emoji}}, {{AlertKey}}, {{Action}}, {{Instance}}, {{ConnectionID}}, {{InstanceAndConnectionID}}, {{Priority}}, {{Title}}.")]
         [Category("Email Message"), DisplayName("Email Subject Template")]
         public string EmailSubjectTemplate { get; set; }
 
-        [Description($"Optional.  Default: {DefaultEmailMessageTemplate}\nPlaceholders: {{Emoji}}, {{AlertKey}}, {{Action}}, {{Instance}}, {{Priority}}, {{Title}}, {{Text}}.\nHTML Default:{DefaultHTMLMessageTemplate}")]
+        [Description($"Optional.  Default: {DefaultEmailMessageTemplate}\nPlaceholders: {{Emoji}}, {{AlertKey}}, {{Action}}, {{Instance}}, {{ConnectionID}}, {{InstanceAndConnectionID}}, {{Priority}}, {{Title}}, {{Text}}.\nHTML Default:{DefaultHTMLMessageTemplate}")]
         [Category("Email Message"), DisplayName("Email Message Template")]
         public string EmailMessageTemplate { get; set; }
 

--- a/DBADash/Alert/NotificationChannelBase.cs
+++ b/DBADash/Alert/NotificationChannelBase.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Data;
-using System.Linq;
 using System.Runtime.Caching;
 using System.Threading.Tasks;
 using Alert = DBADash.Alert.Alert;
@@ -373,6 +372,8 @@ namespace DBADashGUI.DBADashAlerts
         {
             "{Title}",
             "{Instance}",
+            "{ConnectionID}",
+            "{InstanceAndConnectionID}",
             "{AlertKey}",
             "{Action}",
             "{Text}",
@@ -386,7 +387,9 @@ namespace DBADashGUI.DBADashAlerts
         public string ReplacePlaceholders(Alert alert, string template)
         {
             return template.Replace("{Title}", EscapeText($"{alert.AlertName}[{alert.Status}]"), StringComparison.InvariantCultureIgnoreCase)
-                .Replace("{Instance}", EscapeText(alert.ConnectionID), StringComparison.InvariantCultureIgnoreCase)
+                .Replace("{ConnectionID}", EscapeText(alert.ConnectionID), StringComparison.InvariantCultureIgnoreCase)
+                .Replace("{Instance}", EscapeText(alert.InstanceDisplayName), StringComparison.InvariantCultureIgnoreCase)
+                .Replace("{InstanceAndConnectionID}", EscapeText(alert.InstanceDisplayNameAndConnectionID), StringComparison.InvariantCultureIgnoreCase)
                 .Replace("{AlertKey}", EscapeText(alert.AlertName), StringComparison.InvariantCultureIgnoreCase)
                 .Replace("{Action}", EscapeText(alert.Action), StringComparison.InvariantCultureIgnoreCase)
                 .Replace("{Text}", EscapeText(alert.Message), StringComparison.InvariantCultureIgnoreCase)

--- a/DBADash/Alert/PagerDutyNotificationChannel.cs
+++ b/DBADash/Alert/PagerDutyNotificationChannel.cs
@@ -2,13 +2,11 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
-using System.Linq;
+using System.ComponentModel.DataAnnotations;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using static DBADashGUI.DBADashAlerts.NotificationChannelBase;
 
 namespace DBADash.Alert
 {
@@ -102,7 +100,7 @@ namespace DBADash.Alert
                 {
                     component = "SQL Server",
                     @class = alert.AlertType,
-                    summary = alert.AlertName + " on " + alert.ConnectionID,
+                    summary = $"{alert.AlertName} on {alert.InstanceDisplayNameAndConnectionID}",
                     source = alert.ConnectionID,
                     severity = PagerDutySeverity(alert.Priority),
                     timestamp = alert.TriggerDate,

--- a/DBADash/Alert/SlackNotificationChannel.cs
+++ b/DBADash/Alert/SlackNotificationChannel.cs
@@ -26,7 +26,7 @@ namespace DBADash.Alert
         public string SlackChannel { get; set; }
 
         [DisplayName("Message Template")]
-        [Description("Json message template (Leave blank to use default template).  Available parameters to replace: {title}, {text}, {instance}, {icon}, {emoji}")]
+        [Description("Json message template (Leave blank to use default template).  Available parameters to replace: {title}, {text}, {instance}, {connectionid}, {icon}, {emoji}")]
         [Category("Slack Config")]
         public JsonString MessageTemplate { get; set; }
 

--- a/DBADash/Alert/WebHookNotificationChannel.cs
+++ b/DBADash/Alert/WebHookNotificationChannel.cs
@@ -15,7 +15,7 @@ namespace DBADash.Alert
         public override NotificationChannelTypes NotificationChannelType => NotificationChannelTypes.Webhook;
 
         [DisplayName("Message Template")]
-        [Description("Json message template (Leave blank to use default template).  Available parameters to replace: {title}, {text}, {instance}, {threadkey}, {icon}, {emoji}")]
+        [Description("Json message template (Leave blank to use default template).  Available parameters to replace: {title}, {text}, {instance}, {connectionid}, {instanceandconnectionid}, {threadkey}, {icon}, {emoji}")]
         [Category("Webhook Config")]
         public JsonString MessageTemplate { get; set; }
 
@@ -196,7 +196,5 @@ namespace DBADash.Alert
             }
             foreach (var validationResult in ValidateBase(validationContext)) yield return validationResult;
         }
-
-
     }
 }

--- a/DBADashDB/Alert/Procedures/Notifications_Get.sql
+++ b/DBADashDB/Alert/Procedures/Notifications_Get.sql
@@ -12,6 +12,7 @@ WHERE SettingName = 'AlertMaxNotificationCount'
 
 SELECT AA.AlertID,
 		I.ConnectionID,
+		I.InstanceDisplayName,
 		AA.AlertKey,
 		AA.LastMessage AS AlertDetails,
 		AA.ResolvedDate,


### PR DESCRIPTION
{instance} placeholder now uses the display name/alias for the instance if specified. {connectionid} placeholder can be used to display the connection id instead which was previously {instance}
#1578