### PR TITLE
Report designer fixes

### DIFF
--- a/DBADashGUI/CustomReports/DatabaseFinderReport.cs
+++ b/DBADashGUI/CustomReports/DatabaseFinderReport.cs
@@ -58,6 +58,7 @@ namespace DBADashGUI.CustomReports
                         Columns = new Dictionary<string, ColumnMetadata>
                         {
                             { "InstanceID", new ColumnMetadata { Visible = false } },
+                            { "DatabaseID", new ColumnMetadata { Visible = false } },
                             { "InstanceDisplayName", new ColumnMetadata {
                                 Alias = "Instance",
                                 Link = new NavigateTreeLinkColumnInfo { InstanceColumn = "InstanceID", Tab = Main.Tabs.Performance },

--- a/DBADashGUI/CustomReports/NewDatabasesReport.cs
+++ b/DBADashGUI/CustomReports/NewDatabasesReport.cs
@@ -63,7 +63,7 @@ namespace DBADashGUI.CustomReports
                         ResultName = "New Databases",
                         Columns = new Dictionary<string, ColumnMetadata>
                         {
-                            { "InstanceID", new ColumnMetadata() },
+                            { "InstanceID", new ColumnMetadata() { Visible=false } },
                             { "InstanceGroupName", new ColumnMetadata {
                                 Alias = "Instance",
                                 DisplayIndex = 1,

--- a/DBADashGUI/ExtensionMethods.cs
+++ b/DBADashGUI/ExtensionMethods.cs
@@ -153,10 +153,6 @@ namespace DBADashGUI
                         col.DisplayIndex = savedCol.Value.DisplayIndex;
                     }
                 }
-                else
-                {
-                    col.Visible = false;
-                }
             }
         }
 


### PR DESCRIPTION
Designer needs to be updated for ColumnMetadata.  The backward compatibility layer works for deserialization, but does not support adding items to dictionaries.