### PR TITLE
Fix missing counters

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/Counters_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/Counters_Get.sql
@@ -9,4 +9,17 @@ WHERE EXISTS(SELECT 1
 			FROM dbo.InstanceCounters IC 
 			WHERE IC.CounterID = C.CounterID
 			AND IC.UpdatedDate>=DATEADD(d,-2,GETUTCDATE())
+			UNION ALL
+			SELECT 1
+			FROM dbo.AzureDBElasticPool P 
+			WHERE C.instance_name = P.elastic_pool_name
+			AND C.CounterType = 3 /* Elastic Pool */
+			AND (P.ValidTo IS NULL OR P.ValidTo >= DATEADD(d,-2,GETUTCDATE()))
+			UNION ALL
+			SELECT 1 
+			FROM dbo.Instances I
+			WHERE I.EngineEdition = 5 /* AzureDB */
+			AND C.CounterType = 4 /* AzureDB */
+			AND I.IsActive = 1
 			)
+ORDER BY object_name,counter_name,instance_name


### PR DESCRIPTION
sys.elastic_pool_resource_stats & sys.dm_db_resource_stats counters were not visible due to the UpdatedDate column not being updated in the InstanceCounters table.

#1816