### PR TITLE
Copilot/fix failing GitHub actions job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Run Pester Tests
         shell: powershell
         run: |     
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
           Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
@@ -146,4 +149,3 @@ jobs:
         shell: powershell
         run: | 
             ./Scripts/Get-TableCounts -ServerInstance "LOCALHOST" -Database "DBADashDB_GitHubAction" 
-


### PR DESCRIPTION
The **Build & Test** GitHub Actions job was failing before test execution because `Install-Module Pester` could not find the module in the runner’s PowerShell repository configuration. This change makes the Pester step resilient when `PSGallery` is not pre-registered.

- ### CI workflow hardening
  - Updated `.github/workflows/ci.yml` in the **Run Pester Tests** step.
  - Added a pre-check for `PSGallery` and auto-registration via `Register-PSRepository -Default` when missing.
  - Left the existing Pester install/import/invoke flow unchanged.

- ### Why this resolves the failure
  - Ensures `Install-Module Pester` has a valid repository source in runner contexts where repository registration is absent or reset.

```powershell
if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
  Register-PSRepository -Default
}
Install-Module Pester -Force -SkipPublisherCheck
Import-Module Pester -PassThru
Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
```