### PR TITLE
Fix for custom collections not running

### DIFF
--- a/DBADashService/WorkItem.cs
+++ b/DBADashService/WorkItem.cs
@@ -57,7 +57,7 @@ namespace DBADashService
 
         public virtual async Task ExecuteAsync(CollectionConfig config, CancellationToken cancellationToken)
         {
-            if (Types == null || Types.Length == 0)
+            if (!(Types?.Length > 0 || CustomCollections?.Count > 0))
                 return;
 
             var dequeueLatencyMs = EnqueueSW.ElapsedMilliseconds;


### PR DESCRIPTION
The early return in WorkItem.ExecuteAsync only checked Types, causing custom collections on their own schedule (with no standard collection types) to be skipped. Add CustomCollections to the guard check.

#1895