### PR TITLE
Alert - String or binary data would be truncated fix #2

### DIFF
--- a/DBADashDB/Alert/Procedures/AgentJobAlert_Upd.sql
+++ b/DBADashDB/Alert/Procedures/AgentJobAlert_Upd.sql
@@ -60,8 +60,8 @@ INSERT INTO #AgentJobApplicable(
 )
 SELECT I.InstanceID,
 		R.Priority,
-		NULLIF(JSON_VALUE(R.Details,'$.Category'),'') AS Category,
-		NULLIF(JSON_VALUE(R.Details,'$.JobName'),'') AS JobName,
+		LEFT(NULLIF(JSON_VALUE(R.Details,'$.Category'),''),128) AS Category,
+		LEFT(NULLIF(JSON_VALUE(R.Details,'$.JobName'),''),128) AS JobName,
 		R.RuleID
 FROM Alert.Rules R
 CROSS APPLY Alert.ApplicableInstances_Get(R.ApplyToTagID,R.ApplyToInstanceID,R.AlertKey,R.ApplyToHidden) I

--- a/DBADashGUI/DBADashAlerts/Rules/AgentJobRule.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/AgentJobRule.cs
@@ -9,6 +9,7 @@ namespace DBADashGUI.DBADashAlerts.Rules
         public override RuleTypes RuleType => RuleTypes.AgentJob;
 
         [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
         [Browsable(false)]
         public override decimal? Threshold => null;
 
@@ -25,6 +26,16 @@ namespace DBADashGUI.DBADashAlerts.Rules
 
         public override (bool isValid, string message) Validate()
         {
+            if (!string.IsNullOrEmpty(JobName) && JobName.Length > 128)
+            {
+                return (false, "Job Name cannot be longer than 128 characters.");
+            }
+
+            if (!string.IsNullOrEmpty(Category) && Category.Length > 128)
+            {
+                return (false, "Category cannot be longer than 128 characters.");
+            }
+
             return (true, string.Empty);
         }
     }


### PR DESCRIPTION
User configured alert rules don't impose any length restrictions on job name or category which can lead to "String or binary data would be truncated" errors. #1828