### PR TITLE
Add AzureDB Metrics

### DIFF
--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -847,6 +847,11 @@
     <Build Include="dbo\Tables\FailedLogins.sql" />
     <Build Include="dbo\Stored Procedures\FailedLogins_Upd.sql" />
     <Build Include="dbo\Stored Procedures\FailedLogins_Get.sql" />
+    <Build Include="dbo\Views\AzureDBElasticPoolResourceStatsCounters.sql" />
+    <Build Include="dbo\Views\AzureDBElasticPoolResourceStatsCounters_60MIN.sql" />
+    <Build Include="dbo\Stored Procedures\AzureDBCounters_Upd.sql" />
+    <Build Include="dbo\Views\AzureDBResourceStatsCounters.sql" />
+    <Build Include="dbo\Views\AzureDBResourceStatsCounters_60MIN.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -1977,7 +1977,18 @@ FROM (VALUES('Running Queries','Running Query Count','',2),
 	('Running Queries','TempDB Wait Count','',2),
 	('Running Queries','TempDB Wait Time (ms)','',2),
 	('Running Queries','Sleeping Sessions Count','',2),
-	('Running Queries','Sleeping Sessions Max Idle Time (ms)','',2)
+	('Running Queries','Sleeping Sessions Max Idle Time (ms)','',2),
+	('sys.dm_db_resource_stats', 'avg_cpu_percent','',4),
+	('sys.dm_db_resource_stats', 'avg_data_io_percent','',4),
+	('sys.dm_db_resource_stats', 'avg_log_write_percent','',4),
+	('sys.dm_db_resource_stats', 'avg_memory_usage_percent','',4),
+	('sys.dm_db_resource_stats', 'xtp_storage_percent','',4),
+	('sys.dm_db_resource_stats', 'max_worker_percent','',4),
+	('sys.dm_db_resource_stats', 'max_session_percent','',4),
+	('sys.dm_db_resource_stats', 'dtu_limit','',4),
+	('sys.dm_db_resource_stats', 'avg_instance_cpu_percent','',4),
+	('sys.dm_db_resource_stats', 'avg_instance_memory_percent','',4),
+	('sys.dm_db_resource_stats', 'cpu_limit','',4)
 	) VirtualCounters(object_name,counter_name,instance_name,CounterType)
 WHERE NOT EXISTS(
 				SELECT 1 
@@ -2079,6 +2090,7 @@ BEGIN
 					)
 	DROP TABLE dbo.LogRestoresTemp
 END
+EXEC dbo.AzureDBCounters_Upd
 /* 
 	Update extended property to indicate that a DB deployment is no longer in progress, allowing the GUI to continue loading.
 */

--- a/DBADashDB/dbo/Functions/PerformanceCountersBetweenDates.sql
+++ b/DBADashDB/dbo/Functions/PerformanceCountersBetweenDates.sql
@@ -19,6 +19,7 @@ AND PC.SnapshotDate < CAST(@ToDate AS DATETIME2(2)) /* Important that date type 
 AND PC.InstanceID = @InstanceID
 AND PC.CounterID = @CounterID
 UNION ALL
+/* Running Queries performance counters. No 60 MIN aggregation available so fake schema. */
 SELECT	RQPC.InstanceID,
 		RQPC.CounterID,
 		RQPC.SnapshotDate,
@@ -29,3 +30,27 @@ AND RQPC.SnapshotDate >= @FromDate
 AND RQPC.SnapshotDate < @ToDate
 AND RQPC.InstanceID = @InstanceID
 AND RQPC.CounterID = @CounterID
+UNION ALL
+/* Azure DB Elastic Pool Resource Stats performance counters. */
+SELECT	PC.InstanceID,
+		PC.CounterID,
+		PC.SnapshotDate,
+		PC.value
+FROM dbo.AzureDBElasticPoolResourceStatsCounters PC
+WHERE @CounterType = 3
+AND PC.SnapshotDate >= @FromDate
+AND PC.SnapshotDate < @ToDate
+AND PC.InstanceID = @InstanceID
+AND PC.CounterID = @CounterID
+UNION ALL
+/* Azure DB Resource Stats performance counters. */
+SELECT	PC.InstanceID,
+		PC.CounterID,
+		PC.SnapshotDate,
+		PC.value
+FROM dbo.AzureDBResourceStatsCounters PC
+WHERE @CounterType = 4
+AND PC.SnapshotDate >= CAST(@FromDate AS DATETIME2(3))
+AND PC.SnapshotDate < CAST(@ToDate AS DATETIME2(3))
+AND PC.InstanceID = @InstanceID
+AND PC.CounterID = @CounterID

--- a/DBADashDB/dbo/Functions/PerformanceCountersBetweenDates_60MIN.sql
+++ b/DBADashDB/dbo/Functions/PerformanceCountersBetweenDates_60MIN.sql
@@ -23,7 +23,7 @@ AND PC.SnapshotDate < CAST(@ToDate AS DATETIME2(2))
 AND PC.InstanceID = @InstanceID
 AND PC.CounterID = @CounterID
 UNION ALL
-/* Runing Queries performance counters. No 60 MIN aggregation available so fake schema. */
+/* Running Queries performance counters. No 60 MIN aggregation available so fake schema. */
 SELECT	RQPC.InstanceID,
 		RQPC.CounterID,
 		RQPC.SnapshotDate,
@@ -37,3 +37,33 @@ AND RQPC.SnapshotDate >= @FromDate
 AND RQPC.SnapshotDate < @ToDate
 AND RQPC.InstanceID = @InstanceID
 AND RQPC.CounterID = @CounterID
+UNION ALL
+/* Azure DB Elastic Pool Resource Stats performance counters. */
+SELECT	PC.InstanceID,
+		PC.CounterID,
+		PC.SnapshotDate,
+		PC.value*SampleCount AS Value_Total,
+		NULL AS Value_Min,
+		PC.max_value AS Value_Max,
+		PC.SampleCount
+FROM dbo.AzureDBElasticPoolResourceStatsCounters_60MIN PC
+WHERE @CounterType = 3
+AND PC.SnapshotDate >= CAST(@FromDate AS DATETIME2(3))
+AND PC.SnapshotDate < CAST(@ToDate AS DATETIME2(3))
+AND PC.InstanceID = @InstanceID
+AND PC.CounterID = @CounterID
+UNION ALL
+/* Azure DB Resource Stats performance counters. */
+SELECT	PC.InstanceID,
+		PC.CounterID,
+		PC.SnapshotDate,
+		PC.value*SampleCount AS Value_Total,
+		NULL AS Value_Min,
+		PC.max_value AS Value_Max,
+		PC.SampleCount
+FROM dbo.AzureDBResourceStatsCounters_60MIN PC
+WHERE @CounterType = 4
+AND PC.SnapshotDate >= CAST(@FromDate AS DATETIME2(3))
+AND PC.SnapshotDate < CAST(@ToDate AS DATETIME2(3))
+AND PC.InstanceID = @InstanceID
+AND PC.CounterID = @CounterID

--- a/DBADashDB/dbo/Stored Procedures/AzureDBCounters_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/AzureDBCounters_Upd.sql
@@ -1,0 +1,66 @@
+﻿CREATE PROC dbo.AzureDBCounters_Upd(
+	@InstanceID INT=NULL
+)
+AS
+/*
+	Create virtual counters for Azure SQL Database Elastic Pool resource stats & Azure SQL Database resource stats.
+	dbo.AzureDBElasticPoolResourceStatsCounters, dbo.AzureDBElasticPoolResourceStatsCounters_60MIN, AzureDBResourceStatsCounters & AzureDBResourceStatsCounters_60MIN views replicate dbo.PerformanceCounters and dbo.PerformanceCounters_60MIN tables.
+	dbo.PerformanceCountersBetweenDates & dbo.PerformanceCountersBetweenDates_60MIN functions incorporate these views when CounterType=3 (Elastic Pool) or CounterType=4 (Azure DB resource stats).
+	
+*/
+INSERT INTO dbo.Counters(object_name,counter_name,instance_name,CounterType)
+SELECT 'sys.elastic_pool_resource_stats',counter_name,elastic_pool_name,3
+FROM (	SELECT DISTINCT elastic_pool_name 
+		FROM dbo.AzureDBElasticPool
+		WHERE (InstanceID = @InstanceID OR @InstanceID IS NULL)
+		) pools
+CROSS APPLY (
+VALUES('avg_allocated_storage_percent'),
+	('avg_cpu_percent'),
+	('avg_data_io_percent'),
+	('avg_log_write_percent'),
+	('avg_storage_percent'),
+	('max_worker_percent'),
+	('max_session_percent'),
+	('elastic_pool_dtu_limit'),
+	('elastic_pool_storage_limit_mb'),
+	('elastic_pool_cpu_limit')
+	) T (counter_name)
+WHERE NOT EXISTS(
+		SELECT 1 
+		FROM dbo.Counters C
+		WHERE C.object_name='sys.elastic_pool_resource_stats'
+		AND C.CounterType = 3
+		AND C.instance_name = pools.elastic_pool_name
+		AND C.counter_name = T.counter_name
+		)
+OPTION(RECOMPILE)
+	
+INSERT INTO dbo.InstanceCounters(InstanceID,CounterID)
+SELECT P.InstanceID, C.CounterID
+FROM dbo.Counters C
+JOIN dbo.AzureDBElasticPool P ON C.instance_name = P.elastic_pool_name
+WHERE C.CounterType = 3
+AND C.object_name = 'sys.elastic_pool_resource_stats'
+AND (P.InstanceID = @InstanceID OR @InstanceID IS NULL)
+AND NOT EXISTS(	SELECT 1 
+				FROM InstanceCounters IC
+				WHERE IC.InstanceID = P.InstanceID
+				AND IC.CounterID = C.CounterID
+				)
+OPTION(RECOMPILE)
+
+INSERT INTO dbo.InstanceCounters(InstanceID,CounterID)
+SELECT  I.InstanceID,C.CounterID
+FROM dbo.Instances I
+CROSS JOIN dbo.Counters C
+WHERE EngineEdition = 5
+AND C.CounterType = 4
+AND NOT EXISTS(
+			SELECT 1 
+			FROM dbo.InstanceCounters IC 
+			WHERE IC.CounterID = C.CounterID 
+			AND IC.InstanceID = I.InstanceID
+			)
+AND (I.InstanceID = @InstanceID OR @InstanceID IS NULL)
+OPTION(RECOMPILE)

--- a/DBADashDB/dbo/Stored Procedures/AzureDBElasticPoolResourceStats_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/AzureDBElasticPoolResourceStats_Upd.sql
@@ -1,5 +1,8 @@
-﻿
-CREATE PROC [dbo].[AzureDBElasticPoolResourceStats_Upd](@AzureDBElasticPoolResourceStats dbo.AzureDBElasticPoolResourceStats READONLY,@InstanceID INT,@SnapshotDate DATETIME2(3))
+﻿CREATE PROC dbo.AzureDBElasticPoolResourceStats_Upd(
+	@AzureDBElasticPoolResourceStats dbo.AzureDBElasticPoolResourceStats READONLY,
+	@InstanceID INT,
+	@SnapshotDate DATETIME2(3)
+)
 AS
 SET XACT_ABORT ON
 DECLARE @Ref VARCHAR(100)='AzureDBElasticPoolResourceStats'
@@ -27,6 +30,11 @@ BEGIN
 	VALUES(@InstanceID,S.elastic_pool_name,S.elastic_pool_dtu_limit ,S.elastic_pool_cpu_limit,GETUTCDATE())
 	OUTPUT Inserted.PoolID, DELETED.elastic_pool_dtu_limit,DELETED.elastic_pool_cpu_limit,INSERTED.elastic_pool_dtu_limit,Inserted.elastic_pool_cpu_limit,ISNULL(Deleted.ValidFrom,'19000101'),Inserted.ValidFrom
 	INTO dbo.AzureDBElasticPoolHistory(PoolID,elastic_pool_dtu_limit_old,elastic_pool_cpu_limit_old,elastic_pool_dtu_limit_new,elastic_pool_cpu_limit_new,ValidFrom,ValidTo);
+
+	IF @@ROWCOUNT>0
+	BEGIN
+		EXEC dbo.AzureDBCounters_Upd @InstanceID = @InstanceID
+	END
 
 	SELECT @MaxDate=ISNULL(MAX(end_time),'19000101')
 	FROM dbo.AzureDBElasticPoolResourceStats RS 
@@ -70,7 +78,6 @@ BEGIN
 
 	IF @@ROWCOUNT>0
 	BEGIN
-
 
 		DELETE agg
 		FROM dbo.AzureDBElasticPoolResourceStats_60MIN agg

--- a/DBADashDB/dbo/Stored Procedures/Instance_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/Instance_Upd.sql
@@ -86,7 +86,10 @@ BEGIN
 										 @Reference = @Ref,
 										 @SnapshotDate = @SnapshotDate
 		COMMIT
-
+		IF @EngineEdition = 5 /* Azure SQL DB */
+		BEGIN
+			EXEC dbo.AzureDBCounters_Upd @InstanceID = @InstanceID
+		END
 	END
 	ELSE
 	BEGIN

--- a/DBADashDB/dbo/Views/AzureDBElasticPoolResourceStatsCounters.sql
+++ b/DBADashDB/dbo/Views/AzureDBElasticPoolResourceStatsCounters.sql
@@ -1,0 +1,42 @@
+﻿CREATE VIEW dbo.AzureDBElasticPoolResourceStatsCounters
+AS
+/*
+	Replicates dbo.PerformanceCounters table for use in dbo.PerformanceCountersBetweenDates function
+*/
+SELECT unpvt.InstanceID,
+	C.CounterID,
+	unpvt.end_time AS SnapshotDate,
+	unpvt.value,
+	1 AS SampleCount
+FROM (
+	SELECT	InstanceID,
+			EP.elastic_pool_name,
+			EPRS.end_time,
+			CAST(EPRS.avg_allocated_storage_percent AS DECIMAL(28,9)) AS avg_allocated_storage_percent,
+			CAST(EPRS.avg_cpu_percent AS DECIMAL(28,9)) AS avg_cpu_percent,
+			CAST(EPRS.avg_data_io_percent AS DECIMAL(28,9)) AS avg_data_io_percent,
+			CAST(EPRS.avg_log_write_percent AS DECIMAL(28,9)) AS avg_log_write_percent,
+			CAST(EPRS.avg_storage_percent AS DECIMAL(28,9)) AS avg_storage_percent,
+			CAST(EPRS.max_worker_percent AS DECIMAL(28,9)) AS max_worker_percent ,
+			CAST(EPRS.max_session_percent AS DECIMAL(28,9)) AS max_session_percent,
+			CAST(EPRS.elastic_pool_dtu_limit AS DECIMAL(28,9)) AS elastic_pool_dtu_limit,
+			CAST(EPRS.elastic_pool_storage_limit_mb AS DECIMAL(28,9)) AS elastic_pool_storage_limit_mb,
+			CAST(EPRS.elastic_pool_cpu_limit AS DECIMAL(28,9)) AS elastic_pool_cpu_limit
+	FROM dbo.AzureDBElasticPool EP
+	JOIN dbo.AzureDBElasticPoolResourceStats EPRS ON EP.PoolID = EPRS.PoolID
+) PoolStats
+UNPIVOT(
+	value FOR CounterName IN(
+	avg_allocated_storage_percent,
+	avg_cpu_percent,
+	avg_data_io_percent,
+	avg_log_write_percent,
+	avg_storage_percent,
+	max_worker_percent,
+	max_session_percent,
+	elastic_pool_dtu_limit,
+	elastic_pool_storage_limit_mb,
+	elastic_pool_cpu_limit
+	)
+) unpvt
+JOIN dbo.Counters C ON C.counter_name = unpvt.CounterName AND C.CounterType = 3 AND C.instance_name = elastic_pool_name AND C.object_name = 'sys.elastic_pool_resource_stats'

--- a/DBADashDB/dbo/Views/AzureDBElasticPoolResourceStatsCounters_60MIN.sql
+++ b/DBADashDB/dbo/Views/AzureDBElasticPoolResourceStatsCounters_60MIN.sql
@@ -1,0 +1,65 @@
+﻿CREATE VIEW dbo.AzureDBElasticPoolResourceStatsCounters_60MIN
+AS
+/*
+	Replicates dbo.PerformanceCounters_60MIN table for use in dbo.PerformanceCountersBetweenDates_60MIN function
+*/
+SELECT unpvt.InstanceID,
+	C.CounterID,
+	calc.CounterName,
+	unpvt.end_time AS SnapshotDate,
+    MAX(CASE WHEN Calc.IsMaxCounter=1 THEN unpvt.value ELSE NULL END) AS max_value,
+    MAX(CASE WHEN Calc.IsMaxCounter=0 THEN unpvt.value ELSE NULL  END) AS value,
+    MAX(unpvt.SampleCount) AS SampleCount
+FROM (
+	SELECT	InstanceID,
+			EP.elastic_pool_name,
+			EPRS.end_time,
+			CAST(EPRS.avg_allocated_storage_percent AS DECIMAL(28,9)) AS avg_allocated_storage_percent,
+			CAST(EPRS.avg_cpu_percent AS DECIMAL(28,9)) AS avg_cpu_percent,
+			CAST(EPRS.max_cpu_percent AS DECIMAL(28,9)) AS max_cpu_percent,
+			CAST(EPRS.avg_data_io_percent AS DECIMAL(28,9)) AS avg_data_io_percent,
+			CAST(EPRS.max_data_io_percent AS DECIMAL(28,9)) AS max_data_io_percent,
+			CAST(EPRS.avg_log_write_percent AS DECIMAL(28,9)) AS avg_log_write_percent,
+			CAST(EPRS.max_log_write_percent AS DECIMAL(28,9)) AS max_log_write_percent,
+			CAST(EPRS.avg_storage_percent AS DECIMAL(28,9)) AS avg_storage_percent,
+			CAST(EPRS.max_storage_percent AS DECIMAL(28,9)) AS max_storage_percent,
+			CAST(EPRS.max_worker_percent AS DECIMAL(28,9)) AS max_worker_percent ,
+			CAST(EPRS.max_session_percent AS DECIMAL(28,9)) AS max_session_percent,
+			CAST(EPRS.elastic_pool_dtu_limit AS DECIMAL(28,9)) AS elastic_pool_dtu_limit,
+			CAST(EPRS.elastic_pool_storage_limit_mb AS DECIMAL(28,9)) AS elastic_pool_storage_limit_mb,
+			CAST(EPRS.elastic_pool_cpu_limit AS DECIMAL(28,9)) AS elastic_pool_cpu_limit,
+			EPRS.CPU10+EPRS.CPU20+EPRS.CPU30+EPRS.CPU40+EPRS.CPU50+EPRS.CPU60+EPRS.CPU70+EPRS.CPU80+EPRS.CPU90+EPRS.CPU100  AS SampleCount
+	FROM dbo.AzureDBElasticPool EP
+	JOIN dbo.AzureDBElasticPoolResourceStats_60MIN EPRS ON EP.PoolID = EPRS.PoolID
+) PoolStats
+UNPIVOT(
+	value FOR CounterName IN(
+	avg_allocated_storage_percent,
+	avg_cpu_percent,
+	max_cpu_percent,
+	avg_data_io_percent,
+	max_data_io_percent,
+	avg_log_write_percent,
+	max_log_write_percent,
+	avg_storage_percent,
+	max_storage_percent,
+	max_worker_percent,
+	max_session_percent,
+	elastic_pool_dtu_limit,
+	elastic_pool_storage_limit_mb,
+	elastic_pool_cpu_limit
+	)
+) unpvt
+OUTER APPLY(SELECT CASE WHEN CounterName = 'max_cpu_percent' THEN 'avg_cpu_percent' 
+                   WHEN CounterName = 'max_data_io_percent' THEN 'avg_data_io_percent'
+                   WHEN CounterName = 'max_log_write_percent' THEN 'avg_log_write_percent'
+				   WHEN CounterName = 'max_storage_percent' THEN 'avg_storage_percent'
+                    ELSE CounterName END AS CounterName,
+                CASE WHEN unpvt.CounterName IN('max_cpu_percent','max_data_io_percent','max_log_write_percent','max_storage_percent','max_worker_percent','max_session_percent')
+                    THEN 1 ELSE 0 END AS IsMaxCounter
+            ) AS calc
+JOIN dbo.Counters C ON C.counter_name = calc.CounterName AND C.CounterType = 3 AND C.instance_name = elastic_pool_name AND C.object_name = 'sys.elastic_pool_resource_stats'
+GROUP BY  unpvt.InstanceID,
+        unpvt.end_time,
+        C.CounterID,
+        calc.CounterName

--- a/DBADashDB/dbo/Views/AzureDBResourceStatsCounters.sql
+++ b/DBADashDB/dbo/Views/AzureDBResourceStatsCounters.sql
@@ -1,0 +1,39 @@
+﻿CREATE VIEW dbo.AzureDBResourceStatsCounters
+AS
+SELECT  unpvt.InstanceID,
+        unpvt.end_time AS SnapshotDate,
+        C.CounterID,
+        unpvt.CounterName,
+        unpvt.value,
+        1 AS SampleCount
+FROM (SELECT    InstanceID,
+                end_time,
+                CAST(avg_cpu_percent AS DECIMAL(28,9)) AS avg_cpu_percent,
+                CAST( avg_data_io_percent AS DECIMAL(28,9)) AS avg_data_io_percent,
+                CAST(avg_log_write_percent AS DECIMAL(28,9)) AS avg_log_write_percent,
+                CAST(avg_memory_usage_percent AS DECIMAL(28,9)) AS avg_memory_usage_percent ,
+                CAST(xtp_storage_percent AS DECIMAL(28,9)) AS xtp_storage_percent,
+                CAST(max_worker_percent AS DECIMAL(28,9)) AS max_worker_percent,
+                CAST(max_session_percent AS DECIMAL(28,9)) AS max_session_percent,
+                CAST(dtu_limit AS DECIMAL(28,9)) AS dtu_limit,
+                CAST(avg_instance_cpu_percent AS DECIMAL(28,9)) AS avg_instance_cpu_percent,
+                CAST(avg_instance_memory_percent AS DECIMAL(28,9)) AS avg_instance_memory_percent,
+                CAST(cpu_limit AS DECIMAL(28,9)) AS cpu_limit
+       FROM dbo.AzureDBResourceStats
+       ) AS S
+UNPIVOT( value 
+        FOR CounterName IN(
+            avg_cpu_percent,
+            avg_data_io_percent,
+            avg_log_write_percent,
+            avg_memory_usage_percent,
+            xtp_storage_percent,
+            max_worker_percent,
+            max_session_percent,
+            dtu_limit,
+            avg_instance_cpu_percent,
+            avg_instance_memory_percent,
+            cpu_limit
+          )
+      ) unpvt
+JOIN dbo.Counters C ON C.counter_name = unpvt.CounterName AND C.CounterType = 4 AND C.object_name = 'sys.dm_db_resource_stats' AND C.instance_name = ''

--- a/DBADashDB/dbo/Views/AzureDBResourceStatsCounters_60MIN.sql
+++ b/DBADashDB/dbo/Views/AzureDBResourceStatsCounters_60MIN.sql
@@ -1,0 +1,73 @@
+﻿CREATE VIEW dbo.AzureDBResourceStatsCounters_60MIN
+AS
+/*
+	Replicates dbo.PerformanceCounters_60MIN table for use in dbo.PerformanceCountersBetweenDates_60MIN function
+*/
+SELECT  unpvt.InstanceID,
+        unpvt.end_time AS SnapshotDate,
+        C.CounterID,
+        calc.CounterName,
+        MAX(CASE WHEN Calc.IsMaxCounter=1 THEN unpvt.value ELSE NULL END) AS max_value,
+        MAX(CASE WHEN Calc.IsMaxCounter=0 THEN unpvt.value ELSE NULL  END) AS value,
+        MAX(unpvt.SampleCount) AS SampleCount
+FROM (SELECT    RS.InstanceID,
+                RS.end_time,
+                CAST(RS.avg_cpu_percent AS DECIMAL(28,9)) AS avg_cpu_percent,
+                CAST(RS.max_cpu_percent AS DECIMAL(28,9)) AS max_cpu_percent,
+                CAST(RS.avg_data_io_percent AS DECIMAL(28,9)) AS avg_data_io_percent,
+                CAST(RS.max_data_io_percent AS DECIMAL(28,9)) AS max_data_io_percent,
+                CAST(RS.avg_log_write_percent AS DECIMAL(28,9)) AS avg_log_write_percent,
+                CAST(RS.max_log_write_percent AS DECIMAL(28,9)) AS max_log_write_percent,
+                CAST(RS.avg_memory_usage_percent AS DECIMAL(28,9)) AS avg_memory_usage_percent ,
+                CAST(RS.max_memory_usage_percent AS DECIMAL(28,9)) AS max_memory_usage_percent,
+                CAST(RS.xtp_storage_percent AS DECIMAL(28,9)) AS xtp_storage_percent,
+                CAST(RS.max_xtp_storage_percent AS DECIMAL(28,9)) AS max_xtp_storage_percent,
+                CAST(RS.max_worker_percent AS DECIMAL(28,9)) AS max_worker_percent,
+                CAST(RS.max_session_percent AS DECIMAL(28,9)) AS max_session_percent,
+                CAST(RS.dtu_limit AS DECIMAL(28,9)) AS dtu_limit,
+                CAST(RS.avg_instance_cpu_percent AS DECIMAL(28,9)) AS avg_instance_cpu_percent,
+                CAST(RS.max_instance_cpu_percent AS DECIMAL(28,9)) AS max_instance_cpu_percent,
+                CAST(RS.avg_instance_memory_percent AS DECIMAL(28,9)) AS avg_instance_memory_percent,
+                CAST(RS.max_instance_memory_percent AS DECIMAL(28,9)) AS max_instance_memory_percent,
+                CAST(cpu_limit AS DECIMAL(28,9)) AS cpu_limit,
+                RS.CPU10+RS.CPU20+RS.CPU30+RS.CPU40+RS.CPU50+RS.CPU60+RS.CPU70+RS.CPU80+RS.CPU90+RS.CPU100  AS SampleCount
+       FROM dbo.AzureDBResourceStats_60MIN RS
+       ) AS S
+UNPIVOT( value 
+        FOR CounterName IN(
+            avg_cpu_percent,
+            max_cpu_percent,
+            avg_data_io_percent,
+            max_data_io_percent,
+            avg_log_write_percent,
+            max_log_write_percent,
+            avg_memory_usage_percent,
+            max_memory_usage_percent,
+            xtp_storage_percent,
+            max_xtp_storage_percent,
+            max_worker_percent,
+            max_session_percent,
+            dtu_limit,
+            avg_instance_cpu_percent,
+            max_instance_cpu_percent,
+            avg_instance_memory_percent,
+            max_instance_memory_percent,
+            cpu_limit
+          )
+      ) unpvt
+OUTER APPLY(SELECT CASE WHEN CounterName = 'max_cpu_percent' THEN 'avg_cpu_percent' 
+                    WHEN CounterName = 'max_data_io_percent' THEN 'avg_data_io_percent'
+                    WHEN CounterName = 'max_log_write_percent' THEN 'avg_log_write_percent'
+                    WHEN CounterName = 'max_memory_usage_percent' THEN 'avg_memory_usage_percent'
+                    WHEN CounterName = 'max_xtp_storage_percent' THEN 'xtp_storage_percent'
+                    WHEN CounterName = 'max_instance_cpu_percent' THEN 'avg_instance_cpu_percent'
+                    WHEN CounterName = 'max_instance_memory_percent' THEN 'avg_instance_memory_percent'
+                    ELSE CounterName END AS CounterName,
+                CASE WHEN unpvt.CounterName IN('max_cpu_percent','max_data_io_percent','max_log_write_percent','max_memory_usage_percent','max_xtp_storage_percent','max_instance_cpu_percent','max_instance_memory_percent','max_worker_percent','max_session_percent')
+                    THEN 1 ELSE 0 END AS IsMaxCounter
+            ) AS calc
+JOIN dbo.Counters C ON C.counter_name = calc.CounterName AND C.CounterType = 4 AND C.object_name = 'sys.dm_db_resource_stats' AND C.instance_name = ''
+GROUP BY  unpvt.InstanceID,
+        unpvt.end_time,
+        C.CounterID,
+        calc.CounterName

--- a/DBADashGUI/Performance/PerformanceCounters.cs
+++ b/DBADashGUI/Performance/PerformanceCounters.cs
@@ -100,7 +100,10 @@ namespace DBADashGUI.Performance
             foreach (DataRow r in dt.Rows)
             {
                 string aggColName = "Value_" + Enum.GetName(Metric.AggregateType);
-
+                if (r[aggColName] == DBNull.Value)
+                {
+                    continue;
+                }
                 var value = Convert.ToDouble(r[aggColName]);
                 maxValue = value > maxValue ? value : maxValue;
                 minValue = value < minValue ? value : minValue;


### PR DESCRIPTION
Add AzureDBElasticPoolResourceStatsCounters & AzureDBResourceStats as virtual metrics, allowing alerts to be created. #1610
