### PR TITLE
fix: ensure PSGallery exists before installing Pester in CI

### DIFF
--- a/.github/workflows/ci_BucketDestination.yml
+++ b/.github/workflows/ci_BucketDestination.yml
@@ -307,6 +307,9 @@ jobs:
       - name: Run Pester Tests FromBucket
         shell: powershell
         run: |     
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
           Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_FromBucket" }

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -203,6 +203,9 @@ jobs:
       - name: Run Pester Tests FromFolder
         shell: powershell
         run: |     
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
           Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_FromFolder" }

--- a/.github/workflows/ci_MinimalPermissions.yml
+++ b/.github/workflows/ci_MinimalPermissions.yml
@@ -154,6 +154,9 @@ jobs:
       - name: Run Pester Tests
         shell: powershell
         run: |     
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
           Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -PassThru
           $NoWMI=$true


### PR DESCRIPTION
Apply earlier fix to other workflows.