### PR TITLE
Implement queue based scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,11 @@ jobs:
         run: | 
           ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_GitHubAction" 
 
+      - name: Output Log and Check for Errors
+        shell: powershell
+        run: | 
+          ./Scripts/Get-LogContent -LogPath  "C:\DBADashTest\Logs" -ThrowError
+
       - name: Run Pester Tests
         shell: powershell
         run: |     
@@ -140,7 +145,3 @@ jobs:
         run: | 
             ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_GitHubAction" 
 
-      - name: Output Log and Check for Errors
-        shell: powershell
-        run: | 
-          ./Scripts/Get-LogContent -LogPath  "C:\DBADashTest\Logs" -ThrowError

--- a/.github/workflows/ci_BucketDestination.yml
+++ b/.github/workflows/ci_BucketDestination.yml
@@ -292,6 +292,16 @@ jobs:
         run: | 
             ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_Direct" 
 
+      - name: Output Log and Check for Errors (DBADashWriteToBucket)
+        shell: powershell
+        run: | 
+          ./Scripts/Get-LogContent -LogPath  "C:\DBADashWriteToBucket\Logs" -ThrowError
+
+      - name: Output Log and Check for Errors (DBADashReadFromBucket)
+        shell: powershell
+        run: | 
+          ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromBucket\Logs" -ThrowError
+
       - name: Run Pester Tests FromBucket
         shell: powershell
         run: |     
@@ -305,13 +315,4 @@ jobs:
         run: |     
             $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
             Invoke-Pester -Container $container -Output Detailed
-      
-      - name: Output Log and Check for Errors (DBADashWriteToBucket)
-        shell: powershell
-        run: | 
-          ./Scripts/Get-LogContent -LogPath  "C:\DBADashWriteToBucket\Logs" -ThrowError
-
-      - name: Output Log and Check for Errors (DBADashReadFromBucket)
-        shell: powershell
-        run: | 
-          ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromBucket\Logs" -ThrowError
+    

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -188,6 +188,16 @@ jobs:
         run: | 
             ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_Direct" 
 
+      - name: Output Log and Check for Errors (DBADashWriteToFolder)
+        shell: powershell
+        run: | 
+          ./Scripts/Get-LogContent -LogPath  "C:\DBADashWriteToFolder\Logs" -ThrowError
+
+      - name: Output Log and Check for Errors (DBADashReadFromFolder)
+        shell: powershell
+        run: | 
+          ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromFolder\Logs" -ThrowError
+
       - name: Run Pester Tests FromFolder
         shell: powershell
         run: |     
@@ -202,12 +212,3 @@ jobs:
             $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
             Invoke-Pester -Container $container -Output Detailed
       
-      - name: Output Log and Check for Errors (DBADashWriteToFolder)
-        shell: powershell
-        run: | 
-          ./Scripts/Get-LogContent -LogPath  "C:\DBADashWriteToFolder\Logs" -ThrowError
-
-      - name: Output Log and Check for Errors (DBADashReadFromFolder)
-        shell: powershell
-        run: | 
-          ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromFolder\Logs" -ThrowError

--- a/.github/workflows/ci_MinimalPermissions.yml
+++ b/.github/workflows/ci_MinimalPermissions.yml
@@ -144,6 +144,11 @@ jobs:
         run: | 
           ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_GitHubAction" 
 
+      - name: Output Log and Check for Errors
+        shell: powershell
+        run: | 
+          ./Scripts/Get-LogContent -LogPath  "C:\DBADashTest\Logs" -ThrowError
+
       - name: Run Pester Tests
         shell: powershell
         run: |     
@@ -151,8 +156,3 @@ jobs:
           Import-Module Pester -PassThru
           $NoWMI=$true
           Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
-      
-      - name: Output Log and Check for Errors
-        shell: powershell
-        run: | 
-          ./Scripts/Get-LogContent -LogPath  "C:\DBADashTest\Logs" -ThrowError

--- a/DBADash/CollectionSchedule.cs
+++ b/DBADash/CollectionSchedule.cs
@@ -114,12 +114,9 @@ namespace DBADashService
             }
         }
 
-        public CollectionType[] OnServiceStartCollection
+        public IEnumerable<CollectionType> OnServiceStartCollection
         {
-            get
-            {
-                return this.Where(s => s.Key != CollectionType.SchemaSnapshot && s.Value.RunOnServiceStart).Select(s => s.Key).ToArray();
-            }
+            get => this.Where(s => s.Value.RunOnServiceStart).Select(s => s.Key);
         }
     }
 

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -1115,7 +1115,7 @@ OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid
         private async Task CollectRunningQueriesAsync()
         {
             await using var cn = new SqlConnection(ConnectionString);
-            await using var cmd = new SqlCommand(SqlStrings.RunningQueries, cn);
+            await using var cmd = new SqlCommand(SqlStrings.RunningQueries, cn) { CommandTimeout = CollectionType.RunningQueries.GetCommandTimeout() };
             using var da = new SqlDataAdapter(cmd);
             cmd.Parameters.AddWithValue("CollectSessionWaits", Source.CollectSessionWaits);
             cmd.Parameters.AddWithValue("CollectTranBeginTime", Source.CollectTranBeginTime);
@@ -1320,7 +1320,8 @@ OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Unable to connect to the SQL instance.");
+                var builder = new SqlConnectionStringBuilder(ConnectionString);
+                Log.Error(ex, $"Unable to connect to the SQL instance. {builder.DataSource}");
                 throw new DatabaseConnectionException("Unable to connect to the SQL instance.", ex);
             }
 

--- a/DBADashService/CollectionWorkQueue.cs
+++ b/DBADashService/CollectionWorkQueue.cs
@@ -1,0 +1,401 @@
+using AsyncKeyedLock;
+using DBADash;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    /// <summary>
+    /// Manages a work queue for parallel instance collection processing with configurable per-instance concurrency
+    /// </summary>
+    public class CollectionWorkQueue
+    {
+        private readonly Channel<IWorkItem> _highChannel;
+        private readonly Channel<IWorkItem> _normalChannel;
+        private readonly Channel<IWorkItem> _lowChannel;
+        private readonly ConcurrentDictionary<string, WorkItemState> _instanceStates;
+        private readonly AsyncKeyedLocker<string> _instanceLocker;
+        private readonly CollectionConfig _config;
+        private readonly int _workerCount;
+        private readonly int _maxConcurrentCollectionsPerInstance;
+        private Task[] _workers;
+        private CancellationTokenSource _cts;
+        private const int DEFAULT_MAX_CONCURRENT_COLLECTIONS_PER_INSTANCE = 3;
+        private int _lowInProgress;
+        private const int MIN_LOW_PRIORITY_POLL_MS = 10;
+        private const int MAX_LOW_PRIORITY_POLL_MS = 40;
+
+        // Limit the number of concurrently running Low-priority items (to avoid starving higher priorities)
+        private readonly int _lowMaxConcurrent;
+
+        private readonly SemaphoreSlim _lowGate;
+
+        // De-duplication: track pending/running work keys
+        private readonly ConcurrentDictionary<string, byte> _pendingKeys = new(StringComparer.Ordinal);
+
+        // First-pick probabilities (should sum to 1.0). Low gets 5% first pick.
+        private readonly double _highFirst = 0.80;
+
+        private readonly double _normalFirst = 0.15; // Low first = 1 - (high + normal) = 0.05
+
+        // Tracking item count in high priority queue (waiting in channels or pending write)
+        private int _queuedHigh;
+
+        // Tracking item count in normal priority queue (waiting in channels or pending write)
+        private int _queuedNormal;
+
+        // Tracking item count in low priority queue (waiting in channels or pending write)
+        private int _queuedLow;
+
+        public CollectionWorkQueue(CollectionConfig config, int? maxConcurrentCollectionsPerInstance = null)
+        {
+            _config = config;
+            _workerCount = config.GetThreadCount();
+            _maxConcurrentCollectionsPerInstance = maxConcurrentCollectionsPerInstance ?? DEFAULT_MAX_CONCURRENT_COLLECTIONS_PER_INSTANCE; // Default: allow up to 3 concurrent collections per instance
+            _instanceStates = new ConcurrentDictionary<string, WorkItemState>();
+            _instanceLocker = new AsyncKeyedLocker<string>(new AsyncKeyedLockOptions
+            {
+                MaxCount = _maxConcurrentCollectionsPerInstance // Semaphore-style: allow N concurrent operations per key
+            });
+            // Cap low-priority concurrency to 25% of workers (min 1)
+            _lowMaxConcurrent = Convert.ToInt32(Math.Max(1, config.GetLowPriorityQueueMaxThreadPercentage() * _workerCount));
+            Log.Information("Low-priority queue max concurrency set to {lowMaxConcurrent} ({percentage:P0} of total workers)", _lowMaxConcurrent, config.GetLowPriorityQueueMaxThreadPercentage());
+            _lowGate = new SemaphoreSlim(_lowMaxConcurrent, _lowMaxConcurrent);
+
+            // Bounded channel with backpressure - capacity based on worker count
+            var capacity = Math.Max(_workerCount * 10, 100);
+            var options = new BoundedChannelOptions(capacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = false,
+                SingleWriter = false
+            };
+            _highChannel = Channel.CreateBounded<IWorkItem>(options);
+            _normalChannel = Channel.CreateBounded<IWorkItem>(options);
+            _lowChannel = Channel.CreateBounded<IWorkItem>(options);
+
+            Log.Information("CollectionWorkQueue initialized with {workerCount} workers, channel capacity {capacity}, max {maxConcurrency} concurrent collections per instance",
+                _workerCount, capacity, _maxConcurrentCollectionsPerInstance);
+        }
+
+        public void Start(CancellationToken cancellationToken)
+        {
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _workers = new Task[_workerCount];
+
+            for (int i = 0; i < _workerCount; i++)
+            {
+                var workerId = i;
+                _workers[i] = Task.Run(async () => await WorkerAsync(workerId, _cts.Token), _cts.Token);
+            }
+
+            Log.Information("Started {workerCount} collection workers", _workerCount);
+        }
+
+        public async Task StopAsync()
+        {
+            var workers = _workers;
+            if (workers == null || workers.Length == 0)
+            {
+                return;
+            }
+
+            // Cancel first to break out of waits/loops cleanly (idempotent-safe)
+            var cts = Interlocked.Exchange(ref _cts, null);
+            try
+            {
+                cts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed/canceled elsewhere; ignore
+            }
+
+            // Complete writers to wake up any readers that aren't canceled yet
+            _highChannel.Writer.TryComplete();
+            _normalChannel.Writer.TryComplete();
+            _lowChannel.Writer.TryComplete();
+
+            try
+            {
+                await Task.WhenAll(workers);
+            }
+            finally
+            {
+                cts?.Dispose();
+                _pendingKeys.Clear();
+                Interlocked.Exchange(ref _queuedHigh, 0);
+                Interlocked.Exchange(ref _queuedNormal, 0);
+                Interlocked.Exchange(ref _queuedLow, 0);
+                _workers = Array.Empty<Task>();
+                Log.Information("All collection workers stopped");
+            }
+        }
+
+        /// <summary>
+        /// Enqueue work with priority. Returns false if channel is closed or duplicate detected.
+        /// </summary>
+        public async Task<bool> EnqueueAsync(IWorkItem item, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(item.DedupKey))
+                {
+                    if (!_pendingKeys.TryAdd(item.DedupKey, 0))
+                    {
+                        Log.Warning("Skipping enqueue of {item}.  The previous scheduled collection is still enqueued or in progress.",
+                            item.Description);
+                        return false;
+                    }
+                }
+
+                var writer = GetWriter(item.Priority);
+
+                // Count as queued before write so we include backpressured writes
+                IncrementPriorityQueued(item.Priority);
+
+                // Fast-path: if there is capacity, write synchronously
+                if (writer.TryWrite(item))
+                {
+                    return true;
+                }
+
+                // Fall back to async path (backpressure or racing with readers/writer completion)
+                await writer.WriteAsync(item, cancellationToken);
+                return true;
+            }
+            catch (ChannelClosedException)
+            {
+                Log.Warning("Attempted to enqueue work after channel was closed");
+                if (!string.IsNullOrEmpty(item.DedupKey))
+                {
+                    _pendingKeys.TryRemove(item.DedupKey, out _);
+                }
+                DecrementPriorityQueued(item.Priority);
+                return false;
+            }
+            catch
+            {
+                if (!string.IsNullOrEmpty(item.DedupKey))
+                {
+                    _pendingKeys.TryRemove(item.DedupKey, out _);
+                }
+                DecrementPriorityQueued(item.Priority);
+                throw;
+            }
+        }
+
+        public WorkItemState GetState(string connectionString)
+        {
+            return _instanceStates.GetOrAdd(connectionString, static _ => new WorkItemState());
+        }
+
+        private ChannelWriter<IWorkItem> GetWriter(WorkItemPriority priority)
+        {
+            return priority switch
+            {
+                WorkItemPriority.High => _highChannel.Writer,
+                WorkItemPriority.Low => _lowChannel.Writer,
+                _ => _normalChannel.Writer
+            };
+        }
+
+        // Total queue depth derived from per-priority counters
+        public int QueueDepth => HighQueueDepth + NormalQueueDepth + LowQueueDepth;
+
+        public int HighQueueDepth => Volatile.Read(ref _queuedHigh);
+        public int NormalQueueDepth => Volatile.Read(ref _queuedNormal);
+        public int LowQueueDepth => Volatile.Read(ref _queuedLow);
+
+        // Centralized dequeue by priority with proper low gating and counters
+        private bool TryDequeue(WorkItemPriority priority, out IWorkItem item)
+        {
+            switch (priority)
+            {
+                case WorkItemPriority.High:
+                    if (_highChannel.Reader.TryRead(out var high))
+                    {
+                        DecrementPriorityQueued(WorkItemPriority.High);
+                        item = high;
+                        return true;
+                    }
+                    break;
+
+                case WorkItemPriority.Normal:
+                    if (_normalChannel.Reader.TryRead(out var normal))
+                    {
+                        DecrementPriorityQueued(WorkItemPriority.Normal);
+                        item = normal;
+                        return true;
+                    }
+                    break;
+
+                case WorkItemPriority.Low:
+                    if (_lowGate.Wait(0))
+                    {
+                        if (_lowChannel.Reader.TryRead(out var low))
+                        {
+                            Interlocked.Increment(ref _lowInProgress);
+                            DecrementPriorityQueued(WorkItemPriority.Low);
+                            item = low;
+                            return true;
+                        }
+                        _lowGate.Release();
+                    }
+                    break;
+            }
+
+            item = default!;
+            return false;
+        }
+
+        /// <summary>
+        /// Returns an item from one of the queues, picking a queue at random based on priority weights, then trying queues in strict priority order.
+        /// </summary>
+        private bool DequeueByPriorityWithRandom(out IWorkItem item)
+        {
+            var roll = Random.Shared.NextDouble();
+            var firstPriority =
+                roll < _highFirst ? WorkItemPriority.High :
+                roll < (_highFirst + _normalFirst) ? WorkItemPriority.Normal :
+                WorkItemPriority.Low;
+
+            if (TryDequeue(firstPriority, out item)) return true;
+
+            if (TryDequeue(WorkItemPriority.High, out item)) return true;
+            if (TryDequeue(WorkItemPriority.Normal, out item)) return true;
+            if (TryDequeue(WorkItemPriority.Low, out item)) return true;
+
+            item = default!;
+            return false;
+        }
+
+        private async Task<IWorkItem> ReadNextAsync(CancellationToken cancellationToken)
+        {
+            if (DequeueByPriorityWithRandom(out var random)) return random;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                if (DequeueByPriorityWithRandom(out var item)) return item;
+
+                var allowLow = _lowGate.CurrentCount > 0;
+
+                var highReady = _highChannel.Reader.WaitToReadAsync(cancellationToken).AsTask();
+                var normalReady = _normalChannel.Reader.WaitToReadAsync(cancellationToken).AsTask();
+                var lowReadyOrTick = allowLow
+                    ? _lowChannel.Reader.WaitToReadAsync(cancellationToken).AsTask()
+                    : Task.Delay(Random.Shared.Next(MIN_LOW_PRIORITY_POLL_MS, MAX_LOW_PRIORITY_POLL_MS), cancellationToken);
+
+                await Task.WhenAny(highReady, normalReady, lowReadyOrTick);
+
+                if (_highChannel.Reader.Completion.IsCompleted &&
+                    _normalChannel.Reader.Completion.IsCompleted &&
+                    _lowChannel.Reader.Completion.IsCompleted &&
+                    !DequeueByPriorityWithRandom(out item))
+                {
+                    throw new OperationCanceledException();
+                }
+            }
+
+            throw new OperationCanceledException();
+        }
+
+        private async Task WorkerAsync(int workerId, CancellationToken cancellationToken)
+        {
+            Log.Debug("Worker {workerId} started", workerId);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                IWorkItem item;
+                try
+                {
+                    item = await ReadNextAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    Log.Information("Worker {workerId} canceled", workerId);
+                    break;
+                }
+
+                var isLow = item.Priority == WorkItemPriority.Low;
+
+                try
+                {
+                    await ProcessWorkItemAsync(item, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Worker {workerId} error processing {item}",
+                        workerId, item.Description);
+                }
+                finally
+                {
+                    if (!string.IsNullOrEmpty(item.DedupKey))
+                    {
+                        _pendingKeys.TryRemove(item.DedupKey, out _);
+                    }
+
+                    if (isLow)
+                    {
+                        Interlocked.Decrement(ref _lowInProgress);
+                        _lowGate.Release();
+                    }
+                }
+            }
+
+            Log.Debug("Worker {workerId} stopped", workerId);
+        }
+
+        private async Task ProcessWorkItemAsync(IWorkItem item, CancellationToken cancellationToken)
+        {
+            var connectionString = item.Source?.ConnectionString ?? Guid.NewGuid().ToString();
+
+            // Allow up to N concurrent collections per instance (configured via MaxCount in AsyncKeyedLocker)
+            // This maintains the current behavior where different schedules can run concurrently
+            using (await _instanceLocker.LockAsync(connectionString, cancellationToken))
+            {
+                await item.ExecuteAsync(_config, cancellationToken);
+            }
+        }
+
+        private void IncrementPriorityQueued(WorkItemPriority priority)
+        {
+            switch (priority)
+            {
+                case WorkItemPriority.High:
+                    Interlocked.Increment(ref _queuedHigh);
+                    break;
+
+                case WorkItemPriority.Normal:
+                    Interlocked.Increment(ref _queuedNormal);
+                    break;
+
+                case WorkItemPriority.Low:
+                    Interlocked.Increment(ref _queuedLow);
+                    break;
+            }
+        }
+
+        private void DecrementPriorityQueued(WorkItemPriority priority)
+        {
+            switch (priority)
+            {
+                case WorkItemPriority.High:
+                    Interlocked.Decrement(ref _queuedHigh);
+                    break;
+
+                case WorkItemPriority.Normal:
+                    Interlocked.Decrement(ref _queuedNormal);
+                    break;
+
+                case WorkItemPriority.Low:
+                    Interlocked.Decrement(ref _queuedLow);
+                    break;
+            }
+        }
+    }
+}

--- a/DBADashService/DBADashJob.cs
+++ b/DBADashService/DBADashJob.cs
@@ -1,15 +1,9 @@
-﻿using Amazon.S3.Model;
-using AsyncKeyedLock;
-using DBADash;
+﻿using DBADash;
 using Newtonsoft.Json;
 using Quartz;
 using Serilog;
-using SerilogTimings;
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using static DBADash.DBADashConnection;
@@ -20,39 +14,13 @@ namespace DBADashService
     public class DBADashJob : IJob
     {
         private static readonly CollectionConfig config = SchedulerServiceConfig.Config;
-        /* Ensure the Jobs collection runs once every ~24hrs.  Allowing 10mins as Jobs runs every 1hr by default */
-        private static readonly int MAX_TIME_SINCE_LAST_JOB_COLLECTION = 1430;
-        private const uint ERROR_SHARING_VIOLATION = 0x80070020;
-
-        private static readonly AsyncKeyedLocker<string> _asyncKeyedLocker = new();
-
-        private static string GetID(DataSet ds)
-        {
-            try
-            {
-                return ds.Tables["DBADash"].Rows[0]["Instance"] + "_" + ds.Tables["DBADash"].Rows[0]["DBName"];
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error getting ID from DataSet");
-                return "DEFAULT";
-            }
-        }
-
-        /// <summary>
-        /// Parse Instance from filename.  File format is DBADash_YYYYMMDD_HHMM_SS_{InstanceName}_{random}.xml
-        /// </summary>
-        public static string ParseInstance(string fileName)
-        {
-            return fileName[25..fileName.LastIndexOf('_')];
-        }
 
         public async Task Execute(IJobExecutionContext context)
         {
             Log.Information("Processing Job : " + context.JobDetail.Key);
             var dataMap = context.JobDetail.JobDataMap;
             var cfg = JsonConvert.DeserializeObject<DBADashSource>(dataMap.GetString("CFG")!);
-
+            var schedule = dataMap.GetString("Schedule");
             try
             {
                 if (OfflineInstances.IsOffline(cfg))
@@ -64,31 +32,30 @@ namespace DBADashService
                 {
                     case ConnectionType.Directory:
                         {
-                            Log.Debug("Wait for lock {0}", context.JobDetail.Key);
-                            // Ensures that this folder can only be processed by 1 job instance at a time.
-                            // Note: DisallowConcurrentExecution didn't prevent triggered at startup job from overlapping with the scheduled one
-                            using (await _asyncKeyedLocker.LockAsync(cfg.ConnectionString))
-                            {
-                                Log.Debug("Lock acquired {0}", context.JobDetail.Key);
-                                await CollectFolderAsync(cfg);
-                            }
-
+                            var wi = new DirectoryWorkItem() { Source = cfg, Schedule = schedule };
+                            await wi.ExecuteAsync(config, CancellationToken.None);
                             break;
                         }
                     case ConnectionType.AWSS3:
                         {
-                            Log.Debug("Wait for lock {0}", context.JobDetail.Key);
-                            // Ensures that S3 folder can only be processed by 1 job instance at a time.
-                            // Note: DisallowConcurrentExecution didn't prevent triggered at startup job from overlapping with the scheduled one
-                            using (await ScheduleService.Locker.LockAsync(cfg.ConnectionString))
-                            {
-                                Log.Debug("Lock acquired {0}", context.JobDetail.Key);
-                                await CollectS3(cfg);
-                            }
+                            var wi = new S3WorkItem() { Source = cfg, Schedule = schedule };
+                            await wi.ExecuteAsync(config, CancellationToken.None);
                             break;
                         }
                     case ConnectionType.SQL:
-                        await CollectSQL(cfg, dataMap, context);
+                        var types = JsonConvert.DeserializeObject<CollectionType[]>(dataMap.GetString("Type")!);
+                        var customCollections = JsonConvert.DeserializeObject<Dictionary<string, CustomCollection>>(dataMap.GetString("CustomCollections")!);
+
+                        var workItem = new WorkItem
+                        {
+                            Source = cfg,
+                            Types = types,
+                            CustomCollections = customCollections,
+                            Schedule = schedule,
+                            PreviousFireTime = context.PreviousFireTimeUtc?.UtcDateTime
+                        };
+
+                        await workItem.ExecuteAsync(config, CancellationToken.None);
                         break;
 
                     case ConnectionType.Invalid:
@@ -99,402 +66,6 @@ namespace DBADashService
             catch (Exception ex)
             {
                 Log.Error(ex, "JobExecute");
-            }
-        }
-
-        /// <summary>
-        /// Collect data from monitored SQL instance
-        /// </summary>
-        private static async Task CollectSQL(DBADashSource cfg, JobDataMap dataMap, IJobExecutionContext context)
-        {
-            var types = JsonConvert.DeserializeObject<CollectionType[]>(dataMap.GetString("Type")!);
-            var collectJobs = types.Contains(CollectionType.Jobs);
-
-            var customCollections = JsonConvert.DeserializeObject<Dictionary<string, CustomCollection>>(dataMap.GetString("CustomCollections")!);
-            if (collectJobs)
-            {
-                types = types.Where(t => t != CollectionType.Jobs).ToArray(); // Remove Jobs collection - we will save this to last
-            }
-
-            try
-            {
-                if (types.Length > 0 ||
-                    customCollections.Count >
-                    0) // Might be zero if we are only collecting Jobs in this batch (collected in the next section)
-                {
-                    // Value used to disable future collections of SlowQueries if we encounter a not supported error on a RDS instance not running Standard or Enterprise edition
-                    dataMap.TryGetBooleanValue("IsExtendedEventsNotSupportedException",
-                        out var dataMapExtendedEventsNotSupported);
-                    var collector = await DBCollector.CreateAsync(cfg, config.ServiceName);
-                    collector.Job_instance_id = dataMap.GetInt("Job_instance_id");
-                    collector.IsExtendedEventsNotSupportedException = dataMapExtendedEventsNotSupported;
-                    collector.FailedLoginsBackfillMinutes = config.FailedLoginsBackfillMinutes ?? CollectionConfig.DefaultFailedLoginsBackfillMinutes;
-                    if (SchedulerServiceConfig.Config.IdentityCollectionThreshold.HasValue)
-                    {
-                        collector.IdentityCollectionThreshold =
-                            (int)SchedulerServiceConfig.Config.IdentityCollectionThreshold;
-                    }
-
-                    if (context.PreviousFireTimeUtc.HasValue)
-                    {
-                        collector.PerformanceCollectionPeriodMins = (Int32)DateTime.UtcNow
-                            .Subtract(context.PreviousFireTimeUtc.Value.UtcDateTime).TotalMinutes + 5;
-                    }
-                    else
-                    {
-                        collector.PerformanceCollectionPeriodMins = 30;
-                    }
-
-                    collector.LogInternalPerformanceCounters =
-                        SchedulerServiceConfig.Config.LogInternalPerformanceCounters;
-                    using (var op = Operation.Begin("Collect {types} from instance {instance}",
-                               string.Join(", ", types.Select(s => s.ToString()).ToArray()),
-                               cfg.SourceConnection.ConnectionForPrint))
-                    {
-                        await collector.CollectAsync(types);
-                        if (!dataMapExtendedEventsNotSupported && collector.IsExtendedEventsNotSupportedException)
-                        {
-                            // We encountered an error setting up extended events on a RDS instance because it's only supported for Standard and Enterprise editions.  Disable the collection
-                            Log.Information(
-                                "Disabling Extended events collection for {0}.  Instance type doesn't support extended events",
-                                cfg.SourceConnection.ConnectionForPrint);
-                            dataMap.Put("IsExtendedEventsNotSupportedException", true);
-                        }
-
-                        dataMap.Put("Job_instance_id",
-                            collector.Job_instance_id); // Store instance_id so we can get new history only on next run
-                        op.Complete();
-                    }
-
-                    if (customCollections.Count > 0)
-                    {
-                        using var op = Operation.Begin("Collect Custom Collections {types} from instance {instance}",
-                            string.Join(", ", customCollections.Select(s => s.Key).ToArray()),
-                            cfg.SourceConnection.ConnectionForPrint);
-                        await collector.CollectAsync(customCollections);
-                        op.Complete();
-                    }
-
-                    var fileName = DBADashSource.GenerateFileName(cfg.SourceConnection.ConnectionForFileName);
-                    try
-                    {
-                        await DestinationHandling.WriteAllDestinationsAsync(collector.Data, cfg, fileName, config);
-
-                        collector.CacheCollectedText();
-                        collector.CacheCollectedPlans();
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "Error writing {filename} to destination.  File will be copied to {folder}",
-                            fileName, SchedulerServiceConfig.FailedMessageFolder);
-                        await DestinationHandling.WriteFolderAsync(collector.Data, SchedulerServiceConfig.FailedMessageFolder,
-                            fileName, config);
-                    }
-                }
-
-                if (collectJobs)
-                {
-                    try
-                    {
-                        using var op = Operation.Begin("Collect Jobs from instance {instance}",
-                            cfg.SourceConnection.ConnectionForPrint);
-                        await CollectJobsAsync(cfg, dataMap);
-                        op.Complete();
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "Error running CollectJobs");
-                    }
-                }
-            }
-            catch (DatabaseConnectionException ex)
-            {
-                OfflineInstances.Add(cfg, ex.InnerException.Message);
-            }
-            catch (Exception ex)
-            {
-                Log.Logger.Error(ex, "Error collecting types {types} from instance {instance}", string.Join(", ", types.Select(s => s.ToString()).ToArray()), cfg.SourceConnection.ConnectionForPrint);
-            }
-        }
-
-        private static async Task CollectJobsAsync(DBADashSource cfg, JobDataMap dataMap)
-        {
-            dataMap.TryGetDateTimeValue("JobCollectDate", out var jobLastCollected);
-            dataMap.TryGetDateTimeValue("JobLastModified", out var jobLastModified);
-            var minsSinceLastCollection = DateTime.Now.Subtract(jobLastCollected).TotalMinutes;
-            var forcedCollectionDate = jobLastCollected.AddMinutes(MAX_TIME_SINCE_LAST_JOB_COLLECTION);
-
-            var collector = await DBCollector.CreateAsync(cfg, config.ServiceName, default, SchedulerServiceConfig.Config.LogInternalPerformanceCounters);
-
-            // Setting the JobLastModified means we will only collect job data if jobs have been updated since the last collection.
-            // Skip setting JobLastModified if we haven't collected in 1 day to ensure we collect at least once per day.
-
-            if (jobLastCollected == DateTime.MinValue)
-            {
-                Log.Debug("Skipping setting JobLastModified (First collection on startup) on {Connection}", cfg.SourceConnection.ConnectionForPrint);
-            }
-            else if (DateTime.Now < forcedCollectionDate)
-            {
-                collector.JobLastModified = jobLastModified;
-                Log.Debug("Setting JobLastModified to {JobLastModified}. Forced collection will run after {ForcedCollectionDate}.  {MinsSinceLastCollection}mins since last collection ({LastCollected}) on {Connection}", jobLastModified, forcedCollectionDate, minsSinceLastCollection.ToString("N0"), jobLastCollected, cfg.SourceConnection.ConnectionForPrint);
-            }
-            else
-            {
-                Log.Debug("Skipping setting JobLastModified to {JobLastModified} - forcing job collection to run. {MinsSinceLastCollection}mins since last collection ({LastCollected}) on {Connection}.", jobLastModified, minsSinceLastCollection.ToString("N0"), jobLastCollected, cfg.SourceConnection.ConnectionForPrint);
-            }
-
-            await collector.CollectAsync(CollectionType.Jobs);
-            bool containsJobs = collector.Data.Tables.Contains("Jobs");
-            if (containsJobs) // Only set JobLastModified/JobCollectDate and write to destination if Jobs collection ran
-            {
-                // We have collected jobs data - Store JobLastModified and time we have collected the jobs.
-                // Used on next run to determine if we need to refresh this data.
-                dataMap.Put("JobLastModified", collector.JobLastModified);
-                dataMap.Put("JobCollectDate", DateTime.Now);
-
-                var fileName = DBADashSource.GenerateFileName(cfg.SourceConnection.ConnectionForFileName);
-                try
-                {
-                    await DestinationHandling.WriteAllDestinationsAsync(collector.Data, cfg, fileName, config);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error writing {filename} to destination.  File will be copied to {folder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
-                    await DestinationHandling.WriteFolderAsync(collector.Data, SchedulerServiceConfig.FailedMessageFolder, fileName, config);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Split file list by Instance parsed from the filename.  Each instance will have 1 item in the dictionary containing a list of files to process for that instance
-        /// </summary>
-        private static Dictionary<string, List<string>> GetFilesToProcessByInstance(List<string> files)
-        {
-            Dictionary<string, List<string>> filesToProcessByInstance = new();
-            foreach (var path in files)
-            {
-                string instance;
-                try
-                {
-                    instance = ParseInstance(Path.GetFileName(path));
-                }
-                catch (Exception ex)
-                {
-                    instance = "default";
-                    Log.Warning("Unable to parse Instance from {0}: {1}", path, ex.Message);
-                }
-                if (filesToProcessByInstance.TryGetValue(instance, out var value))
-                {
-                    value.Add(path);
-                }
-                else
-                {
-                    filesToProcessByInstance.Add(instance, new List<string> { path });
-                }
-            }
-            return filesToProcessByInstance;
-        }
-
-        /// <summary>
-        /// Get files to import from folder and process in parallel for each instance.
-        /// </summary>
-        private static async Task CollectFolderAsync(DBADashSource cfg)
-        {
-            var folder = cfg.GetSource();
-            Log.Logger.Information("Import from folder {folder}", folder);
-            if (Directory.Exists(folder))
-            {
-                try
-                {
-                    var files = Directory.EnumerateFiles(folder, DestinationHandling.FileSearchPattern, SearchOption.TopDirectoryOnly)
-                        .Where(f => f.EndsWith(DestinationHandling.FileExtension))
-                        .ToList();
-
-                    var filesToProcessByInstance = GetFilesToProcessByInstance(files);
-                    // Parallel processing of files for each instance, but process the files for a given instance in order
-                    var tasks = filesToProcessByInstance.Select(instanceItem => instanceItem.Value).Select(instanceFiles => ProcessFileListForCollectFolderAsync(instanceFiles, cfg)).ToList();
-
-                    await Task.WhenAll(tasks);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Import from folder {folder}", folder);
-                }
-            }
-            else
-            {
-                Log.Error("Source directory doesn't exist {folder}", folder);
-            }
-        }
-
-        /// <summary>
-        /// Process a given list of files in order for a specific instance, writing collected data to the DBADash repository database
-        /// </summary>
-        private static async Task ProcessFileListForCollectFolderAsync(List<string> files, DBADashSource cfg)
-        {
-            files.Sort(); // Ensure we process files in order
-            foreach (var f in files)
-            {
-                await ProcessFile(f, cfg);
-                TryDeleteFile(f);
-            }
-        }
-
-        private static void TryDeleteFile(string filePath)
-        {
-            if (!File.Exists(filePath)) return;
-            try
-            {
-                File.Delete(filePath);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error deleting file");
-            }
-        }
-
-        private static async Task ProcessFile(string f, DBADashSource cfg, int tryCount = 1)
-        {
-            const int MaxTryCount = 5;
-            const int RetryDelay = 10;
-            Log.Information("Processing file {0}", f);
-            var fileName = Path.GetFileName(f);
-            try
-            {
-                var ds = DataSetSerialization.DeserializeFromFile(f);
-                var id = GetID(ds);
-                using (await Locker.AsyncLocker.LockAsync(id))
-                {
-                    await DestinationHandling.WriteAllDestinationsAsync(ds, cfg, fileName, config);
-                }
-            }
-            catch (IOException ex) when ((uint)ex.HResult == ERROR_SHARING_VIOLATION) // Another process has a lock on the file.  It might still be being written to.
-            {
-                if (tryCount > MaxTryCount)
-                {
-                    Log.Warning("File {FileName} is in use.  Exceeded max wait/retry.  File will be processed on the next iteration", fileName);
-                    return;
-                }
-                Log.Information("File {FileName} is in use.  Waiting for lock to release. Attempt {TryCount}/{MaxRetryCount}", fileName, tryCount, MaxTryCount);
-                await Task.Delay(RetryDelay);
-                await ProcessFile(f, cfg, tryCount + 1);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error importing from {filename}.  File will be copied to {failedMessageFolder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
-                File.Copy(f, Path.Combine(SchedulerServiceConfig.FailedMessageFolder, f));
-            }
-        }
-
-        /// <summary>
-        /// Process The S3 bucket source.  Run a separate thread per instance and process the files for each instance sequentially in the order they were collected
-        /// </summary>
-        private static async Task CollectS3(DBADashSource cfg)
-        {
-            Log.Information("Import from S3 {connection}", cfg.ConnectionString);
-            try
-            {
-                // Support AWS and S3-compatible providers (e.g., MinIO) by flexible parsing
-                string bucket;
-                string keyPrefix;
-                if (Amazon.S3.Util.AmazonS3Uri.TryParseAmazonS3Uri(cfg.ConnectionString, out var s3Uri))
-                {
-                    bucket = s3Uri.Bucket;
-                    keyPrefix = s3Uri.Key ?? string.Empty;
-                }
-                else
-                {
-                    var endpointUri = new Uri(cfg.ConnectionString, UriKind.Absolute);
-                    var segments = endpointUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                    if (segments.Length == 0)
-                    {
-                        throw new ArgumentException("S3 source must include bucket name in path", nameof(cfg.ConnectionString));
-                    }
-                    bucket = segments[0];
-                    keyPrefix = string.Join('/', segments.Skip(1));
-                }
-
-                using var s3Cli = await AWSTools.GetS3ClientForEndpointAsync(config.AWSProfile, config.AccessKey, config.GetSecretKey(), cfg.ConnectionString);
-                // Build prefix correctly for root or subfolder without leading slash
-                var normalizedPrefix = string.IsNullOrEmpty(keyPrefix)
-                    ? DestinationHandling.FileNamePrefix
-                    : string.Join('/', new[] { keyPrefix.TrimEnd('/'), DestinationHandling.FileNamePrefix });
-                ListObjectsRequest request = new()
-                {
-                    BucketName = bucket,
-                    Prefix = normalizedPrefix
-                };
-
-                do
-                {
-                    var resp = await s3Cli.ListObjectsAsync(request);
-                    if (resp is { S3Objects: not null })
-                    {
-                        var fileList = resp.S3Objects.Where(f => f.Key.EndsWith(DestinationHandling.FileExtension)).Select(f => f.Key).ToList();
-                        var filesToProcessByInstance = GetFilesToProcessByInstance(fileList);
-
-                        Log.Information("Processing {0} files from {1}. Instance Count: {2}", fileList.Count, string.IsNullOrEmpty(keyPrefix) ? "(root)" : keyPrefix, filesToProcessByInstance.Count);
-
-                        // Start a thread to process the files associated with each instance.  Each instance will have it's files processed sequentially in the order they were collected.
-                        var tasks = filesToProcessByInstance.Select(instanceItem => instanceItem.Value).Select(instanceFiles => ProcessS3FileListForCollectS3Async(instanceFiles, s3Cli, bucket, cfg)).ToList();
-
-                        await Task.WhenAll(tasks);
-                    }
-
-                    if (resp?.IsTruncated == true)
-                    {
-                        Log.Debug("Response truncated.  Processing next marker for {0}", keyPrefix);
-                        request.Marker = resp.NextMarker;
-                    }
-                    else
-                    {
-                        request = null;
-                    }
-                }
-                while (request != null);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error importing files from S3");
-            }
-        }
-
-        /// <summary>
-        /// Process a given list of S3 files for a specific instance in order, writing collected data to DBA Dash repository database
-        /// </summary>
-        private static async Task ProcessS3FileListForCollectS3Async(List<string> instanceFiles, Amazon.S3.AmazonS3Client s3Cli, string bucket, DBADashSource cfg)
-        {
-            instanceFiles.Sort(); // Ensure files are processed in order
-            foreach (var s3Path in instanceFiles)
-            {
-                using var response = await s3Cli.GetObjectAsync(bucket, s3Path);
-                await using var responseStream = response.ResponseStream;
-
-                var ds = new DataSet();
-                ds.ReadXml(responseStream);
-                var id = GetID(ds);
-                using (await Locker.AsyncLocker.LockAsync(id))
-                {
-                    var fileName = Path.GetFileName(s3Path);
-                    try
-                    {
-                        await DestinationHandling.WriteAllDestinationsAsync(ds, cfg, fileName, config);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex,
-                            "Error importing file {filename}.  Writing file to failed message folder {folder}",
-                            fileName, SchedulerServiceConfig.FailedMessageFolder);
-                        await DestinationHandling.WriteFolderAsync(ds, SchedulerServiceConfig.FailedMessageFolder,
-                            fileName, config);
-                    }
-                    finally
-                    {
-                        await s3Cli.DeleteObjectAsync(bucket, s3Path);
-                    }
-                }
-
-                Log.Information("Imported {file}", s3Path);
             }
         }
     }

--- a/DBADashService/DBADashService.csproj
+++ b/DBADashService/DBADashService.csproj
@@ -75,6 +75,7 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="5.0.0" />

--- a/DBADashService/DirectoryWorkItem.cs
+++ b/DBADashService/DirectoryWorkItem.cs
@@ -1,0 +1,172 @@
+using AsyncKeyedLock;
+using DBADash;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    public sealed class DirectoryWorkItem : IWorkItem
+    {
+        private static readonly AsyncKeyedLocker<string> _folderLocker = new();
+        private const uint ERROR_SHARING_VIOLATION = 0x80070020;
+
+        public DBADashSource Source { get; set; }
+
+        public string DedupKey => Source.ConnectionString;
+
+        public string Schedule { get; set; }
+
+        public WorkItemPriority Priority { get; set; } = WorkItemPriority.Normal;
+
+        public string Description => $"Import from {Source.ConnectionString}";
+
+        public async Task ExecuteAsync(CollectionConfig config, CancellationToken cancellationToken)
+        {
+            var folder = Source.GetSource();
+            Log.Logger.Information("Import from folder {folder}", folder);
+            if (!Directory.Exists(folder))
+            {
+                Log.Error("Source directory doesn't exist {folder}", folder);
+                return;
+            }
+
+            // One job per folder at a time
+            using (await _folderLocker.LockAsync(Source.ConnectionString).ConfigureAwait(false))
+            {
+                List<string> files;
+                try
+                {
+                    files = Directory.EnumerateFiles(folder, DestinationHandling.FileSearchPattern, SearchOption.TopDirectoryOnly)
+                                     .Where(f => f.EndsWith(DestinationHandling.FileExtension))
+                                     .ToList();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Enumerate files {folder}", folder);
+                    return;
+                }
+
+                var filesByInstance = GetFilesToProcessByInstance(files);
+                var tasks = filesByInstance.Select(kv => ProcessInstanceFilesAsync(kv.Value, Source, config, cancellationToken)).ToList();
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Process a given list of files in order for a specific instance, writing collected data to the DBADash repository database
+        /// </summary>
+        private static async Task ProcessInstanceFilesAsync(List<string> files, DBADashSource source, CollectionConfig config, CancellationToken cancellationToken)
+        {
+            files.Sort(); // Ensure we process files in order
+            foreach (var f in files)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await ProcessFileAsync(f, source, config);
+                TryDeleteFile(f);
+            }
+        }
+
+        private static async Task ProcessFileAsync(string f, DBADashSource source, CollectionConfig config, int tryCount = 1)
+        {
+            const int MaxTryCount = 5;
+            const int RetryDelay = 10;
+            Log.Information("Processing file {0}", f);
+            var fileName = Path.GetFileName(f);
+            try
+            {
+                var ds = DataSetSerialization.DeserializeFromFile(f);
+                var id = GetID(ds);
+                using (await Locker.AsyncLocker.LockAsync(id))
+                {
+                    await DestinationHandling.WriteAllDestinationsAsync(ds, source, fileName, config);
+                }
+            }
+            catch (IOException ex) when ((uint)ex.HResult == ERROR_SHARING_VIOLATION) // Another process has a lock on the file.  It might still be being written to.
+            {
+                if (tryCount > MaxTryCount)
+                {
+                    Log.Warning("File {FileName} is in use.  Exceeded max wait/retry.  File will be processed on the next iteration", fileName);
+                    return;
+                }
+                Log.Information("File {FileName} is in use.  Waiting for lock to release. Attempt {TryCount}/{MaxRetryCount}", fileName, tryCount, MaxTryCount);
+                await Task.Delay(RetryDelay);
+                await ProcessFileAsync(f, source, config, tryCount + 1);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error importing from {filename}.  File will be copied to {failedMessageFolder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
+                File.Copy(f, Path.Combine(SchedulerServiceConfig.FailedMessageFolder, f));
+            }
+        }
+
+        internal static string GetID(DataSet ds)
+        {
+            try
+            {
+                return ds.Tables["DBADash"].Rows[0]["Instance"] + "_" + ds.Tables["DBADash"].Rows[0]["DBName"];
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error getting ID from DataSet");
+                return "DEFAULT";
+            }
+        }
+
+        /// <summary>
+        /// Parse Instance from filename.  File format is DBADash_YYYYMMDD_HHMM_SS_{InstanceName}_{random}.xml
+        /// </summary>
+        public static string ParseInstance(string fileName)
+        {
+            return fileName[25..fileName.LastIndexOf('_')];
+        }
+
+        /// <summary>
+        /// Split file list by Instance parsed from the filename.  Each instance will have 1 item in the dictionary containing a list of files to process for that instance
+        /// </summary>
+        internal static Dictionary<string, List<string>> GetFilesToProcessByInstance(List<string> files)
+        {
+            Dictionary<string, List<string>> filesToProcessByInstance = new();
+            foreach (var path in files)
+            {
+                string instance;
+                try
+                {
+                    instance = ParseInstance(Path.GetFileName(path));
+                }
+                catch (Exception ex)
+                {
+                    instance = "default";
+                    Log.Warning("Unable to parse Instance from {0}: {1}", path, ex.Message);
+                }
+                if (filesToProcessByInstance.TryGetValue(instance, out var value))
+                {
+                    value.Add(path);
+                }
+                else
+                {
+                    filesToProcessByInstance.Add(instance, new List<string> { path });
+                }
+            }
+            return filesToProcessByInstance;
+        }
+
+        private static void TryDeleteFile(string filePath)
+        {
+            if (!File.Exists(filePath)) return;
+            try
+            {
+                File.Delete(filePath);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error deleting file");
+            }
+        }
+    }
+}

--- a/DBADashService/IWorkItem.cs
+++ b/DBADashService/IWorkItem.cs
@@ -1,0 +1,24 @@
+using DBADash;
+using Serilog;
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    public interface IWorkItem
+    {
+        public string DedupKey { get; }
+
+        public DBADashSource Source { get; }
+
+        public string Schedule { get; set; }
+
+        public WorkItemPriority Priority { get; }
+
+        public string Description { get; }
+
+        Task ExecuteAsync(CollectionConfig config, CancellationToken cancellationToken);
+    }
+}

--- a/DBADashService/S3WorkItem.cs
+++ b/DBADashService/S3WorkItem.cs
@@ -1,0 +1,152 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using AsyncKeyedLock;
+using DBADash;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    public sealed class S3WorkItem : IWorkItem
+    {
+        private static readonly AsyncKeyedLocker<string> _s3Locker = new();
+        public DBADashSource Source { get; set; }
+
+        public string DedupKey => Source.ConnectionString;
+
+        public string Schedule { get; set; }
+
+        public WorkItemPriority Priority { get; set; } = WorkItemPriority.Normal;
+
+        public string Description => $"Import from {Source.ConnectionString}";
+
+        public async Task ExecuteAsync(CollectionConfig config, CancellationToken cancellationToken)
+        {
+            Log.Information("Import from S3 {connection}", Source.ConnectionString);
+
+            // One job per S3 source at a time
+            using (await _s3Locker.LockAsync(Source.ConnectionString).ConfigureAwait(false))
+            {
+                try
+                {
+                    string bucket;
+                    string keyPrefix;
+                    if (Amazon.S3.Util.AmazonS3Uri.TryParseAmazonS3Uri(Source.ConnectionString, out var s3Uri))
+                    {
+                        bucket = s3Uri.Bucket;
+                        keyPrefix = s3Uri.Key ?? string.Empty;
+                    }
+                    else
+                    {
+                        var endpointUri = new Uri(Source.ConnectionString, UriKind.Absolute);
+                        var segments = endpointUri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                        if (segments.Length == 0)
+                        {
+                            throw new ArgumentException("S3 source must include bucket name in path", nameof(Source.ConnectionString));
+                        }
+                        bucket = segments[0];
+                        keyPrefix = string.Join('/', segments.Skip(1));
+                    }
+
+                    using var s3Cli = await AWSTools.GetS3ClientForEndpointAsync(config.AWSProfile, config.AccessKey, config.GetSecretKey(), Source.ConnectionString).ConfigureAwait(false);
+
+                    var normalizedPrefix = string.IsNullOrEmpty(keyPrefix)
+                        ? DestinationHandling.FileNamePrefix
+                        : string.Join('/', new[] { keyPrefix.TrimEnd('/'), DestinationHandling.FileNamePrefix });
+
+                    var request = new ListObjectsRequest
+                    {
+                        BucketName = bucket,
+                        Prefix = normalizedPrefix
+                    };
+
+                    do
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        var resp = await s3Cli.ListObjectsAsync(request).ConfigureAwait(false);
+                        if (resp is { S3Objects: not null })
+                        {
+                            var fileList = resp.S3Objects
+                                .Where(f => f.Key.EndsWith(DestinationHandling.FileExtension))
+                                .Select(f => f.Key)
+                                .ToList();
+
+                            var filesByInstance = DirectoryWorkItem.GetFilesToProcessByInstance(fileList);
+
+                            Log.Information("Processing {count} files from {prefix}. Instances: {instances}", fileList.Count, string.IsNullOrEmpty(keyPrefix) ? "(root)" : keyPrefix, filesByInstance.Count);
+
+                            // Pass per-instance lists to tasks to avoid concurrent mutations of the same list
+                            var tasks = filesByInstance
+                                .Select(kv => ProcessS3FileListForCollectS3Async(kv.Value, s3Cli, bucket, Source, config))
+                                .ToList();
+
+                            await Task.WhenAll(tasks).ConfigureAwait(false);
+                        }
+
+                        if (resp?.IsTruncated == true)
+                        {
+                            Log.Debug("Response truncated. Processing next marker for {prefix}", keyPrefix);
+                            request.Marker = resp.NextMarker;
+                        }
+                        else
+                        {
+                            request = null!;
+                        }
+                    }
+                    while (request != null);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error importing files from S3");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Process a given list of S3 files for a specific instance in order, writing collected data to DBA Dash repository database
+        /// </summary>
+        private static async Task ProcessS3FileListForCollectS3Async(List<string> instanceFiles, AmazonS3Client s3Cli, string bucket, DBADashSource source, CollectionConfig config)
+        {
+            instanceFiles.Sort(); // Ensure files are processed in order
+
+            foreach (var s3Path in instanceFiles)
+            {
+                using var response = await s3Cli.GetObjectAsync(bucket, s3Path);
+                await using var responseStream = response.ResponseStream;
+
+                var ds = new DataSet();
+                ds.ReadXml(responseStream);
+                var id = DirectoryWorkItem.GetID(ds);
+                using (await Locker.AsyncLocker.LockAsync(id))
+                {
+                    var fileName = Path.GetFileName(s3Path);
+                    try
+                    {
+                        await DestinationHandling.WriteAllDestinationsAsync(ds, source, fileName, config);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex,
+                            "Error importing file {filename}.  Writing file to failed message folder {folder}",
+                            fileName, SchedulerServiceConfig.FailedMessageFolder);
+                        await DestinationHandling.WriteFolderAsync(ds, SchedulerServiceConfig.FailedMessageFolder,
+                            fileName, config);
+                    }
+                    finally
+                    {
+                        await s3Cli.DeleteObjectAsync(bucket, s3Path);
+                    }
+                }
+
+                Log.Information("Imported {file}", s3Path);
+            }
+        }
+    }
+}

--- a/DBADashService/ScheduledCollectionJob.cs
+++ b/DBADashService/ScheduledCollectionJob.cs
@@ -1,0 +1,258 @@
+using DBADash;
+using Newtonsoft.Json;
+using Quartz;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    /// <summary>
+    /// Scheduled job that enqueues collection work for all instances with a specific schedule.
+    /// One job per cron schedule instead of one job per instance per schedule.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public class ScheduledCollectionJob : IJob
+    {
+        private static CollectionWorkQueue _workQueue;
+
+        private const int HIGH_THRESHOLD_SECONDS = 300;    // Up to 5 minutes.  If the schedule is this frequent, treat as high priority. Less frequent is normal or low priority
+        private const int NORMAL_THRESHOLD_SECONDS = 7200; // Up to 2 hours. If the schedule is this frequent, treat as normal priority. Less frequent is low priority
+
+        private static readonly ConcurrentDictionary<string, WorkItemPriority> _priorityCache = new(StringComparer.Ordinal);
+
+        // jobKey -> instanceKey -> source
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, DBADashSource>> _sourcesByJob
+            = new(StringComparer.Ordinal);
+
+        public static void Initialize(CollectionWorkQueue workQueue)
+        {
+            _workQueue = workQueue;
+        }
+
+        // Upsert sources for a job identity
+        public static void UpsertSources(string jobKey, IEnumerable<DBADashSource> sources)
+        {
+            if (string.IsNullOrEmpty(jobKey) || sources == null) return;
+            var bucket = _sourcesByJob.GetOrAdd(jobKey, _ => new ConcurrentDictionary<string, DBADashSource>(StringComparer.Ordinal));
+            foreach (var s in sources)
+            {
+                if (s == null) continue;
+                var key = s.ConnectionString;
+                if (!string.IsNullOrEmpty(key))
+                {
+                    bucket[key] = s;
+                }
+            }
+        }
+
+        private static IReadOnlyCollection<DBADashSource> GetSourcesForJob(string jobKey)
+        {
+            if (!string.IsNullOrEmpty(jobKey) && _sourcesByJob.TryGetValue(jobKey, out var bucket) && bucket.Count > 0)
+            {
+                return bucket.Values.ToArray();
+            }
+            return Array.Empty<DBADashSource>();
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            var swTotal = Stopwatch.StartNew();
+            var dataMap = context.JobDetail.JobDataMap;
+            var schedule = dataMap.GetString("Schedule");
+
+            var jobKey = context.JobDetail.Key.Name;
+            var sources = GetSourcesForJob(jobKey);
+
+            var priority = GetOrComputePriority(schedule, dataMap);
+
+            var collectionTypes = JsonConvert.DeserializeObject<CollectionType[]>(dataMap.GetString("Types"));
+            var customCollections = JsonConvert.DeserializeObject<Dictionary<string, CustomCollection>>(dataMap.GetString("CustomCollections"));
+
+            var queueDepth = _workQueue.QueueDepth;
+            Log.Information("Enqueuing collection for {instanceCount} instances on schedule {schedule}. Queue Total:{total} (H:{high}, N:{normal} L:{low}). Priority: {priority}",
+                sources.Count, schedule, _workQueue.QueueDepth, _workQueue.HighQueueDepth, _workQueue.NormalQueueDepth, _workQueue.LowQueueDepth, priority);
+
+            var enqueueTasks = new List<Task<bool>>(sources.Count * 2);
+            int enqueuedWork = 0;
+
+            foreach (var source in sources)
+            {
+                switch (source.SourceConnection.Type)
+                {
+                    case DBADashConnection.ConnectionType.AWSS3:
+                        EnqueueS3(enqueueTasks, source, schedule, context, priority);
+                        enqueuedWork++;
+                        break;
+
+                    case DBADashConnection.ConnectionType.Directory:
+                        EnqueueDirectory(enqueueTasks, source, schedule, context, priority);
+                        enqueuedWork++;
+                        break;
+
+                    case DBADashConnection.ConnectionType.SQL:
+                        enqueuedWork += EnqueueSQL(enqueueTasks, source, schedule, context, priority, collectionTypes, customCollections);
+                        break;
+                }
+            }
+
+            var results = await Task.WhenAll(enqueueTasks);
+            var failedCount = results.Count(r => !r);
+            var totalMs = swTotal.Elapsed.TotalMilliseconds;
+
+            if (failedCount > 0)
+            {
+                Log.Warning("Failed to enqueue {failedCount} work items for schedule {schedule} in {duration}ms", failedCount, schedule, totalMs);
+            }
+            else
+            {
+                Log.Information("Successfully enqueued {count} work items for schedule {schedule} in {duration}ms", enqueueTasks.Count, schedule, totalMs);
+            }
+        }
+
+        private static int EnqueueSQL(
+            List<Task<bool>> enqueueTasks,
+            DBADashSource source,
+            string schedule,
+            IJobExecutionContext context,
+            WorkItemPriority priority,
+            CollectionType[] collectionTypes,
+            Dictionary<string, CustomCollection> customCollections)
+        {
+            var enqueueCount = 0;
+
+            var isOffline = OfflineInstances.IsOffline(source);
+            if (isOffline)
+            {
+                Log.Debug("Skipping {instance} - offline",
+                    source.ConnectionID ?? source.SourceConnection.ConnectionForPrint);
+                return 0;
+            }
+
+            var typesSet = new HashSet<CollectionType>(collectionTypes);
+            var hasSnapshot = typesSet.Contains(CollectionType.SchemaSnapshot);
+            var typesWithoutSnapshot = hasSnapshot
+                ? collectionTypes.Where(c => c != CollectionType.SchemaSnapshot).ToArray()
+                : collectionTypes;
+
+            if (hasSnapshot)
+            {
+                var snapshotWorkItem = new SchemaSnapshotWorkItem
+                {
+                    Source = source,
+                    Schedule = schedule,
+                };
+
+                enqueueTasks.Add(_workQueue.EnqueueAsync(snapshotWorkItem, context.CancellationToken));
+                enqueueCount++;
+                if (typesWithoutSnapshot.Length == 0 && customCollections.Count == 0)
+                {
+                    return enqueueCount;
+                }
+            }
+
+            var workItem = new WorkItem
+            {
+                Source = source,
+                Types = typesWithoutSnapshot,
+                CustomCollections = customCollections,
+                PreviousFireTime = context.PreviousFireTimeUtc?.UtcDateTime,
+                Schedule = schedule,
+                Priority = priority
+            };
+            enqueueCount++;
+            enqueueTasks.Add(_workQueue.EnqueueAsync(workItem, context.CancellationToken));
+            return enqueueCount;
+        }
+
+        private static void EnqueueS3(List<Task<bool>> enqueueTasks, DBADashSource source, string schedule, IJobExecutionContext context, WorkItemPriority priority)
+        {
+            var s3WorkItem = new S3WorkItem
+            {
+                Source = source,
+                Schedule = schedule,
+                Priority = priority
+            };
+            enqueueTasks.Add(_workQueue.EnqueueAsync(s3WorkItem, context.CancellationToken));
+        }
+
+        private static void EnqueueDirectory(List<Task<bool>> enqueueTasks, DBADashSource source, string schedule, IJobExecutionContext context, WorkItemPriority priority)
+        {
+            var dirWorkItem = new DirectoryWorkItem
+            {
+                Source = source,
+                Schedule = schedule,
+                Priority = priority
+            };
+            enqueueTasks.Add(_workQueue.EnqueueAsync(dirWorkItem, context.CancellationToken));
+        }
+
+        private static WorkItemPriority GetOrComputePriority(string schedule, JobDataMap map)
+        {
+            // Prefer stored value in JobDataMap
+            if (map.ContainsKey("Priority"))
+            {
+                return (WorkItemPriority)map.GetInt("Priority");
+            }
+
+            // Try cache
+            if (_priorityCache.TryGetValue(schedule, out var cached))
+            {
+                map.Put("Priority", (int)cached);
+                return cached;
+            }
+
+            // Compute once
+            var computed = ComputePriorityFromSchedule(schedule);
+
+            // Persist for subsequent runs
+            _priorityCache[schedule] = computed;
+            map.Put("Priority", (int)computed);
+
+            return computed;
+        }
+
+        internal static WorkItemPriority ComputePriorityFromSchedule(string schedule)
+        {
+            if (string.IsNullOrEmpty(schedule)) return WorkItemPriority.Normal;
+            // Numeric seconds schedule
+            if (int.TryParse(schedule, out var seconds))
+            {
+                if (seconds <= HIGH_THRESHOLD_SECONDS) return WorkItemPriority.High;
+                if (seconds <= NORMAL_THRESHOLD_SECONDS) return WorkItemPriority.Normal;
+                return WorkItemPriority.Low;
+            }
+
+            // Cron expression: compute interval between next two occurrences
+            try
+            {
+                var cron = new CronExpression(schedule);
+                var now = DateTimeOffset.UtcNow;
+
+                var next1 = cron.GetNextValidTimeAfter(now);
+                var next2 = next1.HasValue ? cron.GetNextValidTimeAfter(next1.Value) : null;
+
+                if (next1.HasValue && next2.HasValue)
+                {
+                    var intervalSeconds = (int)Math.Round((next2.Value - next1.Value).TotalSeconds);
+
+                    if (intervalSeconds <= HIGH_THRESHOLD_SECONDS) return WorkItemPriority.High;
+                    if (intervalSeconds <= NORMAL_THRESHOLD_SECONDS) return WorkItemPriority.Normal;
+                    return WorkItemPriority.Low;
+                }
+
+                Log.Warning("Unable to determine interval from cron schedule {schedule}. Defaulting priority to Normal.", schedule);
+                return WorkItemPriority.Normal;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Invalid cron schedule {schedule}. Defaulting priority to Normal.", schedule);
+                return WorkItemPriority.Normal;
+            }
+        }
+    }
+}

--- a/DBADashService/SchemaSnapshotWorkItem.cs
+++ b/DBADashService/SchemaSnapshotWorkItem.cs
@@ -1,0 +1,34 @@
+﻿using DBADash;
+using Newtonsoft.Json;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    internal class SchemaSnapshotWorkItem : IWorkItem
+    {
+        public DBADashSource Source { get; set; }
+
+        public string Schedule { get; set; }
+
+        public string DedupKey => "SchemaSnapshot_" + Source.ConnectionString;
+
+        public WorkItemPriority Priority => WorkItemPriority.Low;
+
+        public string Description => $"Schema Snapshot {Source.ConnectionID} for databases {Source.SchemaSnapshotDBs} on schedule {Schedule}";
+
+        public async Task ExecuteAsync(CollectionConfig config, CancellationToken cancellationToken)
+        {
+            if (OfflineInstances.IsOffline(Source))
+            {
+                Log.Warning("Connection to {Connection} is offline.  Skipping schema snapshot", Source.ConnectionID ?? Source.SourceConnection.ConnectionForPrint);
+                return;
+            }
+            await SchemaSnapshotDB.GenerateSchemaSnapshots(SchedulerServiceConfig.Config, Source);
+        }
+    }
+}

--- a/DBADashService/WorkItem.cs
+++ b/DBADashService/WorkItem.cs
@@ -1,0 +1,201 @@
+﻿using AsyncKeyedLock;
+using DBADash;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBADashService
+{
+    public enum WorkItemPriority
+    {
+        High = 0,
+        Normal = 1,
+        Low = 2
+    }
+
+    public class WorkItem : IWorkItem
+    {
+        private static ConcurrentDictionary<string, WorkItemState> WorkItemStates = new();
+        public DBADashSource Source { get; set; }
+        public virtual CollectionType[] Types { get; set; }
+        public Dictionary<string, CustomCollection> CustomCollections { get; set; } = new();
+
+        private WorkItemState _state;
+
+        private WorkItemState State { get => _state ?? GetState(Source.ConnectionString); }
+        public DateTime? PreviousFireTime { get; set; }
+        public string Schedule { get; set; } // Track which schedule this work item belongs to
+
+        private Stopwatch EnqueueSW = Stopwatch.StartNew();
+
+        public WorkItemPriority Priority { get; set; } = WorkItemPriority.Normal;
+
+        // Stable unique identifier for deduplication across queue runs
+        public string DedupKey => $"{Source.ConnectionID ?? Source.ConnectionString}::{string.Join("|", Types)}{string.Join("|", CustomCollections.Keys.OrderBy(k => k))}";
+
+        public IEnumerable<string> AllTypes => Types.Select(c => c.ToString()).Union(CustomCollections?.Keys.ToArray<string>() ?? []);
+
+        public string Description => $"Collect {string.Join(',', AllTypes)} on schedule {Schedule} from {Source.ConnectionID}";
+
+        private WorkItemState GetState(string connectionString)
+        {
+            return WorkItemStates.GetOrAdd(connectionString, _ => new WorkItemState());
+        }
+
+        public virtual async Task ExecuteAsync(CollectionConfig config, CancellationToken cancellationToken)
+        {
+            if (Types == null || Types.Length == 0)
+                return;
+
+            var dequeueLatencyMs = EnqueueSW.ElapsedMilliseconds;
+            var collectJobs = Types.Contains(CollectionType.Jobs);
+            var types = collectJobs ? Types.Where(t => t != CollectionType.Jobs).ToArray() : Types;
+
+            try
+            {
+                if (types.Length > 0 || CustomCollections?.Count > 0)
+                {
+                    var collector = await DBCollector.CreateAsync(Source, config.ServiceName);
+                    collector.Job_instance_id = State.JobInstanceId;
+                    collector.IsExtendedEventsNotSupportedException = State.IsExtendedEventsNotSupportedException;
+                    collector.FailedLoginsBackfillMinutes = config.FailedLoginsBackfillMinutes ??
+                        CollectionConfig.DefaultFailedLoginsBackfillMinutes;
+
+                    if (SchedulerServiceConfig.Config.IdentityCollectionThreshold.HasValue)
+                    {
+                        collector.IdentityCollectionThreshold = (int)SchedulerServiceConfig.Config.IdentityCollectionThreshold;
+                    }
+
+                    if (PreviousFireTime.HasValue)
+                    {
+                        collector.PerformanceCollectionPeriodMins =
+                            (int)DateTime.UtcNow.Subtract(PreviousFireTime.Value).TotalMinutes + 5;
+                    }
+                    else
+                    {
+                        collector.PerformanceCollectionPeriodMins = 30;
+                    }
+
+                    collector.LogInternalPerformanceCounters = config.LogInternalPerformanceCounters;
+
+                    using (var op = SerilogTimings.Operation.Begin("Collect {types} from instance {instance} on schedule {schedule} with priority {priority}. Dequeue latency {latency}ms.",
+                               string.Join(", ", types.Select(s => s.ToString())),
+                               Source.SourceConnection.ConnectionForPrint,
+                               Schedule,
+                               Priority,
+                               dequeueLatencyMs))
+                    {
+                        await collector.CollectAsync(types);
+
+                        if (!State.IsExtendedEventsNotSupportedException && collector.IsExtendedEventsNotSupportedException)
+                        {
+                            Log.Information(
+                                "Disabling Extended events collection for {0}. Instance type doesn't support extended events",
+                                Source.SourceConnection.ConnectionForPrint);
+                            State.IsExtendedEventsNotSupportedException = true;
+                        }
+
+                        State.JobInstanceId = collector.Job_instance_id;
+                        op.Complete();
+                    }
+
+                    if (CustomCollections?.Count > 0)
+                    {
+                        using var op = SerilogTimings.Operation.Begin("Collect Custom Collections {types} from instance {instance}",
+                            string.Join(", ", CustomCollections.Select(s => s.Key)),
+                            Source.SourceConnection.ConnectionForPrint);
+                        await collector.CollectAsync(CustomCollections);
+                        op.Complete();
+                    }
+
+                    var fileName = DBADashSource.GenerateFileName(Source.SourceConnection.ConnectionForFileName);
+                    try
+                    {
+                        await DestinationHandling.WriteAllDestinationsAsync(collector.Data, Source, fileName, config);
+                        collector.CacheCollectedText();
+                        collector.CacheCollectedPlans();
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error writing {filename} to destination. File will be copied to {folder}",
+                            fileName, SchedulerServiceConfig.FailedMessageFolder);
+                        await DestinationHandling.WriteFolderAsync(collector.Data,
+                            SchedulerServiceConfig.FailedMessageFolder, fileName, config);
+                    }
+                }
+
+                if (collectJobs)
+                {
+                    await CollectJobsAsync(Source, State, config, cancellationToken);
+                }
+            }
+            catch (DatabaseConnectionException ex)
+            {
+                OfflineInstances.Add(Source, ex.InnerException.Message);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error collecting types {types} from instance {instance}",
+                    string.Join(", ", Types.Select(s => s.ToString())),
+                    Source.SourceConnection.ConnectionForPrint);
+            }
+        }
+
+        private static async Task CollectJobsAsync(DBADashSource cfg, WorkItemState state,
+            CollectionConfig config, CancellationToken cancellationToken)
+        {
+            const int MAX_TIME_SINCE_LAST_JOB_COLLECTION = 1430;
+
+            var minsSinceLastCollection = DateTime.Now.Subtract(state.JobCollectDate).TotalMinutes;
+            var forcedCollectionDate = state.JobCollectDate.AddMinutes(MAX_TIME_SINCE_LAST_JOB_COLLECTION);
+
+            var collector = await DBCollector.CreateAsync(cfg, config.ServiceName, config.LogInternalPerformanceCounters);
+
+            if (state.JobCollectDate == DateTime.MinValue)
+            {
+                Log.Debug("Skipping setting JobLastModified (First collection on startup) on {Connection}",
+                    cfg.SourceConnection.ConnectionForPrint);
+            }
+            else if (DateTime.Now < forcedCollectionDate)
+            {
+                collector.JobLastModified = state.JobLastModified;
+                Log.Debug("Setting JobLastModified to {JobLastModified}. Forced collection will run after {ForcedCollectionDate}. {MinsSinceLastCollection}mins since last collection ({LastCollected}) on {Connection}",
+                    state.JobLastModified, forcedCollectionDate, minsSinceLastCollection.ToString("N0"),
+                    state.JobCollectDate, cfg.SourceConnection.ConnectionForPrint);
+            }
+            else
+            {
+                Log.Debug("Skipping setting JobLastModified to {JobLastModified} - forcing job collection to run. {MinsSinceLastCollection}mins since last collection ({LastCollected}) on {Connection}.",
+                    state.JobLastModified, minsSinceLastCollection.ToString("N0"),
+                    state.JobCollectDate, cfg.SourceConnection.ConnectionForPrint);
+            }
+
+            await collector.CollectAsync(CollectionType.Jobs);
+            bool containsJobs = collector.Data.Tables.Contains("Jobs");
+
+            if (containsJobs)
+            {
+                state.JobLastModified = collector.JobLastModified;
+                state.JobCollectDate = DateTime.Now;
+
+                var fileName = DBADashSource.GenerateFileName(cfg.SourceConnection.ConnectionForFileName);
+                try
+                {
+                    await DestinationHandling.WriteAllDestinationsAsync(collector.Data, cfg, fileName, config);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error writing {filename} to destination. File will be copied to {folder}",
+                        fileName, SchedulerServiceConfig.FailedMessageFolder);
+                    await DestinationHandling.WriteFolderAsync(collector.Data,
+                        SchedulerServiceConfig.FailedMessageFolder, fileName, config);
+                }
+            }
+        }
+    }
+}

--- a/DBADashService/WorkItemState.cs
+++ b/DBADashService/WorkItemState.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DBADashService
+{
+    /// <summary>
+    /// In-memory state for a WorkItem to persist state between executions
+    /// Lost on service restart (same as current behavior with JobDataMap).
+    /// </summary>
+    public class WorkItemState
+    {
+        public int JobInstanceId { get; set; }
+        public bool IsExtendedEventsNotSupportedException { get; set; }
+        public DateTime JobLastModified { get; set; } = DateTime.MinValue;
+        public DateTime JobCollectDate { get; set; } = DateTime.MinValue;
+    }
+}

--- a/DBADashService/serilog.json
+++ b/DBADashService/serilog.json
@@ -2,24 +2,36 @@
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",
-      "Serilog.Sinks.File"
+      "Serilog.Sinks.File",
+      "Serilog.Sinks.Async"
     ],
     "MinimumLevel": "Information",
-    "Enrich": [ "WithThreadId"],
+    "Enrich": [ "WithThreadId" ],
     "WriteTo": [
       {
-        "Name": "Console",
+        "Name": "Async",
         "Args": {
-          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}"
-        }
-      },
-      {
-        "Name": "File",
-        "Args": {
-          "path": "Logs/log-.txt",
-          "rollingInterval": "Hour",
-          "retainedFileCountLimit": 24,
-          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}"
+          "bufferSize": 65536,
+          "blockWhenFull": false,
+          "configure": [
+            {
+              "Name": "Console",
+              "Args": {
+                "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}"
+              }
+            },
+            {
+              "Name": "File",
+              "Args": {
+                "path": "Logs/log-.txt",
+                "rollingInterval": "Hour",
+                "retainedFileCountLimit": 24,
+                "buffered": true,
+                "flushToDiskInterval": "00:00:02",
+                "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} <{ThreadId}>{NewLine}{Exception}"
+              }
+            }
+          ]
         }
       }
     ]


### PR DESCRIPTION
Implement queue based scheduling.  This reduces the number of schedules and the chance of misfire.  If work is still queued from a previous schedule, this will be logged and skipped.  This new system should be fairer. Priority is given to collections that run frequently as the collections are the most time sensitive.  Very infrequent collections are given low priority and are limited to consuming a percentage of the available threads as they could be long running, blocking other collections. Update serilog to write async.