### PR TITLE
Add BackupFreshness and BackupChainRisk alert rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "dotnet.defaultSolution": "DBADash.CLI.slnf",
+  "dotnetAcquisitionExtension.existingDotnetPath": [
+    {
+      "extensionId": "ms-dotnettools.csdevkit",
+      "path": "/Users/golde/.dotnet/dotnet"
+    },
+    {
+      "extensionId": "ms-dotnettools.csharp",
+      "path": "/Users/golde/.dotnet/dotnet"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/DBADash.CLI.slnf",
+        "--no-restore",
+        "-v",
+        "minimal"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
+    }
+  ]
+}

--- a/DBADash.CLI.slnf
+++ b/DBADash.CLI.slnf
@@ -1,0 +1,14 @@
+{
+  "solution": {
+    "path": "DBADash.sln",
+    "projects": [
+      "DBADash.Test/DBADash.Test.csproj",
+      "DBADash/DBADash.csproj",
+      "DBADashConfig/DBADashConfig.csproj",
+      "DBADashGUI/DBADashGUI.csproj",
+      "DBADashService/DBADashService.csproj",
+      "DBADashServiceConfig/ServiceConfigTool.csproj",
+      "DBADashSharedGUI/DBADashSharedGUI.csproj"
+    ]
+  }
+}

--- a/DBADashDB/Alert/Procedures/Alerts_Upd.sql
+++ b/DBADashDB/Alert/Procedures/Alerts_Upd.sql
@@ -34,6 +34,8 @@ EXEC Alert.CPUAlert_Upd
 EXEC Alert.WaitAlert_Upd
 EXEC Alert.CounterAlert_Upd
 EXEC Alert.AGAlert_Upd
+EXEC Alert.BackupChainRiskAlert_Upd
+EXEC Alert.BackupFreshnessAlert_Upd
 EXEC Alert.DriveSpaceAlert_Upd
 EXEC Alert.CollectionDatesAlert_Upd
 EXEC Alert.AgentJobAlert_Upd

--- a/DBADashDB/Alert/Procedures/BackupChainRiskAlert_Upd.sql
+++ b/DBADashDB/Alert/Procedures/BackupChainRiskAlert_Upd.sql
@@ -1,0 +1,115 @@
+CREATE PROC Alert.BackupChainRiskAlert_Upd
+AS
+SET NOCOUNT ON
+DECLARE @Type VARCHAR(50) = 'BackupChainRisk'
+
+IF NOT EXISTS(
+    SELECT 1
+    FROM Alert.Rules
+    WHERE Type = @Type
+)
+BEGIN
+    PRINT CONCAT('No rules of type ', @Type, ' to process')
+    RETURN;
+END
+PRINT CONCAT('Processing alerts of type ', @Type)
+
+CREATE TABLE #BackupChainApplicable(
+    InstanceID INT NOT NULL,
+    Priority TINYINT NOT NULL,
+    DatabaseName NVARCHAR(128) COLLATE DATABASE_DEFAULT NULL,
+    ExcludedDatabaseName NVARCHAR(128) COLLATE DATABASE_DEFAULT NULL,
+    MinimumDatabaseAgeMins INT NULL,
+    ThresholdMins INT NOT NULL,
+    AlertKeyTemplate NVARCHAR(128) COLLATE DATABASE_DEFAULT NOT NULL,
+    RuleID INT NOT NULL
+)
+
+INSERT INTO #BackupChainApplicable(
+    InstanceID,
+    Priority,
+    DatabaseName,
+    ExcludedDatabaseName,
+    MinimumDatabaseAgeMins,
+    ThresholdMins,
+    AlertKeyTemplate,
+    RuleID
+)
+SELECT I.InstanceID,
+       R.Priority,
+       NULLIF(JSON_VALUE(R.Details, '$.DatabaseName'), '') AS DatabaseName,
+       NULLIF(JSON_VALUE(R.Details, '$.ExcludedDatabaseName'), '') AS ExcludedDatabaseName,
+       TRY_CAST(JSON_VALUE(R.Details, '$.MinimumDatabaseAgeMins') AS INT) AS MinimumDatabaseAgeMins,
+       TRY_CAST(R.Threshold AS INT) AS ThresholdMins,
+       R.AlertKey,
+       R.RuleID
+FROM Alert.Rules R
+CROSS APPLY Alert.ApplicableInstances_Get(R.ApplyToTagID, R.ApplyToInstanceID, R.AlertKey, R.ApplyToHidden) I
+WHERE R.Type = @Type
+AND R.IsActive = 1
+AND TRY_CAST(R.Threshold AS INT) IS NOT NULL
+
+DECLARE @AlertDetails Alert.AlertDetails
+
+;WITH BackupData AS (
+    SELECT BS.InstanceID,
+           BS.DatabaseID,
+           BS.name,
+           BS.recovery_model_desc,
+           BS.create_date_utc,
+           BS.LastFull,
+           BS.LastLog,
+           A.Priority,
+           A.ThresholdMins,
+           A.AlertKeyTemplate,
+           A.RuleID
+    FROM #BackupChainApplicable A
+    JOIN dbo.BackupStatus BS ON BS.InstanceID = A.InstanceID
+    WHERE (BS.name LIKE A.DatabaseName OR A.DatabaseName IS NULL)
+    AND NOT (BS.name LIKE A.ExcludedDatabaseName AND A.ExcludedDatabaseName IS NOT NULL)
+    AND (A.MinimumDatabaseAgeMins IS NULL OR BS.create_date_utc <= DATEADD(MINUTE, -A.MinimumDatabaseAgeMins, GETUTCDATE()))
+    AND BS.recovery_model IN (1,2)
+    AND BS.FullBackupExcludedReason IS NULL
+    AND BS.LogBackupExcludedReason IS NULL
+), RiskData AS (
+    SELECT BD.InstanceID,
+           BD.DatabaseID,
+           BD.name,
+           BD.recovery_model_desc,
+           BD.Priority,
+           BD.ThresholdMins,
+           BD.LastFull,
+           BD.LastLog,
+           BD.AlertKeyTemplate,
+           BD.RuleID,
+           DATEDIFF(MINUTE, BD.LastLog, GETUTCDATE()) AS LogBackupAgeMins,
+           CASE
+               WHEN BD.LastFull IS NULL THEN 'NoFullBackup'
+               WHEN BD.LastLog IS NULL THEN 'NoLogBackup'
+               WHEN BD.LastLog < BD.LastFull THEN 'LogChainNotStartedAfterFull'
+               WHEN DATEDIFF(MINUTE, BD.LastLog, GETUTCDATE()) >= BD.ThresholdMins THEN 'LogBackupTooOld'
+               ELSE NULL
+           END AS RiskType
+    FROM BackupData BD
+)
+INSERT INTO @AlertDetails(
+    InstanceID,
+    Priority,
+    Message,
+    AlertKey,
+    RuleID
+)
+SELECT RD.InstanceID,
+       RD.Priority,
+       CASE RD.RiskType
+           WHEN 'NoFullBackup' THEN CONCAT(RD.name, ' is in ', RD.recovery_model_desc, ' recovery but has no full backup, so a valid log backup chain cannot exist.')
+           WHEN 'NoLogBackup' THEN CONCAT(RD.name, ' is in ', RD.recovery_model_desc, ' recovery and has a full backup, but no log backup was found.')
+           WHEN 'LogChainNotStartedAfterFull' THEN CONCAT(RD.name, ' has a newer full backup than log backup. Last full backup: ', CONVERT(VARCHAR(19), RD.LastFull, 120), ' UTC. Last log backup: ', CONVERT(VARCHAR(19), RD.LastLog, 120), ' UTC.')
+           WHEN 'LogBackupTooOld' THEN CONCAT(RD.name, ' is in ', RD.recovery_model_desc, ' recovery and the last log backup was ', FORMAT(RD.LogBackupAgeMins, 'N0'), ' minutes ago. Threshold: ', FORMAT(RD.ThresholdMins, 'N0'), ' minutes.')
+       END,
+       LEFT(REPLACE(RD.AlertKeyTemplate, '{DatabaseName}', RD.name), 128),
+       RD.RuleID
+FROM RiskData RD
+WHERE RD.RiskType IS NOT NULL
+
+EXEC Alert.ActiveAlerts_Upd @AlertDetails = @AlertDetails, @AlertType = @Type

--- a/DBADashDB/Alert/Procedures/BackupFreshnessAlert_Upd.sql
+++ b/DBADashDB/Alert/Procedures/BackupFreshnessAlert_Upd.sql
@@ -1,0 +1,131 @@
+CREATE PROC Alert.BackupFreshnessAlert_Upd
+AS
+SET NOCOUNT ON
+DECLARE @Type VARCHAR(50) = 'BackupFreshness'
+
+/* Check if we have any rules to process */
+IF NOT EXISTS(
+    SELECT 1
+    FROM Alert.Rules
+    WHERE Type = @Type
+)
+BEGIN
+    PRINT CONCAT('No rules of type ', @Type, ' to process')
+    RETURN;
+END
+PRINT CONCAT('Processing alerts of type ', @Type)
+
+CREATE TABLE #BackupFreshnessApplicable(
+    InstanceID INT NOT NULL,
+    Priority TINYINT NOT NULL,
+    BackupType CHAR(1) NOT NULL,
+    DatabaseName NVARCHAR(128) COLLATE DATABASE_DEFAULT NULL,
+    ExcludedDatabaseName NVARCHAR(128) COLLATE DATABASE_DEFAULT NULL,
+    MinimumDatabaseAgeMins INT NULL,
+    ThresholdMins INT NOT NULL,
+    AlertKeyTemplate NVARCHAR(128) COLLATE DATABASE_DEFAULT NOT NULL,
+    RuleID INT NOT NULL
+)
+
+/* Get rules and the instances they apply to */
+INSERT INTO #BackupFreshnessApplicable(
+    InstanceID,
+    Priority,
+    BackupType,
+    DatabaseName,
+    ExcludedDatabaseName,
+    MinimumDatabaseAgeMins,
+    ThresholdMins,
+    AlertKeyTemplate,
+    RuleID
+)
+SELECT I.InstanceID,
+       R.Priority,
+       CASE UPPER(JSON_VALUE(R.Details, '$.BackupType'))
+            WHEN 'FULL' THEN 'D'
+            WHEN 'DIFF' THEN 'I'
+            WHEN 'LOG' THEN 'L'
+       END AS BackupType,
+       NULLIF(JSON_VALUE(R.Details, '$.DatabaseName'), '') AS DatabaseName,
+       NULLIF(JSON_VALUE(R.Details, '$.ExcludedDatabaseName'), '') AS ExcludedDatabaseName,
+       TRY_CAST(JSON_VALUE(R.Details, '$.MinimumDatabaseAgeMins') AS INT) AS MinimumDatabaseAgeMins,
+       TRY_CAST(R.Threshold AS INT) AS ThresholdMins,
+       R.AlertKey,
+       R.RuleID
+FROM Alert.Rules R
+CROSS APPLY Alert.ApplicableInstances_Get(R.ApplyToTagID, R.ApplyToInstanceID, R.AlertKey, R.ApplyToHidden) I
+WHERE R.Type = @Type
+AND R.IsActive = 1
+AND TRY_CAST(R.Threshold AS INT) IS NOT NULL
+AND UPPER(JSON_VALUE(R.Details, '$.BackupType')) IN ('FULL', 'DIFF', 'LOG')
+
+DECLARE @AlertDetails Alert.AlertDetails
+
+;WITH BackupData AS (
+    SELECT BS.InstanceID,
+           BS.DatabaseID,
+           BS.name,
+           BS.create_date_utc,
+           CASE A.BackupType
+                WHEN 'D' THEN BS.LastFull
+                WHEN 'I' THEN BS.LastDiff
+                WHEN 'L' THEN BS.LastLog
+           END AS LastBackupDateUTC,
+           CASE A.BackupType
+                WHEN 'D' THEN 'Full'
+                WHEN 'I' THEN 'Diff'
+                WHEN 'L' THEN 'Log'
+           END AS BackupTypeName,
+           A.Priority,
+           A.MinimumDatabaseAgeMins,
+           A.ThresholdMins,
+           A.AlertKeyTemplate,
+           A.RuleID
+    FROM #BackupFreshnessApplicable A
+    JOIN dbo.BackupStatus BS ON BS.InstanceID = A.InstanceID
+    WHERE (BS.name LIKE A.DatabaseName OR A.DatabaseName IS NULL)
+    AND NOT (BS.name LIKE A.ExcludedDatabaseName AND A.ExcludedDatabaseName IS NOT NULL)
+    AND (A.MinimumDatabaseAgeMins IS NULL OR BS.create_date_utc <= DATEADD(MINUTE, -A.MinimumDatabaseAgeMins, GETUTCDATE()))
+    AND (
+            (A.BackupType = 'D' AND BS.FullBackupExcludedReason IS NULL)
+            OR (A.BackupType = 'I' AND BS.DiffBackupExcludedReason IS NULL)
+            OR (A.BackupType = 'L' AND BS.LogBackupExcludedReason IS NULL)
+        )
+), ExceededThreshold AS (
+    SELECT BD.InstanceID,
+           BD.DatabaseID,
+           BD.name,
+           BD.Priority,
+           BD.ThresholdMins,
+           BD.LastBackupDateUTC,
+           BD.BackupTypeName,
+           BD.AlertKeyTemplate,
+           BD.RuleID,
+           DATEDIFF(MINUTE, BD.LastBackupDateUTC, GETUTCDATE()) AS BackupAgeMins
+    FROM BackupData BD
+    WHERE BD.LastBackupDateUTC IS NULL
+       OR DATEDIFF(MINUTE, BD.LastBackupDateUTC, GETUTCDATE()) >= BD.ThresholdMins
+)
+INSERT INTO @AlertDetails(
+    InstanceID,
+    Priority,
+    Message,
+    AlertKey,
+    RuleID
+)
+SELECT ET.InstanceID,
+       ET.Priority,
+       CASE
+           WHEN ET.LastBackupDateUTC IS NULL THEN CONCAT('No ', LOWER(ET.BackupTypeName), ' backup found for ', ET.name, '. Threshold: ', FORMAT(ET.ThresholdMins, 'N0'), ' minutes.')
+           ELSE CONCAT(
+                'Last ', LOWER(ET.BackupTypeName), ' backup for ', ET.name,
+                ' was ', FORMAT(ET.BackupAgeMins, 'N0'), ' minutes ago at ',
+                CONVERT(VARCHAR(19), ET.LastBackupDateUTC, 120),
+                ' UTC. Threshold: ', FORMAT(ET.ThresholdMins, 'N0'), ' minutes.'
+           )
+       END,
+       LEFT(REPLACE(REPLACE(ET.AlertKeyTemplate, '{DatabaseName}', ET.name), '{BackupType}', ET.BackupTypeName), 128),
+       ET.RuleID
+FROM ExceededThreshold ET
+
+EXEC Alert.ActiveAlerts_Upd @AlertDetails = @AlertDetails, @AlertType = @Type

--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -775,6 +775,8 @@
     <Build Include="Alert\Procedures\BlackoutPeriod_Del.sql" />
     <Build Include="Alert\Functions\ApplicableInstances_Get.sql" />
     <Build Include="Alert\Procedures\AGAlert_Upd.sql" />
+    <Build Include="Alert\Procedures\BackupChainRiskAlert_Upd.sql" />
+    <Build Include="Alert\Procedures\BackupFreshnessAlert_Upd.sql" />
     <Build Include="Alert\Procedures\ActiveAlerts_Get.sql" />
     <Build Include="Alert\Procedures\ActiveAlertsAck_Upd.sql" />
     <Build Include="Alert\Procedures\NewAlerts_Get.sql" />

--- a/DBADashGUI/DBADashAlerts/ActiveAlerts.cs
+++ b/DBADashGUI/DBADashAlerts/ActiveAlerts.cs
@@ -265,6 +265,8 @@ namespace DBADashGUI.DBADashAlerts
                     case "InstanceDisplayName":
                         var tab = alertType switch
                         {
+                            AlertRuleBase.RuleTypes.BackupChainRisk => Tabs.Backups,
+                            AlertRuleBase.RuleTypes.BackupFreshness => Tabs.Backups,
                             AlertRuleBase.RuleTypes.DriveSpace => Tabs.Drives,
                             AlertRuleBase.RuleTypes.AGHealth => Tabs.AG,
                             AlertRuleBase.RuleTypes.Counter => Tabs.Metrics,

--- a/DBADashGUI/DBADashAlerts/Rules/AlertRuleBase.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/AlertRuleBase.cs
@@ -23,6 +23,8 @@ namespace DBADashGUI.DBADashAlerts.Rules
         public enum RuleTypes
         {
             AGHealth,
+            BackupChainRisk,
+            BackupFreshness,
             CollectionDates,
             Counter,
             CPU,
@@ -43,6 +45,8 @@ namespace DBADashGUI.DBADashAlerts.Rules
                 RuleTypes.Wait => new WaitRule(),
                 RuleTypes.Counter => new CounterRule(),
                 RuleTypes.AGHealth => new AGHealthRule(),
+                RuleTypes.BackupChainRisk => new BackupChainRiskRule(),
+                RuleTypes.BackupFreshness => new BackupFreshnessRule(),
                 RuleTypes.DatabaseStatus => new DatabaseStatusRule(),
                 RuleTypes.DriveSpace => new DriveSpaceRule(),
                 RuleTypes.CollectionDates => new CollectionDatesRule(),
@@ -223,6 +227,8 @@ namespace DBADashGUI.DBADashAlerts.Rules
                 RuleTypes.CPU => new CPURule(),
                 RuleTypes.Wait => string.IsNullOrEmpty(details) ? new WaitRule() : JsonConvert.DeserializeObject<WaitRule>(details),
                 RuleTypes.AGHealth => new AGHealthRule(),
+                RuleTypes.BackupChainRisk => string.IsNullOrEmpty(details) ? new BackupChainRiskRule() : JsonConvert.DeserializeObject<BackupChainRiskRule>(details),
+                RuleTypes.BackupFreshness => string.IsNullOrEmpty(details) ? new BackupFreshnessRule() : JsonConvert.DeserializeObject<BackupFreshnessRule>(details),
                 RuleTypes.Counter => string.IsNullOrEmpty(details) ? new CounterRule() : JsonConvert.DeserializeObject<CounterRule>(details),
                 RuleTypes.DatabaseStatus => string.IsNullOrEmpty(details) ? new DatabaseStatusRule() : JsonConvert.DeserializeObject<DatabaseStatusRule>(details),
                 RuleTypes.DriveSpace => string.IsNullOrEmpty(details) ? new DriveSpaceRule() : JsonConvert.DeserializeObject<DriveSpaceRule>(details),

--- a/DBADashGUI/DBADashAlerts/Rules/BackupChainRiskRule.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/BackupChainRiskRule.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel;
+
+namespace DBADashGUI.DBADashAlerts.Rules
+{
+    internal class BackupChainRiskRule : AlertRuleBase
+    {
+        public override RuleTypes RuleType => RuleTypes.BackupChainRisk;
+
+        [Description("Database name to apply to. Supports LIKE syntax. Leave blank to apply to all eligible databases.")]
+        [DisplayName("Database Name"), Category("Filters")]
+        public string DatabaseName { get; set; }
+
+        [Description("Database name pattern to exclude. Supports LIKE syntax. Leave blank for no exclusions.")]
+        [DisplayName("Exclude Database Name"), Category("Filters")]
+        public string ExcludedDatabaseName { get; set; }
+
+        [Description("Suppress alerts for databases created more recently than this many minutes ago. Leave blank to disable.")]
+        [DisplayName("Minimum Database Age (Mins)"), Category("Filters")]
+        public int? MinimumDatabaseAgeMins { get; set; }
+
+        public override string AlertKey => "Backup Chain Risk: {DatabaseName}";
+
+        [Description("Maximum allowed age in minutes for the last log backup before the database is considered at risk.")]
+        public override decimal? Threshold { get; set; }
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Browsable(false)]
+        public override int? EvaluationPeriodMins => null;
+
+        public override (bool isValid, string message) Validate()
+        {
+            if (Threshold is not >= 0M)
+            {
+                return (false, "Threshold must be >=0");
+            }
+
+            if (MinimumDatabaseAgeMins is < 0)
+            {
+                return (false, "Minimum Database Age (Mins) must be >=0");
+            }
+
+            return (true, string.Empty);
+        }
+    }
+}

--- a/DBADashGUI/DBADashAlerts/Rules/BackupFreshnessRule.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/BackupFreshnessRule.cs
@@ -1,0 +1,59 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.ComponentModel;
+
+namespace DBADashGUI.DBADashAlerts.Rules
+{
+    internal class BackupFreshnessRule : AlertRuleBase
+    {
+        public enum BackupTypes
+        {
+            Full,
+            Diff,
+            Log
+        }
+
+        public override RuleTypes RuleType => RuleTypes.BackupFreshness;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        [DisplayName("Backup Type")]
+        [Description("The backup type to monitor for freshness.")]
+        public BackupTypes BackupType { get; set; } = BackupTypes.Full;
+
+        [Description("Database name to apply to. Supports LIKE syntax. Leave blank to apply to all eligible databases.")]
+        [DisplayName("Database Name"), Category("Filters")]
+        public string DatabaseName { get; set; }
+
+        [Description("Database name pattern to exclude. Supports LIKE syntax. Leave blank for no exclusions.")]
+        [DisplayName("Exclude Database Name"), Category("Filters")]
+        public string ExcludedDatabaseName { get; set; }
+
+        [Description("Suppress alerts for databases created more recently than this many minutes ago. Leave blank to disable.")]
+        [DisplayName("Minimum Database Age (Mins)"), Category("Filters")]
+        public int? MinimumDatabaseAgeMins { get; set; }
+
+        public override string AlertKey => "Backup " + BackupType + ": {DatabaseName}";
+
+        [Description("Threshold in minutes since the last successful backup of the selected type.")]
+        public override decimal? Threshold { get; set; }
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Browsable(false)]
+        public override int? EvaluationPeriodMins => null;
+
+        public override (bool isValid, string message) Validate()
+        {
+            if (Threshold is not >= 0M)
+            {
+                return (false, "Threshold must be >=0");
+            }
+
+            if (MinimumDatabaseAgeMins is < 0)
+            {
+                return (false, "Minimum Database Age (Mins) must be >=0");
+            }
+
+            return (true, string.Empty);
+        }
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+</Project>

--- a/Docs/developer.md
+++ b/Docs/developer.md
@@ -56,3 +56,19 @@ DBA Dash can already collect [custom performance counters](OSPerformanceCounters
       - The Script.PostDeployment1.sql file has an insert into CollectionDatesThresholds that you might want to modify.
 * The DBImporter.cs file has the code used to import the data.  Add {MyCollection} to the tables string array.  This will ensure that *{MyCollection}_Upd* gets called for your new collection.
 * You might also need to consider data retention.  Some collections use partition switching to efficiently remove old data.  The service calls PurgeData to remove old partitions.
+
+## Adding a new alert rule
+
+DBA Dash alert rules are implemented across the GUI rule model and the repository database alert procedures.
+
+* Add a new GUI rule class under *DBADashGUI/DBADashAlerts/Rules*
+* Add the new rule type to the *RuleTypes* enum and wire it into *CreateRule* and *GetRule* in *AlertRuleBase.cs*
+* Add a new stored procedure under *DBADashDB/Alert/Procedures* that:
+  - Reads applicable rows from *Alert.Rules*
+  - Uses *Alert.ApplicableInstances_Get* to respect instance filters and blackout handling
+  - Populates *Alert.AlertDetails*
+  - Calls *Alert.ActiveAlerts_Upd*
+* Register the procedure in *DBADashDB.sqlproj* and *Alert/Procedures/Alerts_Upd.sql*
+* If useful, map the alert type to a tab in *DBADashGUI/DBADashAlerts/ActiveAlerts.cs* so clicking the instance can navigate to a relevant view
+
+The *BackupFreshness* and *BackupChainRisk* alert rules are recent examples of this pattern.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds two new first-class DBA Dash alert rules for backup monitoring:

- `BackupFreshness`
  - alerts when the last `Full`, `Diff`, or `Log` backup exceeds a configured threshold
- `BackupChainRisk`
  - alerts when a `FULL`/`BULK_LOGGED` database appears to have an unsafe log backup chain

## Included changes

- Added GUI rule classes for:
  - `BackupFreshness`
  - `BackupChainRisk`
- Added rule type wiring in `AlertRuleBase`
- Added navigation mapping in `ActiveAlerts` so these alerts open the Backups tab
- Added repository alert procedures:
  - `Alert.BackupFreshnessAlert_Upd`
  - `Alert.BackupChainRiskAlert_Upd`
- Registered both procedures in:
  - `Alert.Alerts_Upd`
  - `DBADashDB.sqlproj`
- Added a short developer note to `Docs/developer.md` describing how new alert rules are added

## Rule behavior

### BackupFreshness
Supports:
- backup type: `Full`, `Diff`, or `Log`
- threshold in minutes
- database include pattern
- database exclude pattern
- minimum database age in minutes

### BackupChainRisk
Evaluates `FULL` and `BULK_LOGGED` databases and alerts when:
- no full backup exists
- a full backup exists but no log backup exists
- the last log backup is older than the last full backup
- the last log backup age exceeds the configured threshold

Also supports:
- database include pattern
- database exclude pattern
- minimum database age in minutes

## Notes

- Both rules use `dbo.BackupStatus` as their backup-state source
- Hidden-instance behavior follows the existing `ApplyToHidden` path via `Alert.ApplicableInstances_Get`
- I removed `ShowInSummary` filtering from the new procedures so hidden-instance targeting remains consistent

## Validation

- `dotnet build DBADash/DBADash.csproj -nologo` succeeded
- GUI/WinForms build was not fully verified in this environment
- SQL objects were reviewed but not deployed against a live repository DB in this environment
