### PR TITLE
Object Execution Tab - Add Query Store link

### DIFF
--- a/DBADashGUI/DBADashContext.cs
+++ b/DBADashGUI/DBADashContext.cs
@@ -57,7 +57,7 @@ namespace DBADashGUI
             get
             {
                 if (_hasInstanceMetadata != null) return _hasInstanceMetadata;
-                _hasInstanceMetadata = InstanceID >0 ? CommonData.HasInstanceMetadata.Contains(InstanceID) : InstanceIDs.Any(id => CommonData.HasInstanceMetadata.Contains(id));
+                _hasInstanceMetadata = InstanceID > 0 ? CommonData.HasInstanceMetadata.Contains(InstanceID) : InstanceIDs.Any(id => CommonData.HasInstanceMetadata.Contains(id));
                 return _hasInstanceMetadata;
             }
         }
@@ -133,9 +133,9 @@ namespace DBADashGUI
             }
 
             try
-            { 
+            {
                 var engineEditionValue = (int)row["EngineEdition"];
-            
+
                 if (Enum.IsDefined(typeof(DatabaseEngineEdition), engineEditionValue))
                 {
                     _engineEdition = (DatabaseEngineEdition)engineEditionValue;
@@ -152,6 +152,10 @@ namespace DBADashGUI
                 Log.Debug(ex, "Error retrieving EngineEdition value.");
             }
         }
+
+        public bool IsAzure => EngineEdition == DatabaseEngineEdition.SqlDatabase || EngineEdition == DatabaseEngineEdition.SqlManagedInstance;
+
+        public bool InstanceSupportsQueryStore => ProductVersion != null && (ProductVersion.Major >= 13 || IsAzure);
 
         public bool CanMessage
         {

--- a/DBADashGUI/Performance/QueryStoreTopQueries.cs
+++ b/DBADashGUI/Performance/QueryStoreTopQueries.cs
@@ -35,7 +35,7 @@ namespace DBADashGUI.Performance
             if (_context != CurrentContext)
             {
                 dgv.DataSource = null;
-                txtObjectName.Text = string.Empty;
+                txtObjectName.Text = _context.ObjectName;
                 txtPlan.Text = string.Empty;
                 splitContainer1.Panel2Collapsed = true;
                 dgvDrillDown.DataSource = null;
@@ -66,8 +66,8 @@ namespace DBADashGUI.Performance
 
         public async void RefreshData()
         {
-            txtObjectName.Enabled = QueryHash == null && PlanHash == null;
-            txtPlan.Enabled = QueryHash == null && PlanHash == null;
+            txtObjectName.Enabled = QueryHash == null && PlanHash == null && string.IsNullOrEmpty(CurrentContext.ObjectName);
+            txtPlan.Enabled = QueryHash == null && PlanHash == null && string.IsNullOrEmpty(CurrentContext.ObjectName);
             txtPlan.Text = PlanHash != null ? PlanHash.ToHexString(true) : txtPlan.Text;
             txtObjectName.Text = QueryHash != null ? QueryHash.ToHexString(true) : txtObjectName.Text;
 

--- a/DBADashGUI/Performance/QueryStoreViewer.cs
+++ b/DBADashGUI/Performance/QueryStoreViewer.cs
@@ -27,8 +27,12 @@ namespace DBADashGUI.Performance
         private void QueryStoreViewer_Load(object sender, EventArgs e)
         {
             this.ApplyTheme();
+            if (!string.IsNullOrEmpty(Context.ObjectName))
+            {
+                this.Text += " - " + Context.ObjectName;
+            }
             queryStoreTopQueries1.SetContext(Context);
-            if (PlanHash != null || QueryHash != null)
+            if (PlanHash != null || QueryHash != null || !string.IsNullOrEmpty(Context.ObjectName))
             {
                 queryStoreTopQueries1.RefreshData();
             }


### PR DESCRIPTION
Add query store link to object execution tab, allowing you to quickly access query store data associated with a stored procedure.