### PR TITLE
NuGet update

### DIFF
--- a/DBADash.Test/DBADash.Test.csproj
+++ b/DBADash.Test/DBADash.Test.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />

--- a/DBADash/DBADash.csproj
+++ b/DBADash/DBADash.csproj
@@ -114,15 +114,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.32" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.22" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.26" />
-    <PackageReference Include="Azure.Core" Version="1.53.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.4" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.22.1" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.27" />
+    <PackageReference Include="Azure.Core" Version="1.54.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />

--- a/DBADashConfig/DBADashConfig.csproj
+++ b/DBADashConfig/DBADashConfig.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DBADashGUI/DBADashGUI.csproj
+++ b/DBADashGUI/DBADashGUI.csproj
@@ -249,6 +249,7 @@
     <PackageReference Include="DiffPlex.Wpf" Version="1.9.1" />
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WinForms" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.19.0" />

--- a/DBADashService/DBADashService.csproj
+++ b/DBADashService/DBADashService.csproj
@@ -32,16 +32,17 @@
     <ProjectReference Include="..\DBADash\DBADash.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.32" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.22" />
-    <PackageReference Include="Azure.Core" Version="1.53.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.4" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.22.1" />
+    <PackageReference Include="Azure.Core" Version="1.54.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
@@ -70,7 +71,7 @@
     <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="173.8.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.19.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Quartz" Version="3.18.0" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />

--- a/DBADashServiceConfig/ServiceConfigTool.csproj
+++ b/DBADashServiceConfig/ServiceConfigTool.csproj
@@ -51,17 +51,18 @@
     <EmbeddedResource Include="CreateMSA.ps1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="4.0.3.32" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.22" />
-    <PackageReference Include="Azure.Core" Version="1.53.0" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.4" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.22.1" />
+    <PackageReference Include="Azure.Core" Version="1.54.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
     <PackageReference Include="Humanizer" Version="3.0.10" />
-    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.17" />
+    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.18" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
@@ -76,7 +77,7 @@
     <PackageReference Include="Microsoft.SqlServer.Management.SqlParser" Version="173.8.0" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.19.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Quartz" Version="3.18.0" />
+    <PackageReference Include="Quartz" Version="3.18.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
     <PackageReference Include="System.Management.Automation" Version="7.6.1" />

--- a/DBADashSharedGUI/DBADashSharedGUI.csproj
+++ b/DBADashSharedGUI/DBADashSharedGUI.csproj
@@ -30,7 +30,8 @@
     <PackageReference Include="DiffPlex.Wpf" Version="1.9.1" />
     <PackageReference Include="Markdig" Version="1.1.3" />
     <PackageReference Include="Markdig.SyntaxHighlighting" Version="1.1.7" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />


### PR DESCRIPTION
SQLClient 7.0.1 has required compatibility fixes that previously prevented upgrade.