### PR TITLE
Cron schedule normalization

### DIFF
--- a/DBADash.Test/CronParserTests.cs
+++ b/DBADash.Test/CronParserTests.cs
@@ -6,11 +6,31 @@ namespace DBADash.Test
     public class CronParserTests
     {
         [TestMethod]
+        public void GroupedBySchedule_NormalizesEquivalentSchedules()
+        {
+            var schedules = new DBADashService.CollectionSchedules
+            {
+                [DBADash.CollectionType.CPU] = new DBADashService.CollectionSchedule { Schedule = "0 0/1 * * * ?" },
+                [DBADash.CollectionType.IOStats] = new DBADashService.CollectionSchedule { Schedule = "0 * * ? * *" },
+                [DBADash.CollectionType.Waits] = new DBADashService.CollectionSchedule { Schedule = "0 0/1 * * * ?" }
+            };
+
+            var grouped = schedules.GroupedBySchedule;
+
+            Assert.AreEqual(1, grouped.Count);
+            Assert.IsTrue(grouped.ContainsKey(CronParser.NormalizeCronExpression("0 0/1 * * * ?")));
+            CollectionAssert.AreEquivalent(
+                new[] { DBADash.CollectionType.CPU, DBADash.CollectionType.IOStats, DBADash.CollectionType.Waits },
+                grouped[CronParser.NormalizeCronExpression("0 0/1 * * * ?")]);
+        }
+
+        [TestMethod]
         public void TryParseCronState_EveryNMinutes_Various()
         {
             var cases = new[] {
                 (cron: "0 0/5 * * * ?", expectedInterval: 5, expectedBaseMinute: 0),
-                (cron: "0 2/10 * * * ?", expectedInterval: 10, expectedBaseMinute: 2)
+                (cron: "0 2/10 * * * ?", expectedInterval: 10, expectedBaseMinute: 2),
+                (cron: "0 * * ? * *", expectedInterval: 1, expectedBaseMinute: 0)
             };
             foreach (var c in cases)
             {
@@ -20,6 +40,78 @@ namespace DBADash.Test
                 Assert.AreEqual(0, state.BaseSecond);
                 Assert.AreEqual(c.expectedBaseMinute, state.BaseMinute);
             }
+        }
+
+        [TestMethod]
+        public void TryParseCronState_EveryNHours_Various()
+        {
+            var cases = new[] {
+                (cron: "0 0 0/1 * * ?", expectedInterval: 1, expectedBaseHour: 0, expectedBaseMinute: 0),
+                (cron: "0 0 * ? * *", expectedInterval: 1, expectedBaseHour: 0, expectedBaseMinute: 0)
+            };
+
+            foreach (var c in cases)
+            {
+                Assert.IsTrue(CronParser.TryParseCronState(c.cron, out var state), $"Parsing failed for: {c.cron}");
+                Assert.AreEqual(CronParser.FrequencyMode.EveryNHours, state.Mode);
+                Assert.AreEqual(c.expectedInterval, state.Interval);
+                Assert.AreEqual(c.expectedBaseHour, state.BaseHour);
+                Assert.AreEqual(c.expectedBaseMinute, state.BaseMinute);
+                Assert.AreEqual(0, state.BaseSecond);
+            }
+        }
+
+        [TestMethod]
+        public void TryParseCronState_Daily_Various()
+        {
+            var cases = new[] {
+                (cron: "0 0 0 * * ?", expectedHour: 0, expectedMinute: 0, expectedSecond: 0),
+                (cron: "0 0 23 * * ?", expectedHour: 23, expectedMinute: 0, expectedSecond: 0),
+                (cron: "0 0 22 * * ?", expectedHour: 22, expectedMinute: 0, expectedSecond: 0),
+                (cron: "0 0 0 1/1 * ? *", expectedHour: 0, expectedMinute: 0, expectedSecond: 0),
+                (cron: "0 0 23 1/1 * ? *", expectedHour: 23, expectedMinute: 0, expectedSecond: 0),
+                (cron: "0 0 22 1/1 * ? *", expectedHour: 22, expectedMinute: 0, expectedSecond: 0)
+            };
+
+            foreach (var c in cases)
+            {
+                Assert.IsTrue(CronParser.TryParseCronState(c.cron, out var state), $"Parsing failed for: {c.cron}");
+                Assert.AreEqual(CronParser.FrequencyMode.Daily, state.Mode);
+                Assert.AreEqual(c.expectedHour, state.BaseHour);
+                Assert.AreEqual(c.expectedMinute, state.BaseMinute);
+                Assert.AreEqual(c.expectedSecond, state.BaseSecond);
+            }
+        }
+
+        [TestMethod]
+        public void NormalizeCronExpression_EquivalentForms_MapToSameValue()
+        {
+            Assert.AreEqual(CronParser.NormalizeCronExpression("0 0 * ? * *"), CronParser.NormalizeCronExpression("0 0 0/1 * * ?"));
+            Assert.AreEqual(CronParser.NormalizeCronExpression("0 0 0 1/1 * ? *"), CronParser.NormalizeCronExpression("0 0 0 * * ?"));
+            Assert.AreEqual(CronParser.NormalizeCronExpression("0 0 23 1/1 * ? *"), CronParser.NormalizeCronExpression("0 0 23 * * ?"));
+            Assert.AreEqual(CronParser.NormalizeCronExpression("0 0 22 1/1 * ? *"), CronParser.NormalizeCronExpression("0 0 22 * * ?"));
+        }
+
+        [TestMethod]
+        public void NormalizeCronExpression_AllDaysSelection_UsesDailyCanonicalForm()
+        {
+            var normalized = CronParser.NormalizeCronExpression("0 0 3 ? * SUN,MON,TUE,WED,THU,FRI,SAT");
+
+            Assert.AreEqual("0 0 3 * * ?", normalized);
+            Assert.IsTrue(CronParser.TryParseCronState(normalized, out var state));
+            Assert.AreEqual(CronParser.FrequencyMode.Daily, state.Mode);
+        }
+
+        [TestMethod]
+        public void EquivalentEveryMinuteForms_ParseTheSame()
+        {
+            Assert.IsTrue(CronParser.TryParseCronState("0 0/1 * * * ?", out var stepState));
+            Assert.IsTrue(CronParser.TryParseCronState("0 * * ? * *", out var legacyState));
+
+            Assert.AreEqual(stepState.Mode, legacyState.Mode);
+            Assert.AreEqual(stepState.Interval, legacyState.Interval);
+            Assert.AreEqual(stepState.BaseMinute, legacyState.BaseMinute);
+            Assert.AreEqual(stepState.BaseSecond, legacyState.BaseSecond);
         }
 
         [TestMethod]
@@ -37,6 +129,17 @@ namespace DBADash.Test
                 var compressed = CronParser.CompressDayTokens(state.SelectedDays);
                 CollectionAssert.AreEqual(new[] { c.expectedCompressed }, compressed);
             }
+        }
+
+        [TestMethod]
+        [DataRow("0 0 3 ? * MON,FRI,MON", "0 0 3 ? * MON,FRI")]
+        [DataRow("0 0 3 ? * FRI,MON", "0 0 3 ? * MON,FRI")]
+        [DataRow("0 0 3 ? * MON-FRI", "0 0 3 ? * MON-FRI")]
+        [DataRow("0 0 3 ? * FRI-MON", "0 0 3 ? * FRI-MON")]
+        [DataRow("0 0 3 ? * MON,TUE,MON,TUE", "0 0 3 ? * MON-TUE")]
+        public void NormalizeCronExpression_SortsAndDeduplicatesSelectedDays(string cron, string expected)
+        {
+            Assert.AreEqual(expected, CronParser.NormalizeCronExpression(cron));
         }
 
         [TestMethod]

--- a/DBADash/CollectionSchedule.cs
+++ b/DBADash/CollectionSchedule.cs
@@ -6,11 +6,11 @@ namespace DBADashService
 {
     public class CollectionSchedules : Dictionary<CollectionType, CollectionSchedule>
     {
-        private const string every1min = "0 * * ? * *";
-        private const string hourly = "0 0 * ? * *";
-        private const string midnight = "0 0 0 1/1 * ? *";
-        private const string elevenPm = "0 0 23 1/1 * ? *";
-        private const string tenPm = "0 0 22 1/1 * ? *";
+        private const string every1min = "0 0/1 * * * ?";
+        private const string hourly = "0 0 0/1 * * ?";
+        private const string midnight = "0 0 0 * * ?";
+        private const string elevenPm = "0 0 23 * * ?";
+        private const string tenPm = "0 0 22 * * ?";
         private const string disabled = "";
 
         private static readonly CollectionSchedules collectionSchedules = new() {
@@ -107,13 +107,10 @@ namespace DBADashService
         {
             get
             {
-                var groupedSchedule = new Dictionary<string, CollectionType[]>();
-                var schedules = this.Where(s => s.Key != CollectionType.SchemaSnapshot && !string.IsNullOrEmpty(s.Value.Schedule)).Select(s => s.Value.Schedule).Distinct().ToArray();
-                foreach (var schedule in schedules)
-                {
-                    groupedSchedule.Add(schedule, this.Where(s => s.Value.Schedule == schedule).Select(s => s.Key).ToArray());
-                }
-                return groupedSchedule;
+                return this
+                    .Where(s => s.Key != CollectionType.SchemaSnapshot && !string.IsNullOrEmpty(s.Value.NormalizedSchedule))
+                    .GroupBy(s => s.Value.NormalizedSchedule)
+                    .ToDictionary(g => g.Key, g => g.Select(s => s.Key).ToArray());
             }
         }
 
@@ -128,7 +125,22 @@ namespace DBADashService
         public string Schedule;
         public bool RunOnServiceStart = true;
 
-        private const string every1min = "0 * * ? * *";
+        private string _cachedSchedule;
+        private string _cachedNormalizedSchedule;
+
+        public string NormalizedSchedule
+        {
+            get
+            {
+                if (_cachedNormalizedSchedule == null || _cachedSchedule != Schedule)
+                {
+                    _cachedSchedule = Schedule;
+                    _cachedNormalizedSchedule = CronParser.NormalizeCronExpression(Schedule);
+                }
+                return _cachedNormalizedSchedule;
+            }
+        }
+
         private static readonly CollectionSchedule importSchedule = new() { Schedule = "10" };
         public static readonly CollectionSchedule DefaultImportSchedule = importSchedule;
     }

--- a/DBADash/Cron/CronParser.cs
+++ b/DBADash/Cron/CronParser.cs
@@ -51,6 +51,14 @@ namespace DBADash
         // Helper: canonical day names used in cron expressions
         public static string[] DayNames() => new[] { "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
 
+        private static string[] CanonicalizeSelectedDays(string[] selectedDays)
+        {
+            var normalized = NormalizeDayTokens(selectedDays);
+            if (normalized == null || normalized.Length == 0) return Array.Empty<string>();
+
+            return CompressDayTokens(normalized);
+        }
+
         /// <summary>
         /// Map token (name prefix or number) to index 0..6 (SUN=0). Returns -1 if unrecognized.
         /// </summary>
@@ -202,7 +210,7 @@ namespace DBADash
         /// Unsupported or malformed expressions return <c>false</c> so the UI can fallback to Custom.
         /// Intervals of zero or less are rejected.
         /// </remarks>
-        /// <param name="cron">Cron expression to parse (6 fields).</param>
+        /// <param name="cron">Cron expression to parse (6 or 7 fields).</param>
         /// <param name="state">Output parsed state when parsing succeeds.</param>
         /// <returns>True if parsing succeeded and state is populated; otherwise false.</returns>
         public static bool TryParseCronState(string cron, out ParsedCronState state)
@@ -210,7 +218,8 @@ namespace DBADash
             state = null;
             if (string.IsNullOrWhiteSpace(cron)) return false;
             var parts = cron.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length != 6) return false;
+            if (parts.Length != 6 && parts.Length != 7) return false;
+            if (parts.Length == 7 && parts[6] != "*") return false;
 
             // small helper to parse and validate numeric cron fields
             static bool TryParseField(string token, int min, int max, out int value)
@@ -323,6 +332,21 @@ namespace DBADash
                 return false;
             }
 
+            // Legacy default every-minute form: S * * ? * *
+            if (parts[1] == "*" && parts[2] == "*" && parts[3] == "?" && parts[4] == "*" && parts[5] == "*")
+            {
+                if (!TryParseField(parts[0], 0, 59, out int secForLegacyMinutes)) return false;
+
+                state = new ParsedCronState
+                {
+                    Mode = FrequencyMode.EveryNMinutes,
+                    Interval = 1,
+                    BaseMinute = 0,
+                    BaseSecond = secForLegacyMinutes
+                };
+                return true;
+            }
+
             // Every N hours: accept forms like H/N in the hour field (e.g. 5/5)
             var hourMatch = Regex.Match(parts[2], @"^(\d+)/(\d+)$");
             if (hourMatch.Success)
@@ -374,6 +398,22 @@ namespace DBADash
                 return false;
             }
 
+            // Legacy default hourly form: S M * ? * *
+            if (parts[2] == "*" && parts[3] == "?" && parts[4] == "*" && parts[5] == "*")
+            {
+                if (!TryParseField(parts[1], 0, 59, out int minute) || !TryParseField(parts[0], 0, 59, out int secForLegacyHours)) return false;
+
+                state = new ParsedCronState
+                {
+                    Mode = FrequencyMode.EveryNHours,
+                    Interval = 1,
+                    BaseHour = 0,
+                    BaseMinute = minute,
+                    BaseSecond = secForLegacyHours
+                };
+                return true;
+            }
+
             // Daily: S M H * * ?  (seconds, minutes, hours)
             // require numeric seconds/minutes/hours and validate Quartz ranges (sec/min 0-59, hour 0-23)
             if (parts[3] == "*" && parts[4] == "*" && parts[5] == "?"
@@ -387,6 +427,22 @@ namespace DBADash
                     BaseHour = hr,
                     BaseMinute = min,
                     BaseSecond = s
+                };
+                return true;
+            }
+
+            // Legacy daily form: S M H 1/1 * ? *
+            if (parts[3] == "1/1" && parts[4] == "*" && parts[5] == "?"
+                && TryParseField(parts[0], 0, 59, out int legacyS)
+                && TryParseField(parts[1], 0, 59, out int legacyMin)
+                && TryParseField(parts[2], 0, 23, out int legacyHr))
+            {
+                state = new ParsedCronState
+                {
+                    Mode = FrequencyMode.Daily,
+                    BaseHour = legacyHr,
+                    BaseMinute = legacyMin,
+                    BaseSecond = legacyS
                 };
                 return true;
             }
@@ -413,6 +469,41 @@ namespace DBADash
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Normalize a Quartz cron expression to a canonical form for grouping.
+        /// Unsupported expressions are returned trimmed and unchanged.
+        /// </summary>
+        public static string NormalizeCronExpression(string cron)
+        {
+            if (string.IsNullOrWhiteSpace(cron)) return string.Empty;
+
+            var trimmed = cron.Trim();
+            if (!TryParseCronState(trimmed, out var state)) return trimmed;
+
+            var canonicalSelectedDays = state.SelectedDays is { Length: > 0 }
+                ? CanonicalizeSelectedDays(state.SelectedDays)
+                : Array.Empty<string>();
+            var hasSelectedDays = canonicalSelectedDays.Length > 0 && !(canonicalSelectedDays.Length == 1 && canonicalSelectedDays[0] == "*");
+
+            return state.Mode switch
+            {
+                FrequencyMode.EveryNSeconds => hasSelectedDays
+                    ? $"{state.BaseSecond}/{state.Interval} * * ? * {string.Join(',', canonicalSelectedDays)}"
+                    : $"{state.BaseSecond}/{state.Interval} * * * * ?",
+                FrequencyMode.EveryNMinutes => hasSelectedDays
+                    ? $"{state.BaseSecond} {state.BaseMinute}/{state.Interval} * ? * {string.Join(',', canonicalSelectedDays)}"
+                    : $"{state.BaseSecond} {state.BaseMinute}/{state.Interval} * * * ?",
+                FrequencyMode.EveryNHours => hasSelectedDays
+                    ? $"{state.BaseSecond} {state.BaseMinute} {state.BaseHour}/{state.Interval} ? * {string.Join(',', canonicalSelectedDays)}"
+                    : $"{state.BaseSecond} {state.BaseMinute} {state.BaseHour}/{state.Interval} * * ?",
+                FrequencyMode.Daily => $"{state.BaseSecond} {state.BaseMinute} {state.BaseHour} * * ?",
+                FrequencyMode.Weekly => hasSelectedDays
+                    ? $"{state.BaseSecond} {state.BaseMinute} {state.BaseHour} ? * {string.Join(',', canonicalSelectedDays)}"
+                    : $"{state.BaseSecond} {state.BaseMinute} {state.BaseHour} * * ?",
+                _ => trimmed
+            };
         }
     }
 }

--- a/DBADashService/SchedulerService.cs
+++ b/DBADashService/SchedulerService.cs
@@ -570,7 +570,7 @@ namespace DBADashService
                     {
                         var groupedSchedule = srcSchedule.GroupedBySchedule;
                         foreach (var schedule in customCollections
-                                                    .GroupBy(c => c.Value.Schedule)
+                                                    .GroupBy(c => c.Value.NormalizedSchedule)
                                                     .Where(c => !groupedSchedule.ContainsKey(c.Key))
                                                     .Select(c => c.Key))
                         {
@@ -583,7 +583,7 @@ namespace DBADashService
                             var collections = RemoveNotApplicableCollections(s.Value);
 
                             var custom = customCollections
-                                .Where(c => c.Value.Schedule == s.Key)
+                                .Where(c => c.Value.NormalizedSchedule == s.Key)
                                 .ToDictionary(c => c.Key, c => c.Value);
                             var job = GetJob(collections.ToArray(), src, cfgString, custom, s.Key);
                             Log.Information("Add schedule for {source} to collect {collection},{custom} on schedule {schedule}", src.SourceConnection.ConnectionForPrint, collections, custom.Keys, s.Key);
@@ -593,17 +593,17 @@ namespace DBADashService
                         if (src.SchemaSnapshotDBs is { Length: > 0 })
                         {
                             var snapshotSchedule = srcSchedule[CollectionType.SchemaSnapshot];
-                            if (!string.IsNullOrEmpty(snapshotSchedule.Schedule))
+                            if (!string.IsNullOrEmpty(snapshotSchedule.NormalizedSchedule))
                             {
-                                Log.Information("Add schedule for {source} to collect Schema Snapshots on schedule {schedule}", src.SourceConnection.ConnectionForPrint, snapshotSchedule.Schedule);
+                                Log.Information("Add schedule for {source} to collect Schema Snapshots on schedule {schedule}", src.SourceConnection.ConnectionForPrint, snapshotSchedule.NormalizedSchedule);
                                 var job = JobBuilder.Create<SchemaSnapshotJob>()
                                     .UsingJobData("Source", src.SourceConnection.ConnectionString)
                                     .UsingJobData("CFG", cfgString)
                                     .UsingJobData("SchemaSnapshotDBs", src.SchemaSnapshotDBs)
-                                    .UsingJobData("Schedule", snapshotSchedule.Schedule)
+                                    .UsingJobData("Schedule", snapshotSchedule.NormalizedSchedule)
                                     .Build();
 
-                                ScheduleJob(snapshotSchedule.Schedule, job);
+                                ScheduleJob(snapshotSchedule.NormalizedSchedule, job);
 
                                 if (snapshotSchedule.RunOnServiceStart)
                                 {
@@ -616,9 +616,9 @@ namespace DBADashService
                     }
                 case ConnectionType.Directory or ConnectionType.AWSS3:
                     {
-                        var job = GetJob(null, src, cfgString, null, CollectionSchedule.DefaultImportSchedule.Schedule);
-                        Log.Information("Add schedule for {source} to import on schedule {schedule}", src.SourceConnection.ConnectionForPrint, CollectionSchedule.DefaultImportSchedule);
-                        ScheduleJob(CollectionSchedule.DefaultImportSchedule.Schedule, job);
+                        var job = GetJob(null, src, cfgString, null, CollectionSchedule.DefaultImportSchedule.NormalizedSchedule);
+                        Log.Information("Add schedule for {source} to import on schedule {schedule}", src.SourceConnection.ConnectionForPrint, CollectionSchedule.DefaultImportSchedule.NormalizedSchedule);
+                        ScheduleJob(CollectionSchedule.DefaultImportSchedule.NormalizedSchedule, job);
                         break;
                     }
             }
@@ -716,7 +716,7 @@ namespace DBADashService
             var grouped = srcSchedule.GroupedBySchedule;
 
             foreach (var schedule in customCollections
-                .GroupBy(c => c.Value.Schedule)
+                .GroupBy(c => c.Value.NormalizedSchedule)
                 .Where(g => !grouped.ContainsKey(g.Key))
                 .Select(g => g.Key))
             {
@@ -753,7 +753,7 @@ namespace DBADashService
 
                     // Pre-filter custom collections for this schedule, compute once
                     var customForSchedule = customCollections
-                        .Where(c => c.Value.Schedule == scheduleKey)
+                        .Where(c => c.Value.NormalizedSchedule == scheduleKey)
                         .ToDictionary(c => c.Key, c => c.Value);
 
                     var finalKey = BuildScheduleGroupKey(scheduleKey, collections, customForSchedule.Keys);
@@ -773,7 +773,7 @@ namespace DBADashService
             foreach (var src in connections.Where(src => src.SourceConnection.Type != ConnectionType.SQL))
             {
                 // Non-SQL sources (Directory, AWSS3) - single import schedule
-                var scheduleKey = CollectionSchedule.DefaultImportSchedule.Schedule;
+                var scheduleKey = CollectionSchedule.DefaultImportSchedule.NormalizedSchedule;
                 var finalKey = BuildScheduleGroupKey(scheduleKey, Array.Empty<CollectionType>(), null);
                 if (!scheduleGroups.TryGetValue(finalKey, out var bucket))
                 {
@@ -841,14 +841,14 @@ namespace DBADashService
             var typeGroups = onStartTypes
                 .GroupBy(t =>
                 {
-                    var sched = srcSchedule.ContainsKey(t) ? srcSchedule[t].Schedule : null;
+                    var sched = srcSchedule.ContainsKey(t) ? srcSchedule[t].NormalizedSchedule : null;
                     return ScheduledCollectionJob.ComputePriorityFromSchedule(sched);
                 })
                 .ToDictionary(g => g.Key, g => g.ToArray());
 
             var customOnStartGroups = customCollections
                 .Where(c => c.Value.RunOnServiceStart)
-                .GroupBy(kvp => ScheduledCollectionJob.ComputePriorityFromSchedule(kvp.Value?.Schedule))
+                .GroupBy(kvp => ScheduledCollectionJob.ComputePriorityFromSchedule(kvp.Value?.NormalizedSchedule))
                 .ToDictionary(g => g.Key, g => g.ToDictionary(x => x.Key, x => x.Value));
 
             // Enqueue one work item per priority group (merge custom with same priority)


### PR DESCRIPTION
* Update default schedules so they use the same format generated by cron expression builder
* Update cron expression builder to handle legacy formats
* Normalization of cron expressions for schedule grouping.  Ensure equivalent old format cron schedules can be grouped with new format cron schedules.