### PR TITLE
Running Queries - Reset on context change

### DIFF
--- a/DBADashGUI/Performance/RunningQueries.cs
+++ b/DBADashGUI/Performance/RunningQueries.cs
@@ -563,6 +563,8 @@ namespace DBADashGUI.Performance
             ShowLatestOnNextExecution = false;
             CurrentContext = _context;
             currentSnapshotDate = DateTime.MinValue;
+            SnapshotDateFrom = DateTime.MinValue;
+            SnapshotDateTo = DateTime.MinValue;
             dgv.DataSource = null;
             InstanceID = _context.InstanceID;
             IsForceDetail = false;


### PR DESCRIPTION
Snapshot date should not be preserved when changing context.