### PR TITLE
ResourceGovernorWorkloadGroups fix

### DIFF
--- a/DBADash/SQL/SQLResourceGovernorWorkloadGroups.sql
+++ b/DBADash/SQL/SQLResourceGovernorWorkloadGroups.sql
@@ -5,7 +5,7 @@ SELECT  SYSUTCDATETIME() AS SnapshotDate,
         WG.name,
         WG.pool_id,
         P.name as pool_name,
-        WG.external_pool_id,
+        ' + CASE WHEN COLUMNPROPERTY(OBJECT_ID('sys.dm_resource_governor_workload_groups'),'external_pool_id','ColumnID') IS NULL THEN 'CAST(NULL AS INT) AS external_pool_id,' ELSE 'WG.external_pool_id,' END + '
         TODATETIMEOFFSET(WG.statistics_start_time, DATENAME(TzOffset, SYSDATETIMEOFFSET())) AS statistics_start_time,
         WG.total_request_count,
         WG.total_queued_request_count,

--- a/DBADashDB/dbo/Stored Procedures/ResourceGovernorWorkloadGroups_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/ResourceGovernorWorkloadGroups_Upd.sql
@@ -60,7 +60,7 @@ BEGIN
 	FROM dbo.ResourceGovernorWorkloadGroups WG
 	JOIN dbo.Instances I ON WG.InstanceID = I.InstanceID
 	JOIN @ResourceGovernorWorkloadGroups T ON WG.name = T.name 
-												AND T.statistics_start_time >= WG.statistics_start_time 
+												AND T.statistics_start_time = WG.statistics_start_time 
 	WHERE DATEDIFF_BIG(ms,WG.SnapshotDate,T.SnapshotDate) BETWEEN 0 AND 14400000 /* 4 hours in ms.  Skip recording if the gap between collections is too large. */
 	AND I.InstanceID = @InstanceID
 	


### PR DESCRIPTION
Fix collection for older SQL instances that don't have external_pool_id column (older than 2016). Should only update metrics if statistics_start_time matches, otherwise we might get a negative diff.