### PR TITLE
Fix Schema Snapshot tab load issue

### DIFF
--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -1091,7 +1091,7 @@ namespace DBADashGUI
                 allowedTabs.Add(tabDBADash);
             }
 
-            return allowedTabs;
+            return allowedTabs.Distinct().ToList();
         }
 
         private void Tv1_AfterSelect(object sender, TreeViewEventArgs e)


### PR DESCRIPTION
Schema snapshot tab is not loaded correctly for stored procedures.  This occurs because the tab page is added to the list of allowed tabs twice.  Update to return a DISTINCT list which will fix any similar issues in future. #1712