### PR TITLE
Enable Hidden checkbox column in Manage Instances grid

### DIFF
--- a/DBADashGUI/Options Menu/ManageInstances.cs
+++ b/DBADashGUI/Options Menu/ManageInstances.cs
@@ -34,6 +34,7 @@ namespace DBADashGUI
         private async void RefreshData()
         {
             var dt = await CommonData.GetInstancesAsync(Tags, null);
+            dt.Columns["IsHidden"].ReadOnly = false;
             dgv.AutoGenerateColumns = false;
             dgv.DataSource = new DataView(dt);
         }


### PR DESCRIPTION
Set the DataTable column "IsHidden" ReadOnly = false after loading instances so the bound DataGridViewCheckBoxColumn is editable. Fixes the disabled/greyed-out checkbox caused by columns defaulting to ReadOnly when loaded from a SqlDataReader. #1904