### PR TITLE
Harden post-build asset download against transient GitHub 5xx failure

### DIFF
--- a/DBADashServiceConfig/PostBuild.ps1
+++ b/DBADashServiceConfig/PostBuild.ps1
@@ -25,6 +25,29 @@ for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
     }
 }
 
+function Invoke-WebRequestWithRetry {
+    param(
+        [string]$Uri,
+        [string]$OutFile,
+        [hashtable]$Headers,
+        [int]$MaxRetries = 3
+    )
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        try {
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -Headers $Headers
+            return
+        } catch {
+            if (Test-Path $OutFile) {
+                Remove-Item -Path $OutFile -Force
+            }
+            if ($attempt -eq $MaxRetries) { throw }
+            Write-Warning "Download failed (attempt $attempt/$MaxRetries): $_. Retrying..."
+            Start-Sleep -Seconds (5 * $attempt)
+        }
+    }
+}
+
 # 2. Narrow the asset match to the specific zip name and ensure only one result
 # Using -like "SerializedDataSetViewer_*.zip" to ignore other potential zip assets
 $URL = $ReleaseData.assets | 
@@ -43,7 +66,7 @@ $ConfigFile = [System.IO.Path]::Combine($Folder, "appsettings.json")
 
 # 4. Download and Extract
 Write-Host "Downloading latest version: $FileName"
-Invoke-WebRequest -Uri $URL -OutFile $DownloadPath
+Invoke-WebRequestWithRetry -Uri $URL -OutFile $DownloadPath -Headers $ApiHeaders -MaxRetries $MaxRetries
 Expand-Archive -Path $DownloadPath -DestinationPath $Folder -Force
 
 # 5. Cleanup and Config


### PR DESCRIPTION
The `Build (csharp, 2022, Latin1_General_BIN)` Actions job was failing in `ServiceConfigTool` post-build due to a transient `504 Gateway Timeout` while downloading the latest `SerializedDataSetViewer` release asset. This PR makes that download path resilient to intermittent network/API failures.

- **Root cause addressed**
  - `DBADashServiceConfig/PostBuild.ps1` retried the GitHub *release metadata* call, but performed the actual asset download with a single `Invoke-WebRequest` attempt.
  - A single transient HTTP failure terminated the build with `MSB3073`.

- **Change made**
  - Added `Invoke-WebRequestWithRetry` in `DBADashServiceConfig/PostBuild.ps1`.
  - Switched zip download to use retry/backoff behavior consistent with the metadata fetch.
  - On failed attempts, removes partial download files before retrying to avoid corrupt archive extraction.

- **Behavioral impact**
  - No functional change to artifact selection, extraction, or config output.
  - Build no longer fails on first transient download timeout.

```powershell
function Invoke-WebRequestWithRetry {
    param([string]$Uri, [string]$OutFile, [hashtable]$Headers, [int]$MaxRetries = 3)

    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
        try {
            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -Headers $Headers
            return
        } catch {
            if (Test-Path $OutFile) { Remove-Item -Path $OutFile -Force }
            if ($attempt -eq $MaxRetries) { throw }
            Start-Sleep -Seconds (5 * $attempt)
        }
    }
}
```