### PR TITLE
Add option for drill down to open in a new Window

### DIFF
--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -761,6 +761,9 @@ namespace DBADashGUI.CustomReports
                 reportDS = await GetReportDataAsync(token);
                 this.Invoke(() =>
                 {
+                    // Guard: if this CTS has been superseded by a newer RefreshData call,
+                    // discard results to avoid rendering stale data with the wrong Report.
+                    if (!ReferenceEquals(cts, cancellationTokenSource)) return;
                     ShowParamPrompt(false); // Show grid
                     LoadResultsCombo();
                     if (reportDS.Tables.Count > 0)
@@ -778,7 +781,8 @@ namespace DBADashGUI.CustomReports
                             MessageBoxIcon.Warning);
                     }
                 });
-                SetStatus("Completed", "Success", DashColors.Success);
+                if (ReferenceEquals(cts, cancellationTokenSource))
+                    SetStatus("Completed", "Success", DashColors.Success);
             }
             catch (SqlException ex) when (ex.Number == 201) // Parameter required
             {
@@ -791,8 +795,11 @@ namespace DBADashGUI.CustomReports
             }
             finally
             {
-                IsMessageInProgress = false;
-                StopTimer();
+                if (ReferenceEquals(cts, cancellationTokenSource))
+                {
+                    IsMessageInProgress = false;
+                    StopTimer();
+                }
                 try
                 {
                     // Clear the static field if it still references this run's CTS
@@ -1057,6 +1064,23 @@ namespace DBADashGUI.CustomReports
 
         private void GetChartPanels()
         {
+            // Always move chartLayout to ChartPanel before any early return.
+            // If this is skipped (e.g. different report with no charts), chartLayout can end up in
+            // TablePanel from a previous report, covering the grids and making them invisible.
+            try
+            {
+                if (chartLayout.Parent != ChartPanel)
+                {
+                    chartLayout.Parent?.Controls.Remove(chartLayout);
+                    ChartPanel.Controls.Add(chartLayout);
+                    chartLayout.Dock = DockStyle.Fill;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"GetChartPanels: error repositioning chartLayout: {ex}");
+            }
+
             if (Report.Charts == null || Report.Charts.Count == 0) return;
             // Allow metric-chart-only reports to render even if there are no result tables
             if (reportDS == null || reportDS.Tables.Count == 0)
@@ -1965,6 +1989,13 @@ namespace DBADashGUI.CustomReports
                 if (!PreventReportOverwrite)
                 {
                     Report = _context.Report ?? Report;
+                }
+                // Clear drill-down navigation state on tree navigation (not drill-down).
+                // This prevents a stale back button when the user selects a different report
+                // in the tree or navigates to a different level.
+                if (sqlParams == null)
+                {
+                    ClearNavigationStack();
                 }
                 OnContextChanged(isDrillDown: sqlParams != null);
                 customParams = sqlParams ?? Report.GetCustomSqlParameters();

--- a/DBADashGUI/CustomReports/LinkColumnInfo.cs
+++ b/DBADashGUI/CustomReports/LinkColumnInfo.cs
@@ -183,9 +183,11 @@ namespace DBADashGUI.CustomReports
             }
             var filters = GridFilterFactory?.Invoke(row) ?? GridFilters;
 
+            var targetViewType = report.ViewType ?? typeof(CustomReportView);
             var useExistingWindow = DrillDownMode == DrillDownMode.ExistingWindow
                                     && sender is CustomReportView
-                                    && !Control.ModifierKeys.HasFlag(Keys.Control); // Ctrl+Click forces new window
+                                    && !Control.ModifierKeys.HasFlag(Keys.Control) // Ctrl+Click forces new window
+                                    && targetViewType.IsAssignableFrom(sender.GetType()); // Fall back to new window if ViewType is incompatible
 
             if (useExistingWindow && sender is CustomReportView existingView)
             {

--- a/DBADashGUI/CustomReports/LinkColumnTypeSelector.Designer.cs
+++ b/DBADashGUI/CustomReports/LinkColumnTypeSelector.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LinkColumnTypeSelector));
             optNone = new System.Windows.Forms.RadioButton();
             optURL = new System.Windows.Forms.RadioButton();
@@ -44,6 +45,7 @@
             cboLanguage = new System.Windows.Forms.ComboBox();
             label3 = new System.Windows.Forms.Label();
             tabDrillDown = new System.Windows.Forms.TabPage();
+            chkNewWindow = new System.Windows.Forms.CheckBox();
             dgvMapping = new System.Windows.Forms.DataGridView();
             label8 = new System.Windows.Forms.Label();
             cboReport = new System.Windows.Forms.ComboBox();
@@ -65,6 +67,7 @@
             txtLinkColumn = new System.Windows.Forms.TextBox();
             optQueryPlan = new System.Windows.Forms.RadioButton();
             optNavigateTree = new System.Windows.Forms.RadioButton();
+            toolTip1 = new System.Windows.Forms.ToolTip(components);
             tab1.SuspendLayout();
             tabNone.SuspendLayout();
             tabURL.SuspendLayout();
@@ -227,6 +230,7 @@
             // 
             // tabDrillDown
             // 
+            tabDrillDown.Controls.Add(chkNewWindow);
             tabDrillDown.Controls.Add(dgvMapping);
             tabDrillDown.Controls.Add(label8);
             tabDrillDown.Controls.Add(cboReport);
@@ -238,6 +242,17 @@
             tabDrillDown.TabIndex = 3;
             tabDrillDown.Text = "Drill Down";
             tabDrillDown.UseVisualStyleBackColor = true;
+            // 
+            // chkNewWindow
+            // 
+            chkNewWindow.AutoSize = true;
+            chkNewWindow.Location = new System.Drawing.Point(291, 9);
+            chkNewWindow.Name = "chkNewWindow";
+            chkNewWindow.Size = new System.Drawing.Size(173, 24);
+            chkNewWindow.TabIndex = 15;
+            chkNewWindow.Text = "Open in new window";
+            toolTip1.SetToolTip(chkNewWindow, "Option to open drill-down report in a new window. If unchecked, the user can still open the report in a new window using Ctrl+Click.");
+            chkNewWindow.UseVisualStyleBackColor = true;
             // 
             // dgvMapping
             // 
@@ -522,5 +537,7 @@
         private System.Windows.Forms.ComboBox cboDatabaseNameCol;
         private System.Windows.Forms.ComboBox cboInstanceIDCol;
         private System.Windows.Forms.RadioButton optNavigateTree;
+        private System.Windows.Forms.CheckBox chkNewWindow;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/DBADashGUI/CustomReports/LinkColumnTypeSelector.cs
+++ b/DBADashGUI/CustomReports/LinkColumnTypeSelector.cs
@@ -87,6 +87,7 @@ namespace DBADashGUI.CustomReports
                 case DrillDownLinkColumnInfo drillDown:
                     optDrillDown.Checked = true;
                     cboReport.Text = drillDown.ReportProcedureName;
+                    chkNewWindow.Checked = drillDown.DrillDownMode == DrillDownMode.NewWindow;
                     SetTab();
                     break;
 
@@ -130,7 +131,8 @@ namespace DBADashGUI.CustomReports
                 LinkColumnInfo = new DrillDownLinkColumnInfo()
                 {
                     ReportProcedureName = cboReport.Text,
-                    ColumnToParameterMap = mapping
+                    ColumnToParameterMap = mapping,
+                    DrillDownMode = chkNewWindow.Checked ? DrillDownMode.NewWindow : DrillDownMode.ExistingWindow
                 };
             }
             else if (optQueryPlan.Checked)

--- a/DBADashGUI/CustomReports/LinkColumnTypeSelector.resx
+++ b/DBADashGUI/CustomReports/LinkColumnTypeSelector.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
The option for a drill down to open in the same window was added to the DB Options report.  Now the feature exists, make it available for user custom reports.  The default for new reports will be to use the same window - this provides the most flexibility as the user can still open in a new window using ctrl+click.