### PR TITLE
Service Config Tool improvements

### DIFF
--- a/DBADashServiceConfig/ServiceConfig.Designer.cs
+++ b/DBADashServiceConfig/ServiceConfig.Designer.cs
@@ -52,7 +52,6 @@ namespace DBADashServiceConfig
             bttnSrcFolder = new System.Windows.Forms.Button();
             bttnS3Src = new System.Windows.Forms.Button();
             pictureBox2 = new System.Windows.Forms.PictureBox();
-            bttnDeployDatabase = new System.Windows.Forms.Button();
             bttnConnect = new System.Windows.Forms.Button();
             bttnDestFolder = new System.Windows.Forms.Button();
             bttnS3 = new System.Windows.Forms.Button();
@@ -73,6 +72,8 @@ namespace DBADashServiceConfig
             chkQueueBasedScheduling = new System.Windows.Forms.CheckBox();
             label24 = new System.Windows.Forms.Label();
             lnkAutomaticUpdates = new System.Windows.Forms.LinkLabel();
+            lnkAutoUpgradeDB = new System.Windows.Forms.LinkLabel();
+            lnkDeployDatabase = new System.Windows.Forms.LinkLabel();
             picConfigFileAccess = new System.Windows.Forms.PictureBox();
             lblConfigFileAccess = new System.Windows.Forms.Label();
             pnlBottom = new System.Windows.Forms.Panel();
@@ -93,6 +94,7 @@ namespace DBADashServiceConfig
             numAlertPollingFrequency = new System.Windows.Forms.NumericUpDown();
             chkProcessAlerts = new System.Windows.Forms.CheckBox();
             groupBox3 = new System.Windows.Forms.GroupBox();
+            lnkSummaryRefreshCron = new System.Windows.Forms.LinkLabel();
             chkLowPriorityMaxThreadPct = new System.Windows.Forms.CheckBox();
             numLowMaxThreadPct = new System.Windows.Forms.NumericUpDown();
             chkSchedulerThreads = new System.Windows.Forms.CheckBox();
@@ -190,13 +192,11 @@ namespace DBADashServiceConfig
             grpService = new System.Windows.Forms.GroupBox();
             lnkInstall = new System.Windows.Forms.LinkLabel();
             lblServiceStatus = new System.Windows.Forms.Label();
-            chkAutoUpgradeRepoDB = new System.Windows.Forms.CheckBox();
             lblVersionInfo = new System.Windows.Forms.Label();
             label7 = new System.Windows.Forms.Label();
             txtDestination = new System.Windows.Forms.TextBox();
             tab1 = new ThemedTabControl();
             tabMessaging = new System.Windows.Forms.TabPage();
-            lnkSummaryRefreshCron = new System.Windows.Forms.LinkLabel();
             ((System.ComponentModel.ISupportInitialize)errorProvider1).BeginInit();
             ((System.ComponentModel.ISupportInitialize)pictureBox3).BeginInit();
             ((System.ComponentModel.ISupportInitialize)pictureBox2).BeginInit();
@@ -434,18 +434,6 @@ namespace DBADashServiceConfig
             pictureBox2.TabIndex = 14;
             pictureBox2.TabStop = false;
             toolTip1.SetToolTip(pictureBox2, resources.GetString("pictureBox2.ToolTip"));
-            // 
-            // bttnDeployDatabase
-            // 
-            bttnDeployDatabase.Location = new System.Drawing.Point(103, 93);
-            bttnDeployDatabase.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            bttnDeployDatabase.Name = "bttnDeployDatabase";
-            bttnDeployDatabase.Size = new System.Drawing.Size(214, 29);
-            bttnDeployDatabase.TabIndex = 5;
-            bttnDeployDatabase.Text = "Deploy/Update Database";
-            toolTip1.SetToolTip(bttnDeployDatabase, "Click to create/upgrade your DBA Dash repository database");
-            bttnDeployDatabase.UseVisualStyleBackColor = true;
-            bttnDeployDatabase.Click += BttnDeployDatabase_Click;
             // 
             // bttnConnect
             // 
@@ -690,6 +678,34 @@ namespace DBADashServiceConfig
             toolTip1.SetToolTip(lnkAutomaticUpdates, resources.GetString("lnkAutomaticUpdates.ToolTip"));
             lnkAutomaticUpdates.LinkClicked += AutomaticUpdates_LinkClicked;
             // 
+            // lnkAutoUpgradeDB
+            // 
+            lnkAutoUpgradeDB.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            lnkAutoUpgradeDB.Image = Properties.Resources.Warning_yellow_7231_16x16;
+            lnkAutoUpgradeDB.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            lnkAutoUpgradeDB.Location = new System.Drawing.Point(103, 123);
+            lnkAutoUpgradeDB.Name = "lnkAutoUpgradeDB";
+            lnkAutoUpgradeDB.Size = new System.Drawing.Size(567, 25);
+            lnkAutoUpgradeDB.TabIndex = 28;
+            lnkAutoUpgradeDB.TabStop = true;
+            lnkAutoUpgradeDB.Text = "Enable auto upgrade of repository database on service start (recommended)";
+            lnkAutoUpgradeDB.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            toolTip1.SetToolTip(lnkAutoUpgradeDB, resources.GetString("lnkAutoUpgradeDB.ToolTip"));
+            lnkAutoUpgradeDB.LinkClicked += AutoUpgradeDB_LinkClicked;
+            // 
+            // lnkDeployDatabase
+            // 
+            lnkDeployDatabase.AutoSize = true;
+            lnkDeployDatabase.Enabled = false;
+            lnkDeployDatabase.Location = new System.Drawing.Point(103, 59);
+            lnkDeployDatabase.Name = "lnkDeployDatabase";
+            lnkDeployDatabase.Size = new System.Drawing.Size(312, 20);
+            lnkDeployDatabase.TabIndex = 29;
+            lnkDeployDatabase.TabStop = true;
+            lnkDeployDatabase.Text = "Deploy/Update repository database manually";
+            toolTip1.SetToolTip(lnkDeployDatabase, "Option to deploy the database manually.  This is usually done automatically for you on service start.");
+            lnkDeployDatabase.LinkClicked += DeployDatabase_LinkClicked;
+            // 
             // picConfigFileAccess
             // 
             picConfigFileAccess.Image = Properties.Resources.Security_Shields_Alert_32xLG_color;
@@ -740,7 +756,7 @@ namespace DBADashServiceConfig
             tabJson.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
             tabJson.Size = new System.Drawing.Size(1129, 722);
             tabJson.TabIndex = 6;
-            tabJson.Text = "Json";
+            tabJson.Text = "JSON";
             tabJson.UseVisualStyleBackColor = true;
             // 
             // txtJson
@@ -942,6 +958,17 @@ namespace DBADashServiceConfig
             groupBox3.TabIndex = 38;
             groupBox3.TabStop = false;
             groupBox3.Text = "Miscellaneous";
+            // 
+            // lnkSummaryRefreshCron
+            // 
+            lnkSummaryRefreshCron.AutoSize = true;
+            lnkSummaryRefreshCron.Location = new System.Drawing.Point(286, 102);
+            lnkSummaryRefreshCron.Name = "lnkSummaryRefreshCron";
+            lnkSummaryRefreshCron.Size = new System.Drawing.Size(230, 20);
+            lnkSummaryRefreshCron.TabIndex = 58;
+            lnkSummaryRefreshCron.TabStop = true;
+            lnkSummaryRefreshCron.Text = "Configure summary auto refresh...";
+            lnkSummaryRefreshCron.LinkClicked += LnkSummaryRefreshCron_LinkClicked;
             // 
             // chkLowPriorityMaxThreadPct
             // 
@@ -1933,6 +1960,8 @@ namespace DBADashServiceConfig
             // 
             // tabDest
             // 
+            tabDest.Controls.Add(lnkDeployDatabase);
+            tabDest.Controls.Add(lnkAutoUpgradeDB);
             tabDest.Controls.Add(lnkAutomaticUpdates);
             tabDest.Controls.Add(lblRunningAs);
             tabDest.Controls.Add(bttnViewServiceLog);
@@ -1944,10 +1973,8 @@ namespace DBADashServiceConfig
             tabDest.Controls.Add(grpService);
             tabDest.Controls.Add(bttnS3);
             tabDest.Controls.Add(bttnDestFolder);
-            tabDest.Controls.Add(chkAutoUpgradeRepoDB);
             tabDest.Controls.Add(bttnConnect);
             tabDest.Controls.Add(lblVersionInfo);
-            tabDest.Controls.Add(bttnDeployDatabase);
             tabDest.Controls.Add(label7);
             tabDest.Controls.Add(txtDestination);
             tabDest.Location = new System.Drawing.Point(4, 39);
@@ -2082,24 +2109,10 @@ namespace DBADashServiceConfig
             lblServiceStatus.TabIndex = 23;
             lblServiceStatus.Text = "Service Status";
             // 
-            // chkAutoUpgradeRepoDB
-            // 
-            chkAutoUpgradeRepoDB.AutoSize = true;
-            chkAutoUpgradeRepoDB.Checked = true;
-            chkAutoUpgradeRepoDB.CheckState = System.Windows.Forms.CheckState.Checked;
-            chkAutoUpgradeRepoDB.Location = new System.Drawing.Point(103, 60);
-            chkAutoUpgradeRepoDB.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-            chkAutoUpgradeRepoDB.Name = "chkAutoUpgradeRepoDB";
-            chkAutoUpgradeRepoDB.Size = new System.Drawing.Size(321, 24);
-            chkAutoUpgradeRepoDB.TabIndex = 8;
-            chkAutoUpgradeRepoDB.Text = "Auto upgrade repository DB on service start";
-            chkAutoUpgradeRepoDB.UseVisualStyleBackColor = true;
-            chkAutoUpgradeRepoDB.CheckedChanged += ChkAutoUpgradeRepoDB_CheckedChanged;
-            // 
             // lblVersionInfo
             // 
             lblVersionInfo.AutoSize = true;
-            lblVersionInfo.Location = new System.Drawing.Point(103, 127);
+            lblVersionInfo.Location = new System.Drawing.Point(103, 91);
             lblVersionInfo.Name = "lblVersionInfo";
             lblVersionInfo.Size = new System.Drawing.Size(95, 20);
             lblVersionInfo.TabIndex = 6;
@@ -2122,6 +2135,7 @@ namespace DBADashServiceConfig
             txtDestination.Name = "txtDestination";
             txtDestination.Size = new System.Drawing.Size(903, 27);
             txtDestination.TabIndex = 1;
+            txtDestination.TextChanged += TxtDestination_TextChanged;
             txtDestination.Validated += TxtDestination_Validated;
             // 
             // tab1
@@ -2151,17 +2165,6 @@ namespace DBADashServiceConfig
             tabMessaging.TabIndex = 7;
             tabMessaging.Text = "Messaging";
             tabMessaging.UseVisualStyleBackColor = true;
-            // 
-            // lnkSummaryRefreshCron
-            // 
-            lnkSummaryRefreshCron.AutoSize = true;
-            lnkSummaryRefreshCron.Location = new System.Drawing.Point(286, 102);
-            lnkSummaryRefreshCron.Name = "lnkSummaryRefreshCron";
-            lnkSummaryRefreshCron.Size = new System.Drawing.Size(230, 20);
-            lnkSummaryRefreshCron.TabIndex = 58;
-            lnkSummaryRefreshCron.TabStop = true;
-            lnkSummaryRefreshCron.Text = "Configure summary auto refresh...";
-            lnkSummaryRefreshCron.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(LnkSummaryRefreshCron_LinkClicked);
             // 
             // ServiceConfig
             // 
@@ -2257,10 +2260,8 @@ namespace DBADashServiceConfig
         private System.Windows.Forms.LinkLabel lnkStop;
         private System.Windows.Forms.Button bttnS3;
         private System.Windows.Forms.Button bttnDestFolder;
-        private System.Windows.Forms.CheckBox chkAutoUpgradeRepoDB;
         private System.Windows.Forms.Button bttnConnect;
         private System.Windows.Forms.Label lblVersionInfo;
-        private System.Windows.Forms.Button bttnDeployDatabase;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.TextBox txtDestination;
         private System.Windows.Forms.TabPage tabSource;
@@ -2399,6 +2400,8 @@ namespace DBADashServiceConfig
         private System.Windows.Forms.Label lblRunningAs;
         private System.Windows.Forms.LinkLabel lnkAutomaticUpdates;
         private System.Windows.Forms.LinkLabel lnkSummaryRefreshCron;
+        private System.Windows.Forms.LinkLabel lnkAutoUpgradeDB;
+        private System.Windows.Forms.LinkLabel lnkDeployDatabase;
     }
 }
 

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -379,8 +379,17 @@ namespace DBADashServiceConfig
             if (control.InvokeRequired)
             {
                 control.Invoke(() => InvokeEnable(control, isEnabled));
+                return;
             }
             control.Enabled = isEnabled;
+        }
+
+        private void UpdateDeployDatabaseLinkState()
+        {
+            var canDeploy = RepoDbVersionStatus?.VersionStatus is DBValidations.DBVersionStatusEnum.CreateDB
+                or DBValidations.DBVersionStatusEnum.OK
+                or DBValidations.DBVersionStatusEnum.UpgradeRequired;
+            InvokeEnable(lnkDeployDatabase, canDeploy);
         }
 
         private async Task UpdateDBVersionStatusAsync()
@@ -391,18 +400,21 @@ namespace DBADashServiceConfig
             {
                 RepoDbVersionStatus = null;
                 InvokeSetStatus(lblVersionInfo, "Please start by setting the destination connection for your DBA Dash repository database.", DashColors.Information, FontStyle.Bold);
+                UpdateDeployDatabaseLinkState();
                 return;
             }
             if (dest.Type == ConnectionType.Invalid)
             {
                 RepoDbVersionStatus = null;
                 InvokeSetStatus(lblVersionInfo, "Invalid connection string, directory or S3 path", DashColors.Fail, FontStyle.Regular);
+                UpdateDeployDatabaseLinkState();
                 return;
             }
             if (dest.Type != ConnectionType.SQL)
             {
                 RepoDbVersionStatus = null;
                 InvokeSetStatus(lblVersionInfo, string.Empty, DashColors.TrimbleBlue, FontStyle.Regular);
+                UpdateDeployDatabaseLinkState();
                 return;
             }
 
@@ -427,34 +439,35 @@ namespace DBADashServiceConfig
                 {
                     case null:
                         InvokeSetStatus(lblVersionInfo, "???", DashColors.Fail, FontStyle.Bold);
+                        UpdateDeployDatabaseLinkState();
                         break;
 
                     case DBValidations.DBVersionStatusEnum.CreateDB:
                         InvokeSetStatus(lblVersionInfo,
                             "Start service to create repository database or click Deploy to create manually.",
                             DashColors.Warning, FontStyle.Bold);
-                        InvokeEnable(bttnDeployDatabase, true);
+                        UpdateDeployDatabaseLinkState();
                         return;
 
                     case DBValidations.DBVersionStatusEnum.OK:
                         InvokeSetStatus(lblVersionInfo,
                             "Repository database version check successful. DacVersion/DB Version: " +
                             RepoDbVersionStatus.DACVersion, DashColors.Success, FontStyle.Regular);
-                        InvokeEnable(bttnDeployDatabase, true);
+                        UpdateDeployDatabaseLinkState();
                         break;
 
                     case DBValidations.DBVersionStatusEnum.AppUpgradeRequired:
                         InvokeSetStatus(lblVersionInfo,
                             $"Repository database version {RepoDbVersionStatus.DBVersion} is newer than dac version {RepoDbVersionStatus.DACVersion}.  Please update this app.",
                             DashColors.Warning, FontStyle.Bold);
-                        InvokeEnable(bttnDeployDatabase, false);
+                        UpdateDeployDatabaseLinkState();
                         break;
 
                     case DBValidations.DBVersionStatusEnum.UpgradeRequired:
                         InvokeSetStatus(lblVersionInfo,
                             $"Repository database version {RepoDbVersionStatus.DBVersion}  requires upgrade to {RepoDbVersionStatus.DACVersion}.  Database will be upgraded on service start.",
                             DashColors.Warning, FontStyle.Bold);
-                        InvokeEnable(bttnDeployDatabase, true);
+                        UpdateDeployDatabaseLinkState();
                         break;
 
                     default:
@@ -464,6 +477,7 @@ namespace DBADashServiceConfig
             catch (Exception ex)
             {
                 InvokeSetStatus(lblVersionInfo, ex.Message, DashColors.Fail, FontStyle.Regular);
+                UpdateDeployDatabaseLinkState();
             }
         }
 
@@ -963,7 +977,7 @@ namespace DBADashServiceConfig
                 chkScanAzureDB.Checked = collectionConfig.ScanForAzureDBs;
                 chkScanEvery.Checked = collectionConfig.ScanForAzureDBsInterval > 0;
                 numAzureScanInterval.Value = collectionConfig.ScanForAzureDBsInterval;
-                chkAutoUpgradeRepoDB.Checked = collectionConfig.AutoUpdateDatabase;
+                lnkAutoUpgradeDB.Visible = !collectionConfig.AutoUpdateDatabase;
                 chkLogInternalPerfCounters.Checked = collectionConfig.LogInternalPerformanceCounters;
                 chkDefaultIdentityCollection.Checked = !collectionConfig.IdentityCollectionThreshold.HasValue;
                 numIdentityCollectionThreshold.Value = collectionConfig.IdentityCollectionThreshold ??
@@ -1378,8 +1392,17 @@ namespace DBADashServiceConfig
             await DestinationChangedAsync();
         }
 
-        private async Task DestinationChangedAsync()
+        private void TxtDestination_TextChanged(object sender, EventArgs e)
         {
+            if (txtDestination.Text != collectionConfig.Destination)
+            {
+                RepoDbVersionStatus = null;
+                InvokeEnable(lnkDeployDatabase, false);
+            }
+        }
+
+        private async Task DestinationChangedAsync()
+            {
             if (collectionConfig.Destination != txtDestination.Text)
             {
                 try
@@ -1456,7 +1479,7 @@ namespace DBADashServiceConfig
             SetAvailableOptionsForSource();
         }
 
-        private async void BttnDeployDatabase_Click(object sender, EventArgs e)
+        private async Task DeployDatabase()
         {
             var frm = new DBDeploy();
             var cn = new DBADashConnection(txtDestination.Text);
@@ -1584,12 +1607,6 @@ namespace DBADashServiceConfig
         private void ChkScanAzureDB_CheckedChanged(object sender, EventArgs e)
         {
             collectionConfig.ScanForAzureDBs = chkScanAzureDB.Checked;
-            SetJson();
-        }
-
-        private void ChkAutoUpgradeRepoDB_CheckedChanged(object sender, EventArgs e)
-        {
-            collectionConfig.AutoUpdateDatabase = chkAutoUpgradeRepoDB.Checked;
             SetJson();
         }
 
@@ -2239,8 +2256,8 @@ namespace DBADashServiceConfig
                     ? DashColors.Fail
                     : DashColors.Warning;
             tabJson.Text = collectionConfig.EncryptionOption == BasicConfig.EncryptionOptions.Encrypt
-                ? "Json (Decrypted)"
-                : "Json";
+                ? "JSON (Decrypted)"
+                : "JSON";
         }
 
         private void NumBackupRetention_ValueChanged(object sender, EventArgs e)
@@ -3185,6 +3202,24 @@ namespace DBADashServiceConfig
             {
                 // Unable to parse - validation will be handled elsewhere
             }
+        }
+
+        private void AutoUpgradeDB_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            if (MessageBox.Show("Automatically upgrade the repository database on service startup when a new version is detected? (Recommended)\r\n\r\nThis option can be disabled again by editing \"AutoUpdateDatabase\" in the JSON tab.", "Automatic Database Upgrades", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes) return;
+            collectionConfig.AutoUpdateDatabase = true;
+            lnkAutoUpgradeDB.Visible = false;
+            SetJson();
+        }
+
+        private async void DeployDatabase_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            if (!lnkDeployDatabase.Enabled)
+            {
+                return;
+            }
+
+            await DeployDatabase();
         }
     }
 }

--- a/DBADashServiceConfig/ServiceConfig.resx
+++ b/DBADashServiceConfig/ServiceConfig.resx
@@ -126,6 +126,12 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>172, 17</value>
   </metadata>
+  <data name="lnkAutoUpgradeDB.ToolTip" xml:space="preserve">
+    <value>The database is currently configured not to upgrade automatically on service start. This will require you to deploy database changes manually each time you upgrade DBA Dash.
+
+ Click this link to enable automatic deployment of database changes
+</value>
+  </data>
   <data name="lnkAutomaticUpdates.ToolTip" xml:space="preserve">
     <value>Configure the service to automatically check and install updates on a schedule.
 


### PR DESCRIPTION
* Replace auto upgrade repository DB on service start checkbox with a link that is only visible to re-enable it.  It makes sense to have this option enabled so it's good to make it a bit harder to disable and easy to re-enable.
* Replace Deploy/Update database button with a link.  Users don't need to click this button as the database is deployed automatically.  Still provide the option, but reduce the visibility slightly by making it a link.