### PR TITLE
DBA Dash upgrade script fix

### DIFF
--- a/Scripts/UpgradeDBADash.ps1
+++ b/Scripts/UpgradeDBADash.ps1
@@ -200,7 +200,7 @@ if ($versionCompare -eq -1 -or $ForceUpgrade){
     # Check if we already have the zip downloaded
     if(!(Test-Path -Path $zip)){
         Write-Host "Download latest release:$download"
-        Invoke-WebRequest $download -Out $zip
+        Invoke-WebRequest $download -OutFile $zip
     }
     else{
         "Latest version already downloaded: $zip"


### PR DESCRIPTION
Fix error:
Parameter cannot be processed because the parameter name 'Out' is ambiguous. Possible matches include: -OutFile -OutVariable -OutBuffer. #1735