### PR TITLE
Blocking - Deadlock date fix

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/Deadlocks_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/Deadlocks_Get.sql
@@ -18,6 +18,8 @@ SELECT @Use60Min = CASE WHEN @Use60Min IS NOT NULL THEN @Use60Min WHEN @DateGrou
 SET @SQL = N'
 WITH Deadlocks AS (
 	SELECT  PC.SnapshotDate,
+			/* The snapshot date is the date the metric was collected.  The deadlock events occurred between PreviousSnapshotDate and SnapshotDate.  We can use this for filtering in sp_BlitzLock */
+			LAG(PC.SnapshotDate) OVER (ORDER BY PC.SnapshotDate) AS PreviousSnapshotDate,
 			/* Convert deadlocks/sec to deadlock count */
 			CAST(ROUND((' + CASE WHEN @Use60Min=1 THEN '(PC.Value_Total/PC.SampleCount)' ELSE 'PC.value' END + ' * (DATEDIFF(ms,LAG(PC.SnapshotDate) OVER (ORDER BY PC.SnapshotDate),PC.SnapshotDate)/1000.0)),0) AS BIGINT) AS DeadlockCount
 	FROM dbo.PerformanceCounters' + CASE WHEN @Use60Min=1 THEN '_60MIN' ELSE '' END + ' PC
@@ -30,6 +32,7 @@ WITH Deadlocks AS (
 	AND C.instance_name = ''_Total''
 )
 SELECT ' + @DateGroupingSQL + ' AS SnapshotDate,
+		MIN(PreviousSnapshotDate) AS PreviousSnapshotDate,
 		SUM(DeadlockCount) AS DeadlockCount
 FROM Deadlocks
 ' + CASE WHEN @DateGroupingMin = 0 OR @DateGroupingMin IS NULL THEN '' ELSE 'CROSS APPLY dbo.DateGroupingMins(Deadlocks.SnapshotDate,@DateGroupingMin) DG' END + '

--- a/DBADashGUI/Performance/Blocking.cs
+++ b/DBADashGUI/Performance/Blocking.cs
@@ -553,8 +553,15 @@ namespace DBADashGUI.Performance
                 if (idx < 0 || idx >= _deadlockRows.Count) return;
                 var deadlockRow = _deadlockRows[idx];
                 var snapshotDateUtc = (DateTime)deadlockRow["SnapshotDate"];
-                var fromUtc = snapshotDateUtc.AddMinutes(-Math.Max(_deadlockDateGroupingMin, 1));
-                _ = ShowDeadlockReportAsync(fromUtc, snapshotDateUtc);
+                // Determine the report date range represented by this deadlock snapshot.
+                // Start = PreviousSnapshotDate (if available) or snapshot minus 1 minute as a safe default.
+                // End = snapshot + _deadlockDateGroupingMin minutes to include the full grouping bucket.
+                // Example: a deadlock at 01:59:36 may be included in the 02:00 snapshot; using the previous snapshot
+                // as the start and adding the grouping minutes to the end ensures the report covers the entire interval
+                // represented by that snapshot bucket.
+                var fromUtc = deadlockRow["PreviousSnapshotDate"] == DBNull.Value ? snapshotDateUtc.AddMinutes(-1) : (DateTime)deadlockRow["PreviousSnapshotDate"];
+                var toUtc = snapshotDateUtc.AddMinutes(_deadlockDateGroupingMin);
+                _ = ShowDeadlockReportAsync(fromUtc, toUtc);
                 return;
             }
             // Try to map the clicked ChartPoint back to the original row.


### PR DESCRIPTION
Fix deadlock drilldown date filtering when using date groupings.

Date groupings should be added to the snapshot date range rather than subtracted. Filtering must also start from the previous snapshot date to ensure the correct data is included.

This issue was masked when using a 1-minute date grouping because snapshots are taken at 1-minute intervals, causing the drilldowns to appear correct.