### PR TITLE
Add table-size CLI options

### DIFF
--- a/DBADash.Test/DBADashConfig.cs
+++ b/DBADash.Test/DBADashConfig.cs
@@ -57,10 +57,10 @@ namespace DBADashConfig.Test
         }
 
         [TestMethod]
-        [DataRow("SQL1", "Data Source=SQL1;Integrated Security=SSPI", false, false, true, false, true, false, true, false, true)]
-        [DataRow("SQL2", "Data Source=SQL2;Integrated Security=SSPI", true, false, false, true, false, true, false, true, true)]
-        [DataRow("SQL3", "Data Source=SQL3;Integrated Security=SSPI", false, true, false, false, true, true, false, true, false)]
-        public void AddConnectionTest(string connectionID, string connectionString, bool persistXE, bool useDualSession, bool tempdb, bool tranBeginTime, bool collectSessionWaits, bool writeToSecondaryDest, bool scriptAgentJobs, bool taskWaits, bool collectCursors)
+        [DataRow("SQL1", "Data Source=SQL1;Integrated Security=SSPI", false, false, true, false, true, false, true, false, true, -1, "", -1, -1)]
+        [DataRow("SQL2", "Data Source=SQL2;Integrated Security=SSPI", true, false, false, true, false, true, false, true, true, 100, "master", 10, 2)]
+        [DataRow("SQL3", "Data Source=SQL3;Integrated Security=SSPI", false, true, false, false, true, true, false, true, false, 50, "db1,db2", 100, 5)]
+        public void AddConnectionTest(string connectionID, string connectionString, bool persistXE, bool useDualSession, bool tempdb, bool tranBeginTime, bool collectSessionWaits, bool writeToSecondaryDest, bool scriptAgentJobs, bool taskWaits, bool collectCursors, int tableSizeCollectionThresholdMB, string tableSizeDatabases, int tableSizeMaxTableThreshold, int tableSizeMaxDatabaseThreshold)
         {
             const bool skipValidation = true;
             var args =
@@ -68,6 +68,22 @@ namespace DBADashConfig.Test
             if (!collectSessionWaits)
             {
                 args += " --NoCollectSessionWaits";
+            }
+            if (tableSizeCollectionThresholdMB != -1)
+            {
+                args += $" --TableSizeCollectionThresholdMB {tableSizeCollectionThresholdMB}";
+            }
+            if (!string.IsNullOrEmpty(tableSizeDatabases))
+            {
+                args += $" --TableSizeDatabases \"{tableSizeDatabases}\"";
+            }
+            if (tableSizeMaxTableThreshold != -1)
+            {
+                args += $" --TableSizeMaxTableThreshold {tableSizeMaxTableThreshold}";
+            }
+            if (tableSizeMaxDatabaseThreshold != -1)
+            {
+                args += $" --TableSizeMaxDatabaseThreshold {tableSizeMaxDatabaseThreshold}";
             }
             var psi = new ProcessStartInfo("DBADashConfig", args);
             Helper.RunProcess(psi);
@@ -86,6 +102,11 @@ namespace DBADashConfig.Test
             Assert.AreEqual(conn.ScriptAgentJobs, scriptAgentJobs, "Test ScriptAgentJobs");
             Assert.AreEqual(conn.CollectTaskWaits, taskWaits, "Test CollectTaskWaits");
             Assert.AreEqual(conn.CollectCursors, collectCursors, "Test CollectCursors");
+            Assert.AreEqual(conn.TableSizeCollectionThresholdMB, tableSizeCollectionThresholdMB == -1 ? null : (int?)tableSizeCollectionThresholdMB, "Test TableSizeCollectionThresholdMB");
+            // Treat null and empty string as equivalent for TableSizeDatabases
+            Assert.AreEqual(tableSizeDatabases ?? string.Empty, conn.TableSizeDatabases ?? string.Empty, "Test TableSizeDatabases");
+            Assert.AreEqual(conn.TableSizeMaxTableThreshold, tableSizeMaxTableThreshold == -1 ? null : (int?)tableSizeMaxTableThreshold, "Test TableSizeMaxTableThreshold");
+            Assert.AreEqual(conn.TableSizeMaxDatabaseThreshold, tableSizeMaxDatabaseThreshold == -1 ? null : (int?)tableSizeMaxDatabaseThreshold, "Test TableSizeMaxDatabaseThreshold");
 
             // test removal
             args = $"-a Remove --ConnectionID {connectionID}";

--- a/DBADashConfig/Helper.cs
+++ b/DBADashConfig/Helper.cs
@@ -167,6 +167,23 @@ namespace DBADashConfig
                 CollectTaskWaits = o.CollectTaskWaits ?? false,
                 CollectCursors = o.CollectCursors ?? false
             };
+            // Table size collection options (nullable: omit to use defaults)
+            if (o.TableSizeCollectionThresholdMB.HasValue)
+            {
+                source.TableSizeCollectionThresholdMB = o.TableSizeCollectionThresholdMB.Value;
+            }
+            if (o.TableSizeDatabases != null)
+            {
+                source.TableSizeDatabases = o.TableSizeDatabases;
+            }
+            if (o.TableSizeMaxTableThreshold.HasValue)
+            {
+                source.TableSizeMaxTableThreshold = o.TableSizeMaxTableThreshold.Value;
+            }
+            if (o.TableSizeMaxDatabaseThreshold.HasValue)
+            {
+                source.TableSizeMaxDatabaseThreshold = o.TableSizeMaxDatabaseThreshold.Value;
+            }
             if (!o.SkipValidation)
             {
                 Log.Information("Validating connection...");

--- a/DBADashConfig/Options.cs
+++ b/DBADashConfig/Options.cs
@@ -57,6 +57,18 @@ SetAWS - Set AWS Credentials")]
         [Option("SchemaSnapshotDBs", Default = "", Required = false, HelpText = "Comma-separated list of databases to include in a schema snapshot.  Use \" * \" to snapshot all databases.")]
         public string? SchemaSnapshotDBs { get; set; }
 
+        [Option("TableSizeCollectionThresholdMB", Required = false, HelpText = "Table size collection threshold in MB. Omit to use the collector default.")]
+        public int? TableSizeCollectionThresholdMB { get; set; }
+
+        [Option("TableSizeDatabases", Required = false, HelpText = "Comma-separated list of databases to include in table size collection. Use \"*\" to include all databases. Omit to use the collector default.")]
+        public string? TableSizeDatabases { get; set; }
+
+        [Option("TableSizeMaxTableThreshold", Required = false, HelpText = "Databases with more tables than this threshold are skipped during table size collection. Omit to use the collector default.")]
+        public int? TableSizeMaxTableThreshold { get; set; }
+
+        [Option("TableSizeMaxDatabaseThreshold", Required = false, HelpText = "Table size collection is aborted if the server has more databases than this threshold. Omit to use the collector default.")]
+        public int? TableSizeMaxDatabaseThreshold { get; set; }
+
         [Option("SkipValidation", Default = false, Required = false, HelpText = "Option to skip the validation check on the source connection string")]
         public bool SkipValidation { get; set; }
 


### PR DESCRIPTION
•	Add CLI options: --TableSizeCollectionThresholdMB, --TableSizeDatabases, --TableSizeMaxTableThreshold, --TableSizeMaxDatabaseThreshold •	Apply options to DBADashSource in AddSourceConnectionAsync •	Update unit tests to pass and verify new options; normalize TableSizeDatabases comparison

#1903