### PR TITLE
Tuning Recommendations - PlanId drill down

### DIFF
--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -457,7 +457,7 @@ namespace DBADashGUI.CustomReports
                 CurrentMessageGroup));
         }
 
-        private Task ProcessCompletedMessage(ResponseMessage reply, Guid messageGroup)
+        private Task ProcessCompletedMessage(ResponseMessage reply, Guid messageGroup, MessagingHelper.SetStatusDelegate setStatus)
         {
             if (CurrentMessageGroup != messageGroup) // Context has changed.  Ignore
             {

--- a/DBADashGUI/CustomReports/PlanIdLinkColumnInfo.cs
+++ b/DBADashGUI/CustomReports/PlanIdLinkColumnInfo.cs
@@ -1,0 +1,132 @@
+﻿using DBADash.Messaging;
+using DBADashGUI.Interface;
+using DBADashGUI.Messaging;
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DBADashGUI.CustomReports
+{
+    internal class PlanIdLinkColumnInfo : LinkColumnInfo
+    {
+        public string PlanIdColumn { get; set; }
+        public string DatabaseNameColumn { get; set; }
+
+        public override async void Navigate(DBADashContext context, DataGridViewRow row, int selectedTableIndex, ContainerControl sender)
+        {
+            var status = sender as ISetStatus;
+
+            if (row.DataGridView?.Columns[PlanIdColumn] == null)
+            {
+                status?.SetStatus($"Column '{PlanIdColumn}' not found", string.Empty, DashColors.Fail);
+                return;
+            }
+
+            var planId = row.Cells[PlanIdColumn].Value.DBNullToNull() as long?;
+            if (planId == null)
+            {
+                status?.SetStatus("Plan ID is null", string.Empty, DashColors.Fail);
+                return;
+            }
+
+            var db = context.DatabaseName;
+            if (!string.IsNullOrEmpty(DatabaseNameColumn))
+            {
+                if (row.DataGridView?.Columns[DatabaseNameColumn] == null)
+                {
+                    status?.SetStatus($"Column '{DatabaseNameColumn}' not found", string.Empty, DashColors.Fail);
+                    return;
+                }
+                db = row.Cells[DatabaseNameColumn].Value.DBNullToNull() as string;
+            }
+
+            if (db == null)
+            {
+                status?.SetStatus("Database name is null", string.Empty, DashColors.Fail);
+                return;
+            }
+
+            var message = new PlanCollectionMessage()
+            {
+                CollectAgent = context.CollectAgent,
+                ImportAgent = context.ImportAgent,
+                ConnectionID = context.ConnectionID,
+                DatabaseName = db,
+                PlanID = planId.Value,
+            };
+
+            MessagingHelper.SetStatusDelegate setStatusDelegate = (msg, details, color) => status?.SetStatus(msg, details, color);
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await MessagingHelper.SendMessageAndProcessReply(message, context, setStatusDelegate, ProcessCompletedPlanCollectionMessage, Guid.NewGuid());
+                }
+                catch (Exception ex)
+                {
+                    status?.SetStatus($"Error collecting plan: {ex.Message}", ex.ToString(), DashColors.Fail);
+                }
+            });
+        }
+
+        private static Task ProcessCompletedPlanCollectionMessage(ResponseMessage reply, Guid messageGroup, MessagingHelper.SetStatusDelegate setStatus)
+        {
+            var ds = reply.Data;
+            if (ds == null || ds.Tables.Count == 0 || ds.Tables[0].Columns.Count == 0)
+            {
+                setStatus?.Invoke("No data returned", string.Empty, DashColors.Warning);
+                return Task.CompletedTask;
+            }
+
+            var dt = ds.Tables[0];
+            LoadQueryPlan(dt, setStatus);
+            return Task.CompletedTask;
+        }
+
+        private static void LoadQueryPlan(DataTable dt, MessagingHelper.SetStatusDelegate setStatus)
+        {
+            if (dt.Rows.Count == 0)
+            {
+                setStatus?.Invoke("No query plan", string.Empty, DashColors.Fail);
+                return;
+            }
+
+            if (!dt.Columns.Contains("query_plan"))
+            {
+                setStatus?.Invoke("Response missing 'query_plan' column", string.Empty, DashColors.Fail);
+                return;
+            }
+
+            var plan = dt.Rows[0]["query_plan"]?.ToString();
+            if (string.IsNullOrWhiteSpace(plan))
+            {
+                setStatus?.Invoke("Query plan is empty", string.Empty, DashColors.Fail);
+                return;
+            }
+
+            string fileName = null;
+            if (dt.Columns.Contains("plan_id") && dt.Rows[0]["plan_id"] != DBNull.Value)
+            {
+                fileName = $"Plan_{dt.Rows[0]["plan_id"]}_{DateTime.Now:yyyyMMddHHmmss}.sqlplan";
+            }
+            else
+            {
+                fileName = $"Plan_{DateTime.Now:yyyyMMddHHmmss}.sqlplan";
+            }
+
+            setStatus?.Invoke("Loading Query Plan...", string.Empty, DashColors.Success);
+
+            try
+            {
+                Common.ShowQueryPlan(plan, fileName);
+                setStatus?.Invoke("Query plan loaded in associated app", string.Empty, DashColors.Success);
+            }
+            catch (Exception ex)
+            {
+                setStatus?.Invoke($"Failed to load query plan: {ex.Message}", ex.ToString(), DashColors.Fail);
+            }
+        }
+    }
+}

--- a/DBADashGUI/CustomReports/TuningRecommendationsReport.cs
+++ b/DBADashGUI/CustomReports/TuningRecommendationsReport.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using static DBADashGUI.Messaging.MessagingHelper;
 
 namespace DBADashGUI.CustomReports
 {
@@ -97,12 +98,12 @@ namespace DBADashGUI.CustomReports
             }
         }
 
-        private async Task ForcePlanReply(ResponseMessage reply, Guid messageGroup)
+        private async Task ForcePlanReply(ResponseMessage reply, Guid messageGroup, SetStatusDelegate setStatus)
         {
             if (reply.Type == ResponseMessage.ResponseTypes.Success)
             {
                 await MessagingHelper.UpdatePlanForcingLog(messageGroup, "SUCCEEDED");
-                StatusLabel.InvokeSetStatus("Plan Forcing Operation Completed", string.Empty, DashColors.Success);
+                setStatus.Invoke("Plan Forcing Operation Completed", string.Empty, DashColors.Success);
                 if (MessageBox.Show("Plan forcing operation succeeded. Do you want to refresh the report now?", "Refresh Report", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     RefreshData();
@@ -110,7 +111,7 @@ namespace DBADashGUI.CustomReports
             }
             else
             {
-                StatusLabel.InvokeSetStatus("Plan Forcing Operation Failed", reply.Message, DashColors.Fail);
+                setStatus.Invoke("Plan Forcing Operation Failed", reply.Message, DashColors.Fail);
                 await MessagingHelper.UpdatePlanForcingLog(messageGroup, "FAIL:" + reply.Message);
             }
         }
@@ -203,10 +204,9 @@ namespace DBADashGUI.CustomReports
                                     Visible = true,
                                     Alias = "Regressed\nPlan\nID",
                                     Description = "Query store plan ID for the regressed plan",
-                                    Link = new QueryStoreLinkColumnInfo()
+                                    Link = new PlanIdLinkColumnInfo
                                     {
-                                        TargetColumn = "regressed_plan_id",
-                                        TargetColumnLinkType = QueryStoreLinkColumnInfo.QueryStoreLinkColumnType.PlanID,
+                                        PlanIdColumn = "regressed_plan_id",
                                         DatabaseNameColumn = "DB"
                                     }
                                 }
@@ -216,10 +216,9 @@ namespace DBADashGUI.CustomReports
                                     Visible = true,
                                     Alias = "Recommended\nPlan\nID",
                                     Description = "Query store plan ID for the recommended plan",
-                                    Link = new QueryStoreLinkColumnInfo()
+                                    Link = new PlanIdLinkColumnInfo
                                     {
-                                        TargetColumn = "recommended_plan_id",
-                                        TargetColumnLinkType = QueryStoreLinkColumnInfo.QueryStoreLinkColumnType.PlanID,
+                                        PlanIdColumn = "recommended_plan_id",
                                         DatabaseNameColumn = "DB"
                                     }
                                 }

--- a/DBADashGUI/Messaging/MessagingHelper.cs
+++ b/DBADashGUI/Messaging/MessagingHelper.cs
@@ -1,16 +1,17 @@
 ﻿using DBADash.Messaging;
+using DBADashGUI.Interface;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Data;
+using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Microsoft.Data.SqlClient;
-using System.Drawing;
 
 namespace DBADashGUI.Messaging
 {
     public class MessagingHelper
     {
-        public delegate Task MessageCompletedDelegate(ResponseMessage reply, Guid messageGroup);
+        public delegate Task MessageCompletedDelegate(ResponseMessage reply, Guid messageGroup, SetStatusDelegate setStatus);
 
         public delegate Task MessageResponseDelegate(ResponseMessage reply, Guid messageGroup);
 
@@ -50,7 +51,7 @@ namespace DBADashGUI.Messaging
                 ResponseMessage reply;
                 try
                 {
-                    reply = await Messaging.CollectionMessaging.ReceiveReply(messageGroup, message.Lifetime * 1000);
+                    reply = await CollectionMessaging.ReceiveReply(messageGroup, message.Lifetime * 1000);
                 }
                 catch (Exception ex)
                 {
@@ -69,12 +70,12 @@ namespace DBADashGUI.Messaging
                     case ResponseMessage.ResponseTypes.Failure:
                         completed = true;
                         setStatus(reply.Message, reply.Exception?.ToString(), DashColors.Fail);
-                        await processCompleted(reply, messageGroup);
+                        await processCompleted(reply, messageGroup, setStatus);
                         break;
 
                     case ResponseMessage.ResponseTypes.Success:
                         completed = false; // It's done but wait for end dialog
-                        await processCompleted(reply, messageGroup);
+                        await processCompleted(reply, messageGroup, setStatus);
                         break;
 
                     case ResponseMessage.ResponseTypes.EndConversation:

--- a/DBADashGUI/Performance/QueryStorePlanChart.cs
+++ b/DBADashGUI/Performance/QueryStorePlanChart.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Data;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using DBADash.Messaging;
+﻿using DBADash.Messaging;
 using DBADashGUI.Messaging;
 using DBADashGUI.Theme;
 using LiveChartsCore;
@@ -22,6 +14,15 @@ using LiveChartsCore.SkiaSharpView.VisualElements;
 using LiveChartsCore.VisualElements;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using static DBADashGUI.Messaging.MessagingHelper;
 using Padding = LiveChartsCore.Drawing.Padding;
 
 namespace DBADashGUI.Performance
@@ -79,11 +80,11 @@ namespace DBADashGUI.Performance
         private DataTable ChartData;
         private string MetricName => tsMeasure.Tag?.ToString();
 
-        private Task ProcessChart(ResponseMessage reply, Guid messageGroup)
+        private Task ProcessChart(ResponseMessage reply, Guid messageGroup, SetStatusDelegate setStatus)
         {
             if (InvokeRequired)
             {
-                Invoke(new Action(() => ProcessChart(reply, messageGroup)));
+                Invoke(new Action(() => ProcessChart(reply, messageGroup, setStatus)));
                 return Task.CompletedTask;
             }
 

--- a/DBADashGUI/Performance/QueryStoreTopQueries.Designer.cs
+++ b/DBADashGUI/Performance/QueryStoreTopQueries.Designer.cs
@@ -125,11 +125,9 @@ namespace DBADashGUI.Performance
             dgv.Location = new System.Drawing.Point(0, 0);
             dgv.Name = "dgv";
             dgv.ReadOnly = true;
-            dgv.ResultSetID = 0;
-            dgv.ResultSetName = null;
             dgv.RowHeadersVisible = false;
             dgv.RowHeadersWidth = 51;
-            dgv.Size = new System.Drawing.Size(1408, 267);
+            dgv.Size = new System.Drawing.Size(1408, 266);
             dgv.TabIndex = 0;
             dgv.CellContentClick += Dgv_CellContentClick;
             dgv.CellFormatting += Dgv_CellFormatting;
@@ -457,11 +455,15 @@ namespace DBADashGUI.Performance
             // tsDateRange
             // 
             tsDateRange.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            tsDateRange.DefaultTimeSpan = System.TimeSpan.Parse("01:00:00");
             tsDateRange.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.ImageAndText;
             tsDateRange.Font = new System.Drawing.Font("Segoe UI", 9F);
             tsDateRange.Image = (System.Drawing.Image)resources.GetObject("tsDateRange.Image");
             tsDateRange.ImageTransparentColor = System.Drawing.Color.Magenta;
+            tsDateRange.MaximumTimeSpan = System.TimeSpan.Parse("10675199.02:48:05.4775807");
+            tsDateRange.MinimumTimeSpan = System.TimeSpan.Parse("-10675199.02:48:05.4775808");
             tsDateRange.Name = "tsDateRange";
+            tsDateRange.SelectedTimeSpan = System.TimeSpan.Parse("01:00:00");
             tsDateRange.Size = new System.Drawing.Size(71, 24);
             tsDateRange.Text = "1 Hr";
             tsDateRange.Visible = false;
@@ -471,16 +473,16 @@ namespace DBADashGUI.Performance
             // 
             statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { lblStatus });
-            statusStrip1.Location = new System.Drawing.Point(0, 640);
+            statusStrip1.Location = new System.Drawing.Point(0, 638);
             statusStrip1.Name = "statusStrip1";
-            statusStrip1.Size = new System.Drawing.Size(1408, 22);
+            statusStrip1.Size = new System.Drawing.Size(1408, 24);
             statusStrip1.TabIndex = 2;
             statusStrip1.Text = "statusStrip1";
             // 
             // lblStatus
             // 
             lblStatus.Name = "lblStatus";
-            lblStatus.Size = new System.Drawing.Size(0, 16);
+            lblStatus.Size = new System.Drawing.Size(0, 18);
             // 
             // splitContainer1
             // 
@@ -496,8 +498,8 @@ namespace DBADashGUI.Performance
             // splitContainer1.Panel2
             // 
             splitContainer1.Panel2.Controls.Add(tabDrillDown);
-            splitContainer1.Size = new System.Drawing.Size(1408, 613);
-            splitContainer1.SplitterDistance = 267;
+            splitContainer1.Size = new System.Drawing.Size(1408, 611);
+            splitContainer1.SplitterDistance = 266;
             splitContainer1.TabIndex = 3;
             // 
             // tabDrillDown
@@ -511,7 +513,7 @@ namespace DBADashGUI.Performance
             tabDrillDown.Name = "tabDrillDown";
             tabDrillDown.Padding = new System.Drawing.Point(20, 8);
             tabDrillDown.SelectedIndex = 0;
-            tabDrillDown.Size = new System.Drawing.Size(1408, 342);
+            tabDrillDown.Size = new System.Drawing.Size(1408, 341);
             tabDrillDown.TabIndex = 1;
             tabDrillDown.SelectedIndexChanged += DrillDownTabIndexChanged;
             // 
@@ -521,7 +523,7 @@ namespace DBADashGUI.Performance
             tabSummary.Location = new System.Drawing.Point(4, 4);
             tabSummary.Name = "tabSummary";
             tabSummary.Padding = new System.Windows.Forms.Padding(3);
-            tabSummary.Size = new System.Drawing.Size(1400, 299);
+            tabSummary.Size = new System.Drawing.Size(1400, 298);
             tabSummary.TabIndex = 0;
             tabSummary.Text = "Summary";
             tabSummary.UseVisualStyleBackColor = true;
@@ -553,11 +555,9 @@ namespace DBADashGUI.Performance
             dgvDrillDown.EnableHeadersVisualStyles = false;
             dgvDrillDown.Location = new System.Drawing.Point(3, 3);
             dgvDrillDown.Name = "dgvDrillDown";
-            dgvDrillDown.ResultSetID = 0;
-            dgvDrillDown.ResultSetName = null;
             dgvDrillDown.RowHeadersVisible = false;
             dgvDrillDown.RowHeadersWidth = 51;
-            dgvDrillDown.Size = new System.Drawing.Size(1394, 293);
+            dgvDrillDown.Size = new System.Drawing.Size(1394, 292);
             dgvDrillDown.TabIndex = 0;
             dgvDrillDown.CellContentClick += Dgv_CellContentClick;
             dgvDrillDown.CellFormatting += Dgv_CellFormatting;

--- a/DBADashGUI/Performance/RunningQueries.cs
+++ b/DBADashGUI/Performance/RunningQueries.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using static DBADashGUI.Messaging.MessagingHelper;
 
 namespace DBADashGUI.Performance
 {
@@ -1107,7 +1108,7 @@ namespace DBADashGUI.Performance
             };
         }
 
-        private async Task ProcessPlanCollectionMessageReply(ResponseMessage reply, Guid messageGroup)
+        private async Task ProcessPlanCollectionMessageReply(ResponseMessage reply, Guid messageGroup, SetStatusDelegate setStatus)
         {
             try
             {


### PR DESCRIPTION
Add PlanId drilldown link column type
Pass status delegate so we can handle setting the status when we process reply messages.  This is needed when we have generic processing in LinkColumnInfo Change tuning recommendations report to load plan instead of query store top queries (which can still be accessed clicking query id column) Update top queries report to use new link types.