### PR TITLE
Add separate recipient for resolved alert emails

### DIFF
--- a/DBADash.Test/NotificationChannelTest.cs
+++ b/DBADash.Test/NotificationChannelTest.cs
@@ -208,7 +208,7 @@ namespace DBADashConfig.Test
         }
 
         [TestMethod]
-        public void SendNotification_UnresolvedAlert_UsesToEmail()
+        public void GetRecipientEmail_UnresolvedAlert_UsesToEmail()
         {
             // Arrange
             var testAlert = CreateTestAlert(isResolved: false);
@@ -222,7 +222,7 @@ namespace DBADashConfig.Test
         }
 
         [TestMethod]
-        public void SendNotification_ResolvedAlert_UsesResolutionToEmail()
+        public void GetRecipientEmail_ResolvedAlert_UsesResolutionToEmail()
         {
             // Arrange
             var testAlert = CreateTestAlert(isResolved: true);
@@ -236,7 +236,7 @@ namespace DBADashConfig.Test
         }
 
         [TestMethod]
-        public void SendNotification_ResolvedAlert_FallsBackToToEmail_WhenResolutionToEmailNotConfigured()
+        public void GetRecipientEmail_ResolvedAlert_FallsBackToToEmail_WhenResolutionToEmailNotConfigured()
         {
             // Arrange
             var testAlert = CreateTestAlert(isResolved: true);
@@ -250,7 +250,7 @@ namespace DBADashConfig.Test
         }
 
         [TestMethod]
-        public void SendNotification_ResolvedAlert_FallsBackToToEmail_WhenResolutionToEmailIsEmpty()
+        public void GetRecipientEmail_ResolvedAlert_FallsBackToToEmail_WhenResolutionToEmailIsEmpty()
         {
             // Arrange
             var testAlert = CreateTestAlert(isResolved: true);

--- a/DBADash.Test/NotificationChannelTest.cs
+++ b/DBADash.Test/NotificationChannelTest.cs
@@ -8,25 +8,30 @@ namespace DBADashConfig.Test
     [TestClass]
     public class NotificationChannelTest
     {
+        // Test data constants
+        private static readonly DateTime DefaultTriggerDate = new DateTime(2026, 2, 9, 14, 30, 45);
+        private const string DefaultAlertName = "TEST_ALERT";
+        private const string DefaultMessage = "Test alert message";
+        private const string DefaultConnectionId = "TestServer";
+        private const string DefaultInstanceDisplayName = "TestServer";
+        private const string DefaultAlertType = "Test";
+
+        private const string DefaultChannelName = "TestChannel";
+        private const string DefaultSmtpHost = "smtp.example.com";
+        private const int DefaultSmtpPort = 587;
+        private const string DefaultFromEmail = "alerts@example.com";
+        private const string DefaultFromName = "DBADash";
+        private const string DefaultToEmail = "to@example.com";
+        private const string DefaultResolutionToEmail = "resolved@example.com";
+
         [TestMethod]
         public void TestTriggerDatePlaceholder()
         {
             // Arrange
-            var testAlert = new Alert
-            {
-                AlertID = 1,
-                AlertName = "TEST_ALERT",
-                Priority = Alert.Priorities.High1,
-                TriggerDate = new DateTime(2026, 2, 9, 14, 30, 45),
-                Message = "Test alert message",
-                ConnectionID = "TestServer",
-                InstanceDisplayName = "TestServer",
-                AlertType = "Test"
-            };
-
+            var testAlert = CreateTestAlert();
             var emailChannel = new EmailNotificationChannel
             {
-                ChannelName = "TestChannel"
+                ChannelName = DefaultChannelName
             };
 
             var template = "Alert triggered at {TriggerDate} on {Instance}";
@@ -35,28 +40,17 @@ namespace DBADashConfig.Test
             var result = emailChannel.ReplacePlaceholders(testAlert, template);
 
             // Assert
-            Assert.AreEqual($"Alert triggered at {testAlert.TriggerDate.ToUtcDateTimeOffset().ToStandardString()} on TestServer", result);
+            Assert.AreEqual($"Alert triggered at {testAlert.TriggerDate.ToUtcDateTimeOffset().ToStandardString()} on {DefaultInstanceDisplayName}", result);
         }
 
         [TestMethod]
         public void TestTriggerDatePlaceholderWithTimeZone()
         {
             // Arrange
-            var testAlert = new Alert
-            {
-                AlertID = 1,
-                AlertName = "TEST_ALERT",
-                Priority = Alert.Priorities.High1,
-                TriggerDate = new DateTime(2026, 2, 9, 14, 30, 45),
-                Message = "Test alert message",
-                ConnectionID = "TestServer",
-                InstanceDisplayName = "TestServer",
-                AlertType = "Test"
-            };
-
+            var testAlert = CreateTestAlert();
             var emailChannel = new EmailNotificationChannel
             {
-                ChannelName = "TestChannel"
+                ChannelName = DefaultChannelName
             };
 
             var template = "Alert triggered at {TriggerDate:America/New_York} on {Instance}";
@@ -66,28 +60,17 @@ namespace DBADashConfig.Test
 
             var convertedDate = TimeZoneInfo.ConvertTime(testAlert.TriggerDate.ToUtcDateTimeOffset(), TimeZoneInfo.FindSystemTimeZoneById("America/New_York"));
             // Assert
-            Assert.AreEqual($"Alert triggered at {convertedDate.ToStandardString()} on TestServer", result);
+            Assert.AreEqual($"Alert triggered at {convertedDate.ToStandardString()} on {DefaultInstanceDisplayName}", result);
         }
 
         [TestMethod]
         public void TestTriggerDatePlaceholderCaseInsensitive()
         {
             // Arrange
-            var testAlert = new Alert
-            {
-                AlertID = 1,
-                AlertName = "TEST_ALERT",
-                Priority = Alert.Priorities.Medium1,
-                TriggerDate = new DateTime(2026, 2, 9, 10, 15, 30),
-                Message = "Test message",
-                ConnectionID = "Server1",
-                InstanceDisplayName = "Server1",
-                AlertType = "Test"
-            };
-
+            var testAlert = CreateTestAlert(priority: Alert.Priorities.Medium1, triggerDate: new DateTime(2026, 2, 9, 10, 15, 30), message: "Test message", connectionId: "Server1", instanceDisplayName: "Server1");
             var emailChannel = new EmailNotificationChannel
             {
-                ChannelName = "TestChannel"
+                ChannelName = DefaultChannelName
             };
 
             // Test various case combinations
@@ -111,17 +94,14 @@ namespace DBADashConfig.Test
         public void TestAllPlaceholdersIncludingTriggerDate()
         {
             // Arrange
-            var testAlert = new Alert
-            {
-                AlertID = 1,
-                AlertName = "CPU_HIGH",
-                Priority = Alert.Priorities.Critical,
-                TriggerDate = new DateTime(2026, 2, 9, 16, 45, 0),
-                Message = "CPU usage is 95%",
-                ConnectionID = "PROD-SQL-01",
-                InstanceDisplayName = "Production SQL Server",
-                AlertType = "Performance"
-            };
+            var testAlert = CreateTestAlert(
+                alertName: "CPU_HIGH",
+                priority: Alert.Priorities.Critical,
+                triggerDate: new DateTime(2026, 2, 9, 16, 45, 0),
+                message: "CPU usage is 95%",
+                connectionId: "PROD-SQL-01",
+                instanceDisplayName: "Production SQL Server",
+                alertType: "Performance");
 
             var emailChannel = new EmailNotificationChannel
             {
@@ -180,6 +160,107 @@ namespace DBADashConfig.Test
             // When IsHTML is false ensure the returned template is not HTML
             Assert.IsFalse(string.IsNullOrWhiteSpace(content), "Template should not be empty");
             Assert.IsFalse(content.ToLowerInvariant().Contains("<html"), "Expected plain-text template, not HTML");
+        }
+
+        private static Alert CreateTestAlert(
+            bool isResolved = false,
+            string alertName = DefaultAlertName,
+            Alert.Priorities priority = Alert.Priorities.High1,
+            DateTime? triggerDate = null,
+            string message = DefaultMessage,
+            string connectionId = DefaultConnectionId,
+            string instanceDisplayName = DefaultInstanceDisplayName,
+            string alertType = DefaultAlertType)
+        {
+            return new Alert
+            {
+                AlertID = 1,
+                AlertName = alertName,
+                Priority = priority,
+                TriggerDate = triggerDate ?? DefaultTriggerDate,
+                Message = message,
+                ConnectionID = connectionId,
+                InstanceDisplayName = instanceDisplayName,
+                AlertType = alertType,
+                IsResolved = isResolved
+            };
+        }
+
+        private static EmailNotificationChannel CreateEmailChannel(
+            string toEmail = DefaultToEmail,
+            string resolutionToEmail = DefaultResolutionToEmail,
+            string channelName = DefaultChannelName,
+            string host = DefaultSmtpHost,
+            int port = DefaultSmtpPort,
+            string fromEmail = DefaultFromEmail,
+            string from = DefaultFromName)
+        {
+            return new EmailNotificationChannel
+            {
+                ChannelName = channelName,
+                Host = host,
+                Port = port,
+                FromEmail = fromEmail,
+                From = from,
+                ToEmail = toEmail,
+                ResolutionToEmail = resolutionToEmail
+            };
+        }
+
+        [TestMethod]
+        public void SendNotification_UnresolvedAlert_UsesToEmail()
+        {
+            // Arrange
+            var testAlert = CreateTestAlert(isResolved: false);
+            var emailChannel = CreateEmailChannel();
+
+            // Act
+            var result = emailChannel.GetRecipientEmail(testAlert);
+
+            // Assert
+            Assert.AreEqual("to@example.com", result, "Unresolved alerts should use ToEmail");
+        }
+
+        [TestMethod]
+        public void SendNotification_ResolvedAlert_UsesResolutionToEmail()
+        {
+            // Arrange
+            var testAlert = CreateTestAlert(isResolved: true);
+            var emailChannel = CreateEmailChannel();
+
+            // Act
+            var result = emailChannel.GetRecipientEmail(testAlert);
+
+            // Assert
+            Assert.AreEqual("resolved@example.com", result, "Resolved alerts should use ResolutionToEmail when configured");
+        }
+
+        [TestMethod]
+        public void SendNotification_ResolvedAlert_FallsBackToToEmail_WhenResolutionToEmailNotConfigured()
+        {
+            // Arrange
+            var testAlert = CreateTestAlert(isResolved: true);
+            var emailChannel = CreateEmailChannel(resolutionToEmail: null);
+
+            // Act
+            var result = emailChannel.GetRecipientEmail(testAlert);
+
+            // Assert
+            Assert.AreEqual("to@example.com", result, "Resolved alerts should fall back to ToEmail when ResolutionToEmail is not configured");
+        }
+
+        [TestMethod]
+        public void SendNotification_ResolvedAlert_FallsBackToToEmail_WhenResolutionToEmailIsEmpty()
+        {
+            // Arrange
+            var testAlert = CreateTestAlert(isResolved: true);
+            var emailChannel = CreateEmailChannel(resolutionToEmail: "   ");
+
+            // Act
+            var result = emailChannel.GetRecipientEmail(testAlert);
+
+            // Assert
+            Assert.AreEqual("to@example.com", result, "Resolved alerts should fall back to ToEmail when ResolutionToEmail is whitespace");
         }
     }
 }

--- a/DBADash/Alert/EmailNotificationChannel.cs
+++ b/DBADash/Alert/EmailNotificationChannel.cs
@@ -64,6 +64,16 @@ namespace DBADash.Alert
         [Category("Email Message"), DisplayName("Is HTML?")]
         public bool IsHTML { get; set; }
 
+        [Category("Email Config")]
+        [DisplayName("Resolution To Email")]
+        [Description("Optional. Email address to send resolved alert notifications to. If blank, uses To Email.")]
+        public string ResolutionToEmail { get; set; }
+
+        [Description("Optional. Name associated with resolution email address. Default to Resolution To Email or channel name.")]
+        [Category("Email Config")]
+        [DisplayName("Resolution To")]
+        public string ResolutionTo { get; set; }
+
         private const string DefaultEmailSubjectTemplate = "{Emoji} {AlertKey} {Action} on {Instance}";
         private const string DefaultEmailMessageTemplate = "{Text}";
 
@@ -83,9 +93,15 @@ namespace DBADash.Alert
 
         protected override async Task InternalSendNotificationAsync(Alert alert, string connectionString)
         {
+            var sendToResolutionRecipient = alert.IsResolved && !string.IsNullOrWhiteSpace(ResolutionToEmail);
+            var recipientEmail = sendToResolutionRecipient ? ResolutionToEmail : ToEmail;
+            var recipientName = sendToResolutionRecipient
+                ? (string.IsNullOrWhiteSpace(ResolutionTo) ? ResolutionToEmail : ResolutionTo)
+                : (string.IsNullOrWhiteSpace(To) ? ChannelName : To);
+
             using var message = new MimeMessage();
             message.From.Add(new MailboxAddress(From, FromEmail));
-            message.To.Add(new MailboxAddress(string.IsNullOrEmpty(To) ? ChannelName : To, ToEmail));
+            message.To.Add(new MailboxAddress(recipientName, recipientEmail));
             message.Subject = ReplacePlaceholders(alert, GetEmailSubjectTemplate());
 
             message.Body = new TextPart(IsHTML ? "html" : "plain")

--- a/DBADash/Alert/EmailNotificationChannel.cs
+++ b/DBADash/Alert/EmailNotificationChannel.cs
@@ -69,7 +69,7 @@ namespace DBADash.Alert
         [Description("Optional. Email address to send resolved alert notifications to. If blank, uses To Email.")]
         public string ResolutionToEmail { get; set; }
 
-        [Description("Optional. Name associated with resolution email address. Default to Resolution To Email or channel name.")]
+        [Description("Optional. Name associated with resolution email address. Defaults to ResolutionToEmail if specified, otherwise defaults to To (which defaults to channel name).")]
         [Category("Email Config")]
         [DisplayName("Resolution To")]
         public string ResolutionTo { get; set; }
@@ -91,10 +91,21 @@ namespace DBADash.Alert
             ? IsHTML ? DefaultHTMLMessageTemplate : DefaultEmailMessageTemplate
             : EmailMessageTemplate;
 
-        protected override async Task InternalSendNotificationAsync(Alert alert, string connectionString)
+        /// <summary>
+        /// Gets the recipient email address based on alert resolution status and configuration.
+        /// </summary>
+        /// <param name="alert">The alert to determine the recipient for</param>
+        /// <returns>The recipient email address</returns>
+        public string GetRecipientEmail(Alert alert)
         {
             var sendToResolutionRecipient = alert.IsResolved && !string.IsNullOrWhiteSpace(ResolutionToEmail);
-            var recipientEmail = sendToResolutionRecipient ? ResolutionToEmail : ToEmail;
+            return sendToResolutionRecipient ? ResolutionToEmail : ToEmail;
+        }
+
+        protected override async Task InternalSendNotificationAsync(Alert alert, string connectionString)
+        {
+            var recipientEmail = GetRecipientEmail(alert);
+            var sendToResolutionRecipient = alert.IsResolved && !string.IsNullOrWhiteSpace(ResolutionToEmail);
             var recipientName = sendToResolutionRecipient
                 ? (string.IsNullOrWhiteSpace(ResolutionTo) ? ResolutionToEmail : ResolutionTo)
                 : (string.IsNullOrWhiteSpace(To) ? ChannelName : To);
@@ -137,6 +148,11 @@ namespace DBADash.Alert
                 {
                     yield return new ValidationResult($"Email templates must contain at least one of the following placeholders: {string.Join(", ", Placeholders)}.  Or leave blank to use the default template.");
                 }
+            }
+
+            if (!string.IsNullOrWhiteSpace(ResolutionTo) && string.IsNullOrWhiteSpace(ResolutionToEmail))
+            {
+                yield return new ValidationResult("ResolutionToEmail is required when ResolutionTo is specified. ResolutionTo will only be used when sending to resolved alert recipients.");
             }
 
             foreach (var validationResult in ValidateBase(validationContext)) yield return validationResult;

--- a/DBADash/Alert/EmailNotificationChannel.cs
+++ b/DBADash/Alert/EmailNotificationChannel.cs
@@ -92,21 +92,30 @@ namespace DBADash.Alert
             : EmailMessageTemplate;
 
         /// <summary>
+        /// Determines whether the resolution recipient should be used for the given alert.
+        /// </summary>
+        /// <param name="alert">The alert to check</param>
+        /// <returns>True if the resolution recipient should be used; otherwise false</returns>
+        private bool ShouldUseResolutionRecipient(Alert alert)
+        {
+            return alert.IsResolved && !string.IsNullOrWhiteSpace(ResolutionToEmail);
+        }
+
+        /// <summary>
         /// Gets the recipient email address based on alert resolution status and configuration.
         /// </summary>
         /// <param name="alert">The alert to determine the recipient for</param>
         /// <returns>The recipient email address</returns>
         public string GetRecipientEmail(Alert alert)
         {
-            var sendToResolutionRecipient = alert.IsResolved && !string.IsNullOrWhiteSpace(ResolutionToEmail);
-            return sendToResolutionRecipient ? ResolutionToEmail : ToEmail;
+            return ShouldUseResolutionRecipient(alert) ? ResolutionToEmail : ToEmail;
         }
 
         protected override async Task InternalSendNotificationAsync(Alert alert, string connectionString)
         {
             var recipientEmail = GetRecipientEmail(alert);
-            var sendToResolutionRecipient = alert.IsResolved && !string.IsNullOrWhiteSpace(ResolutionToEmail);
-            var recipientName = sendToResolutionRecipient
+            var useResolutionRecipient = ShouldUseResolutionRecipient(alert);
+            var recipientName = useResolutionRecipient
                 ? (string.IsNullOrWhiteSpace(ResolutionTo) ? ResolutionToEmail : ResolutionTo)
                 : (string.IsNullOrWhiteSpace(To) ? ChannelName : To);
 

--- a/DBADashServiceConfig/ServiceConfigTool.csproj
+++ b/DBADashServiceConfig/ServiceConfigTool.csproj
@@ -102,6 +102,6 @@
   </ItemGroup>
   <Import Project="..\packages\Microsoft.Data.SqlClient.SNI.3.0.0\build\net46\Microsoft.Data.SqlClient.SNI.targets" Condition="Exists('..\packages\Microsoft.Data.SqlClient.SNI.3.0.0\build\net46\Microsoft.Data.SqlClient.SNI.targets')" />
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell.exe $(ProjectDir)PostBuild.ps1 $(TargetDir)" />
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(ProjectDir)PostBuild.ps1' '$(TargetDir)'&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
**Summary**
As described in Issue #1811.  Adds support for sending resolved alert emails to a different recipient than active/triggered alerts for Email notification channels.

**Problem**
Critical/high alert emails sent to a ticketing system create tickets as expected but resolved-alert emails currently go to the same address and create unnecessary additional tickets.

**Solution**
For EmailNotificationChannel, add optional secondary recipient settings for resolved notifications:
•	Resolution To Email
•	Resolution To

**Behavior:**
•	Active/triggered/acknowledged alerts: continue using To Email / To
•	Resolved alerts: use Resolution To Email / Resolution To when configured
•	Fallback: if resolution recipient is blank, existing primary recipient behavior is unchanged

**Files changed**
•	EmailNotificationChannel.cs
•	Added new optional properties
•	Updated recipient selection logic in InternalSendNotificationAsync(Alert, string)
•	ServiceConfigTool.csproj
•	Fixed post-build PowerShell command quoting for paths with spaces (build reliability)

**Validation**
•	Solution builds successfully in VS 2026
•	New fields are visible in Email channel editor (property grid)
•	Routing logic verified:
•	unresolved -> primary recipient
•	resolved + secondary configured -> secondary recipient

**Backward compatibility**
•	No DB schema changes
•	Existing channel configs remain valid
•	Feature is opt-in via optional fields
