### PR TITLE
Cell highlighting fix

### DIFF
--- a/DBADashGUI/Bak/BackupsView.cs
+++ b/DBADashGUI/Bak/BackupsView.cs
@@ -23,7 +23,6 @@ namespace DBADashGUI.Backups
     /// </summary>
     internal class BackupsView : CustomReportView
     {
-        private const string ConfigureColumnName = "Configure";
         private const string BackupReportProcedureName = "BackupReport_Get";
 
         private ToolStripDropDownButton tsConfigureBackups;
@@ -147,41 +146,7 @@ namespace DBADashGUI.Backups
         protected override void OnPostGridRefresh()
         {
             base.OnPostGridRefresh();
-            foreach (var grid in Grids)
-            {
-                ApplyThresholdStyling(grid);
-            }
             UpdateToolbarState();
-        }
-
-        /// <summary>
-        /// Bold the Configure link where a threshold is explicitly configured at that level (matching the styling
-        /// in the legacy BackupsControl).
-        /// </summary>
-        private static void ApplyThresholdStyling(DBADashDataGridView grid)
-        {
-            if (grid.Columns[ConfigureColumnName] == null) return;
-            // Reuse a single bold font across all rows (created lazily) and the grid's own font for the regular case
-            // rather than allocating a Font per row on every refresh.
-            Font boldFont = null;
-            foreach (DataGridViewRow row in grid.Rows)
-            {
-                if (row.DataBoundItem is not DataRowView drv) continue;
-                var table = drv.Row.Table;
-                bool bold;
-                if (grid.ResultSetID == 0)
-                {
-                    bold = table.Columns.Contains("InstanceThresholdConfiguration")
-                           && drv["InstanceThresholdConfiguration"].DBNullToNull() is bool b && b;
-                }
-                else
-                {
-                    bold = table.Columns.Contains("ThresholdsConfiguredLevel")
-                           && (drv["ThresholdsConfiguredLevel"] as string) == "Database";
-                }
-                row.Cells[ConfigureColumnName].Style.Font =
-                    bold ? boldFont ??= new Font(grid.Font, FontStyle.Bold) : grid.Font;
-            }
         }
 
         #endregion Grid post-processing
@@ -248,6 +213,17 @@ namespace DBADashGUI.Backups
                 {
                     new() { ConditionType = CellHighlightingRule.ConditionTypes.GreaterThan, Value1 = "0", Status = statusWhenPositive },
                     new() { ConditionType = CellHighlightingRule.ConditionTypes.All, Status = DBADashStatusEnum.NA },
+                }
+            };
+
+        // Configure link bolding: bold when a threshold is explicitly configured at that level (matching the
+        // styling in the legacy BackupsControl).
+        private static CellHighlightingRuleSet ConfiguredHighlight(string column, string valueWhenConfigured) =>
+            new(column)
+            {
+                Rules = new List<CellHighlightingRule>
+                {
+                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = valueWhenConfigured, Font = new Font("Segoe UI", 9F, FontStyle.Bold) },
                 }
             };
 
@@ -329,7 +305,7 @@ namespace DBADashGUI.Backups
                         ["FullCompressionAlgorithms"] = new ColumnMetadata { DisplayIndex = 48, Alias = "Full Compression Algorithms" },
                         ["DiffCompressionAlgorithms"] = new ColumnMetadata { DisplayIndex = 49, Alias = "Diff Compression Algorithms" },
                         ["LogCompressionAlgorithms"] = new ColumnMetadata { DisplayIndex = 50, Alias = "Log Compression Algorithms" },
-                        ["Configure"] = new ColumnMetadata { DisplayIndex = 51, Alias = "Configure", Link = new BackupConfigureThresholdLink { DatabaseLevel = false }, Description = "Configure instance-level thresholds" },
+                        ["Configure"] = new ColumnMetadata { DisplayIndex = 51, Alias = "Configure", Link = new BackupConfigureThresholdLink { DatabaseLevel = false }, Description = "Configure instance-level thresholds", Highlighting = ConfiguredHighlight("InstanceThresholdConfiguration", "True") },
                         // Hidden technical columns.
                         ["Instance"] = Hidden(52),
                         ["SnapshotAgeStatus"] = Hidden(53),
@@ -402,7 +378,7 @@ namespace DBADashGUI.Backups
                         ["FullCompressionAlgorithm"] = new ColumnMetadata { DisplayIndex = 58, Alias = "Full Compression Algorithm" },
                         ["DiffCompressionAlgorithm"] = new ColumnMetadata { DisplayIndex = 59, Alias = "Diff Compression Algorithm" },
                         ["LogCompressionAlgorithm"] = new ColumnMetadata { DisplayIndex = 60, Alias = "Log Compression Algorithm" },
-                        ["Configure"] = new ColumnMetadata { DisplayIndex = 61, Alias = "Configure", Link = new BackupConfigureThresholdLink { DatabaseLevel = true }, Description = "Configure database-level thresholds" },
+                        ["Configure"] = new ColumnMetadata { DisplayIndex = 61, Alias = "Configure", Link = new BackupConfigureThresholdLink { DatabaseLevel = true }, Description = "Configure database-level thresholds", Highlighting = ConfiguredHighlight("ThresholdsConfiguredLevel", "Database") },
                         // Hidden technical columns - status enums driving cell highlighting and values not displayed.
                         ["Instance"] = Hidden(62),
                         ["recovery_model"] = Hidden(63),

--- a/DBADashGUI/Bak/BackupsView.cs
+++ b/DBADashGUI/Bak/BackupsView.cs
@@ -223,7 +223,7 @@ namespace DBADashGUI.Backups
             {
                 Rules = new List<CellHighlightingRule>
                 {
-                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = valueWhenConfigured, Font = new Font("Segoe UI", 9F, FontStyle.Bold) },
+                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = valueWhenConfigured, RelativeFontStyle = FontStyle.Bold },
                 }
             };
 

--- a/DBADashGUI/Changes/SQLPatchingView.cs
+++ b/DBADashGUI/Changes/SQLPatchingView.cs
@@ -217,9 +217,23 @@ namespace DBADashGUI.Changes
             {
                 if (grid.ResultSetID == 0)
                 {
-                    ApplyVersionInfoStyling(grid);
+                    grid.RowsAdded -= Grid_RowsAdded;
+                    grid.RowsAdded += Grid_RowsAdded;
+                    ApplyVersionInfoStyling(grid, 0, grid.RowCount);
                     UpdateBuildReferenceStatus(grid);
                 }
+            }
+        }
+
+        // Status here is computed from live, admin-configurable Config.*Threshold settings rather than a
+        // precomputed DB status column, so it doesn't fit the declarative CellHighlightingRuleSet model (whose
+        // rule values are fixed at definition time). This is hooked to RowsAdded (rather than a one-shot pass)
+        // so formatting survives grid sorting, since sorting a bound DataGridView resets and re-adds all rows.
+        private void Grid_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)
+        {
+            if (sender is DBADashDataGridView grid)
+            {
+                ApplyVersionInfoStyling(grid, e.RowIndex, e.RowCount);
             }
         }
 
@@ -239,12 +253,13 @@ namespace DBADashGUI.Changes
             return DBADashStatusEnum.NA;
         }
 
-        private static void ApplyVersionInfoStyling(DBADashDataGridView grid)
+        private static void ApplyVersionInfoStyling(DBADashDataGridView grid, int startIndex, int rowCount)
         {
             var hasWindowsUpdateCol = grid.Columns["IsWindowsUpdate"] is not null;
 
-            foreach (DataGridViewRow gRow in grid.Rows)
+            for (var idx = startIndex; idx < startIndex + rowCount && idx < grid.Rows.Count; idx++)
             {
+                var gRow = grid.Rows[idx];
                 if (gRow.DataBoundItem is not DataRowView drv) continue;
 
                 var supportedUntilStatus = GetThresholdStatus(

--- a/DBADashGUI/CustomReports/CellHighlightingRule.cs
+++ b/DBADashGUI/CustomReports/CellHighlightingRule.cs
@@ -20,6 +20,14 @@ namespace DBADashGUI.CustomReports
 
         public Font Font { get; set; }
 
+        /// <summary>
+        /// Font style (e.g. Bold) to apply relative to the cell's own current font, instead of a fixed <see cref="Font"/>.
+        /// Preferred over <see cref="Font"/> for a style-only change (no family/size change), since it stays
+        /// consistent with the grid's actual theme/DPI-scaled font rather than a hard-coded one. Ignored if
+        /// <see cref="Font"/> is also set.
+        /// </summary>
+        public FontStyle? RelativeFontStyle { get; set; }
+
         public DBADashStatus.DBADashStatusEnum? Status { get; set; }
 
         private bool value1IsNumeric;
@@ -170,14 +178,14 @@ namespace DBADashGUI.CustomReports
             if (Status != null)
             {
                 formattedCell.SetStatusColor((DBADashStatus.DBADashStatusEnum)(Status));
-                if (Font != null) formattedCell.Style.Font = Font;
+                ApplyFont(formattedCell);
                 return;
             }
             var b = isDarkMode && BackColorDark != Color.Empty ? BackColorDark : BackColor;
             var f = isDarkMode && ForeColorDark != Color.Empty ? ForeColorDark : ForeColor;
             if (b != Color.Empty) formattedCell.Style.BackColor = b;
             if (f != Color.Empty) formattedCell.Style.ForeColor = f;
-            if (Font != null) formattedCell.Style.Font = Font;
+            ApplyFont(formattedCell);
 
             if (f != Color.Empty && formattedCell is DataGridViewLinkCell linkCell)
             {
@@ -186,6 +194,28 @@ namespace DBADashGUI.CustomReports
                 linkCell.VisitedLinkColor = f;
             }
             if (b != Color.Empty) formattedCell.Style.SelectionBackColor = b.AdjustBasedOnLuminance();
+        }
+
+        // Cache of the derived RelativeFontStyle font, keyed by the base font it was derived from, so repeated
+        // calls (e.g. once per row on every RowsAdded/sort) don't each allocate a new Font/GDI handle.
+        private Font relativeFontCacheBase;
+        private Font relativeFontCache;
+
+        private void ApplyFont(DataGridViewCell formattedCell)
+        {
+            if (Font != null)
+            {
+                formattedCell.Style.Font = Font;
+                return;
+            }
+            if (RelativeFontStyle == null) return;
+            var baseFont = formattedCell.InheritedStyle.Font;
+            if (relativeFontCacheBase != baseFont)
+            {
+                relativeFontCache = new Font(baseFont, RelativeFontStyle.Value);
+                relativeFontCacheBase = baseFont;
+            }
+            formattedCell.Style.Font = relativeFontCache;
         }
 
         /// <summary>

--- a/DBADashGUI/DBFiles/DBFilesView.cs
+++ b/DBADashGUI/DBFiles/DBFilesView.cs
@@ -187,11 +187,14 @@ namespace DBADashGUI.DBFiles
                 grid.RowsAdded -= Grid_RowsAdded;
                 grid.RowsAdded += Grid_RowsAdded;
                 ApplyThresholdStyling(grid, 0, grid.RowCount);
-                grid.GridFilterChanged += (_, _) => UpdateTotals();
+                grid.GridFilterChanged -= Grid_GridFilterChanged;
+                grid.GridFilterChanged += Grid_GridFilterChanged;
             }
             UpdateToolbarState();
             UpdateTotals();
         }
+
+        private void Grid_GridFilterChanged(object sender, EventArgs e) => UpdateTotals();
 
         // FilegroupPctFree/FilegroupFreeMB status depends on both FreeSpaceStatus and FreeSpaceCheckType, and
         // the Configure column font depends on ConfiguredLevel/data_space_id - neither fits the declarative
@@ -251,6 +254,9 @@ namespace DBADashGUI.DBFiles
         private static void ApplyThresholdStyling(DBADashDataGridView grid, int startIndex, int rowCount)
         {
             var hasConfigureColumn = grid.Columns["Configure"] != null;
+            // Reuse a single bold font across all rows (created lazily) and the grid's own font for the regular
+            // case rather than allocating a Font per row every time this runs (including on every sort).
+            Font boldFont = null;
 
             for (var idx = startIndex; idx < startIndex + rowCount && idx < grid.Rows.Count; idx++)
             {
@@ -270,7 +276,8 @@ namespace DBADashGUI.DBFiles
                     var isConfiguredHere = drv["ConfiguredLevel"] != DBNull.Value &&
                                             ((string)drv["ConfiguredLevel"] == "FG" ||
                                              ((string)drv["ConfiguredLevel"] == "DB" && (int)drv["data_space_id"] == 0));
-                    row.Cells["Configure"].Style.Font = new Font(grid.Font, isConfiguredHere ? FontStyle.Bold : FontStyle.Regular);
+                    row.Cells["Configure"].Style.Font =
+                        isConfiguredHere ? boldFont ??= new Font(grid.Font, FontStyle.Bold) : grid.Font;
                 }
             }
 

--- a/DBADashGUI/DBFiles/DBFilesView.cs
+++ b/DBADashGUI/DBFiles/DBFilesView.cs
@@ -184,11 +184,26 @@ namespace DBADashGUI.DBFiles
             foreach (var grid in Grids)
             {
                 ToggleFileLevel(grid);
-                ApplyThresholdStyling(grid);
+                grid.RowsAdded -= Grid_RowsAdded;
+                grid.RowsAdded += Grid_RowsAdded;
+                ApplyThresholdStyling(grid, 0, grid.RowCount);
                 grid.GridFilterChanged += (_, _) => UpdateTotals();
             }
             UpdateToolbarState();
             UpdateTotals();
+        }
+
+        // FilegroupPctFree/FilegroupFreeMB status depends on both FreeSpaceStatus and FreeSpaceCheckType, and
+        // the Configure column font depends on ConfiguredLevel/data_space_id - neither fits the declarative
+        // CellHighlightingRuleSet model (single source column per target), so they're applied here instead.
+        // This is hooked to RowsAdded (rather than a one-shot pass) so formatting survives grid sorting, since
+        // sorting a bound DataGridView resets and re-adds all rows.
+        private void Grid_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)
+        {
+            if (sender is DBADashDataGridView grid)
+            {
+                ApplyThresholdStyling(grid, e.RowIndex, e.RowCount);
+            }
         }
 
         private void UpdateTotals()
@@ -233,47 +248,33 @@ namespace DBADashGUI.DBFiles
             }
         }
 
-        private static void ApplyThresholdStyling(DBADashDataGridView grid)
+        private static void ApplyThresholdStyling(DBADashDataGridView grid, int startIndex, int rowCount)
         {
-            foreach (DataGridViewRow row in grid.Rows)
+            var hasConfigureColumn = grid.Columns["Configure"] != null;
+
+            for (var idx = startIndex; idx < startIndex + rowCount && idx < grid.Rows.Count; idx++)
             {
+                var row = grid.Rows[idx];
                 if (row.DataBoundItem is not DataRowView drv) continue;
 
                 var status = (DBADashStatusEnum)drv["FreeSpaceStatus"];
-                var snapshotStatus = (DBADashStatusEnum)drv["FileSnapshotAgeStatus"];
-                var maxSizeStatus = (DBADashStatusEnum)drv["PctMaxSizeStatus"];
-                var fgAutogrowStatus = (DBADashStatusEnum)drv["FilegroupAutogrowStatus"];
                 var checkType = drv["FreeSpaceCheckType"] == DBNull.Value ? "-" : (string)drv["FreeSpaceCheckType"];
 
-                if (grid.Columns["FileSnapshotAge"] != null)
-                    row.Cells["FileSnapshotAge"].SetStatusColor(snapshotStatus);
-                if (grid.Columns["FilegroupPctOfMaxSize"] != null)
-                    row.Cells["FilegroupPctOfMaxSize"].SetStatusColor(maxSizeStatus);
-                if (grid.Columns["FilegroupAutogrowFileCount"] != null)
-                    row.Cells["FilegroupAutogrowFileCount"].SetStatusColor(fgAutogrowStatus);
                 if (grid.Columns["FilegroupPctFree"] != null)
                     row.Cells["FilegroupPctFree"].SetStatusColor(checkType == "%" ? status : DBADashStatusEnum.NA);
                 if (grid.Columns["FilegroupFreeMB"] != null)
                     row.Cells["FilegroupFreeMB"].SetStatusColor(checkType == "M" ? status : DBADashStatusEnum.NA);
 
-                if (grid.Columns["Configure"] != null)
+                if (hasConfigureColumn)
                 {
-                    if (drv["ConfiguredLevel"] != DBNull.Value && (string)drv["ConfiguredLevel"] == "FG")
-                    {
-                        row.Cells["Configure"].Style.Font = new Font(grid.Font, FontStyle.Bold);
-                    }
-                    else if (drv["ConfiguredLevel"] != DBNull.Value && (string)drv["ConfiguredLevel"] == "DB" && (int)drv["data_space_id"] == 0)
-                    {
-                        row.Cells["Configure"].Style.Font = new Font(grid.Font, FontStyle.Bold);
-                    }
-                    else
-                    {
-                        row.Cells["Configure"].Style.Font = new Font(grid.Font, FontStyle.Regular);
-                    }
+                    var isConfiguredHere = drv["ConfiguredLevel"] != DBNull.Value &&
+                                            ((string)drv["ConfiguredLevel"] == "FG" ||
+                                             ((string)drv["ConfiguredLevel"] == "DB" && (int)drv["data_space_id"] == 0));
+                    row.Cells["Configure"].Style.Font = new Font(grid.Font, isConfiguredHere ? FontStyle.Bold : FontStyle.Regular);
                 }
             }
 
-            if (grid.Columns["Configure"] != null)
+            if (hasConfigureColumn)
             {
                 grid.Columns["Configure"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
             }
@@ -361,10 +362,10 @@ namespace DBADashGUI.DBFiles
                         ["FilegroupFreeMB"] = new() { Alias = "Filegroup Free (MB)", FormatString = "N1" },
                         ["FilegroupPctFree"] = new() { Alias = "Filegroup Free %", FormatString = "P1" },
                         ["FilegroupMaxSizeMB"] = new() { Alias = "Filegroup Max Size (MB)", FormatString = "N0" },
-                        ["FilegroupPctOfMaxSize"] = new() { Alias = "Filegroup % Of Max Size", FormatString = "P1" },
+                        ["FilegroupPctOfMaxSize"] = new() { Alias = "Filegroup % Of Max Size", FormatString = "P1", Highlighting = new CellHighlightingRuleSet("PctMaxSizeStatus") { IsStatusColumn = true } },
                         ["FilegroupUsedPctOfMaxSize"] = new() { Alias = "Filegroup Used % Max Size", FormatString = "P1" },
                         ["FilegroupNumberOfFiles"] = new() { Alias = "Filegroup Number of Files" },
-                        ["FilegroupAutogrowFileCount"] = new() { Alias = "Filegroup Autogrow File Count" },
+                        ["FilegroupAutogrowFileCount"] = new() { Alias = "Filegroup Autogrow File Count", Highlighting = new CellHighlightingRuleSet("FilegroupAutogrowStatus") { IsStatusColumn = true } },
                         ["ExcludedReason"] = new() { Alias = "Excluded Reason" },
                         ["MaxSizeExcludedReason"] = new() { Alias = "Max Size Excluded Reason" },
                         ["is_read_only"] = new() { Alias = "Read Only" },
@@ -372,7 +373,7 @@ namespace DBADashGUI.DBFiles
                         ["is_in_standby"] = new() { Alias = "Standby" },
                         ["state_desc"] = new() { Alias = "State" },
                         ["ConfiguredLevel"] = new() { Alias = "Configured Level" },
-                        ["FileSnapshotAge"] = new() { Alias = "File Snapshot Age" },
+                        ["FileSnapshotAge"] = new() { Alias = "File Snapshot Age", Highlighting = new CellHighlightingRuleSet("FileSnapshotAgeStatus") { IsStatusColumn = true } },
                         ["History"] = new() { Alias = "History", Link = new FileHistoryLink(), Description = "View file space history" },
                         ["Configure"] = new() { Alias = "Configure", Link = new FileConfigureLink(), Description = "Configure file thresholds" },
                         // Hidden columns

--- a/DBADashGUI/Drives/DrivesView.cs
+++ b/DBADashGUI/Drives/DrivesView.cs
@@ -542,7 +542,7 @@ namespace DBADashGUI.Drives
                             {
                                 Rules = new List<CellHighlightingRule>
                                 {
-                                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = "False", Font = new Font("Segoe UI", 9F, FontStyle.Bold) },
+                                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = "False", RelativeFontStyle = FontStyle.Bold },
                                 }
                             }
                         },

--- a/DBADashGUI/Drives/DrivesView.cs
+++ b/DBADashGUI/Drives/DrivesView.cs
@@ -357,7 +357,11 @@ namespace DBADashGUI.Drives
             base.OnPostGridRefresh();
             foreach (var grid in Grids)
             {
-                ApplyThresholdStyling(grid);
+                grid.RowsAdded -= Grid_RowsAdded;
+                grid.RowsAdded += Grid_RowsAdded;
+                ApplyThresholdStyling(grid, 0, grid.RowCount);
+                if (grid.Columns["Configure"] != null)
+                    grid.Columns["Configure"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
             }
 
             var rowCount = Grids.FirstOrDefault()?.RowCount ?? 0;
@@ -382,16 +386,25 @@ namespace DBADashGUI.Drives
             UpdateToolbarState();
         }
 
-        private static void ApplyThresholdStyling(DBADashDataGridView grid)
+        // FreeGB/PctFreeSpace status and the threshold column formats depend on both Status and DriveCheckType,
+        // which doesn't fit the declarative CellHighlightingRuleSet model (single source column per target), so
+        // they're applied here instead. This is hooked to RowsAdded (rather than a one-shot pass) so formatting
+        // survives grid sorting, since sorting a bound DataGridView resets and re-adds all rows.
+        private void Grid_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)
         {
-            foreach (DataGridViewRow row in grid.Rows)
+            if (sender is DBADashDataGridView grid)
             {
+                ApplyThresholdStyling(grid, e.RowIndex, e.RowCount);
+            }
+        }
+
+        private static void ApplyThresholdStyling(DBADashDataGridView grid, int startIndex, int rowCount)
+        {
+            for (var idx = startIndex; idx < startIndex + rowCount && idx < grid.Rows.Count; idx++)
+            {
+                var row = grid.Rows[idx];
                 if (row.DataBoundItem is not DataRowView drv) continue;
                 var status = (DBADashStatusEnum)drv["Status"];
-                var snapshotStatus = (DBADashStatusEnum)drv["SnapshotStatus"];
-
-                if (grid.Columns["SnapshotAgeMins"] != null)
-                    row.Cells["SnapshotAgeMins"].SetStatusColor(snapshotStatus);
 
                 if (drv["DriveCheckType"] != DBNull.Value && (string)drv["DriveCheckType"] == "G")
                 {
@@ -415,19 +428,6 @@ namespace DBADashGUI.Drives
                     if (grid.Columns["DriveCriticalThreshold"] != null)
                         row.Cells["DriveCriticalThreshold"].Style.Format = "P2";
                 }
-
-                if (grid.Columns["Configure"] != null)
-                {
-                    var inherited = drv["IsInheritedThreshold"] != DBNull.Value && (bool)drv["IsInheritedThreshold"];
-                    row.Cells["Configure"].Style.Font = inherited
-                        ? new Font(grid.Font, FontStyle.Regular)
-                        : new Font(grid.Font, FontStyle.Bold);
-                }
-            }
-
-            if (grid.Columns["Configure"] != null)
-            {
-                grid.Columns["Configure"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
             }
         }
 
@@ -512,7 +512,7 @@ namespace DBADashGUI.Drives
                         ["DriveWarningThreshold"] = new ColumnMetadata { DisplayIndex = 7, Alias = "Warning" },
                         ["DriveCriticalThreshold"] = new ColumnMetadata { DisplayIndex = 8, Alias = "Critical" },
                         ["SnapshotDate"] = new ColumnMetadata { DisplayIndex = 9, Alias = "Snapshot Date", FormatString = "yyyy-MM-dd HH:mm" },
-                        ["SnapshotAgeMins"] = new ColumnMetadata { DisplayIndex = 10, Alias = "Snapshot Age (Mins)", FormatString = "N0" },
+                        ["SnapshotAgeMins"] = new ColumnMetadata { DisplayIndex = 10, Alias = "Snapshot Age (Mins)", FormatString = "N0", Highlighting = new CellHighlightingRuleSet("SnapshotStatus") { IsStatusColumn = true } },
                         ["ChangeUsedGB24Hrs"] = new ColumnMetadata { DisplayIndex = 11, Alias = "Used 24Hrs Change (GB+-)", FormatString = "+#,##0.0GB;-#,##0.0GB;-" },
                         ["ChangeUsedGB7Days"] = new ColumnMetadata { DisplayIndex = 12, Alias = "Used 7 Days Change (GB+-)", FormatString = "+#,##0.0GB;-#,##0.0GB;-" },
                         ["ChangeUsedGB30Days"] = new ColumnMetadata { DisplayIndex = 13, Alias = "Used 30 Days Change (GB+-)", FormatString = "+#,##0.0GB;-#,##0.0GB;-" },
@@ -532,7 +532,20 @@ namespace DBADashGUI.Drives
                         // Unbound link columns
                         ["Files"] = new ColumnMetadata { DisplayIndex = 26, Alias = "Files", Link = new DriveFilesLink(), Description = "View database files on this drive" },
                         ["History"] = new ColumnMetadata { DisplayIndex = 27, Alias = "History", Link = new DriveHistoryLink(), Description = "View drive space history" },
-                        ["Configure"] = new ColumnMetadata { DisplayIndex = 28, Alias = "Configure", Link = new DriveConfigureLink(), Description = "Configure drive thresholds" },
+                        ["Configure"] = new ColumnMetadata
+                        {
+                            DisplayIndex = 28,
+                            Alias = "Configure",
+                            Link = new DriveConfigureLink(),
+                            Description = "Configure drive thresholds",
+                            Highlighting = new CellHighlightingRuleSet("IsInheritedThreshold")
+                            {
+                                Rules = new List<CellHighlightingRule>
+                                {
+                                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = "False", Font = new Font("Segoe UI", 9F, FontStyle.Bold) },
+                                }
+                            }
+                        },
                     }
                 }
             },

--- a/DBADashGUI/HA/LogShippingView.cs
+++ b/DBADashGUI/HA/LogShippingView.cs
@@ -19,8 +19,6 @@ namespace DBADashGUI.LogShipping
     /// </summary>
     internal class LogShippingView : CustomReportView
     {
-        private const string ConfigureColumnName = "Configure";
-
         private ToolStripMenuItem mnuMetricsRoot;
         private ToolStripMenuItem mnuMetricsInstance;
         private ToolStripMenuItem mnuThresholdInstance;
@@ -170,41 +168,7 @@ namespace DBADashGUI.LogShipping
         protected override void OnPostGridRefresh()
         {
             base.OnPostGridRefresh();
-            foreach (var grid in Grids)
-            {
-                ApplyThresholdStyling(grid);
-            }
             UpdateToolbarState();
-        }
-
-        /// <summary>
-        /// Bold the Configure link where a threshold is explicitly configured at that level (matching the
-        /// styling in the legacy LogShippingControl).
-        /// </summary>
-        private static void ApplyThresholdStyling(DBADashDataGridView grid)
-        {
-            if (grid.Columns[ConfigureColumnName] == null) return;
-            // Reuse a single bold font across all rows (created lazily) and the grid's own font for the regular case
-            // rather than allocating a Font per row on every refresh.
-            Font boldFont = null;
-            foreach (DataGridViewRow row in grid.Rows)
-            {
-                if (row.DataBoundItem is not DataRowView drv) continue;
-                var table = drv.Row.Table;
-                bool bold;
-                if (grid.ResultSetID == 0)
-                {
-                    bold = table.Columns.Contains("InstanceLevelThreshold")
-                           && drv["InstanceLevelThreshold"].DBNullToNull() is bool b && b;
-                }
-                else
-                {
-                    bold = table.Columns.Contains("ThresholdConfiguredLevel")
-                           && (drv["ThresholdConfiguredLevel"] as string) == "Database";
-                }
-                row.Cells[ConfigureColumnName].Style.Font =
-                    bold ? boldFont ??= new Font(grid.Font, FontStyle.Bold) : grid.Font;
-            }
         }
 
         #endregion Grid post-processing
@@ -266,6 +230,17 @@ namespace DBADashGUI.LogShipping
         private static CellHighlightingRuleSet SnapshotHighlight() =>
             new("SnapshotAgeStatus") { IsStatusColumn = true };
 
+        // Configure link bolding: bold when a threshold is explicitly configured at that level (matching the
+        // styling in the legacy LogShippingControl).
+        private static CellHighlightingRuleSet ConfiguredHighlight(string column, string valueWhenConfigured) =>
+            new(column)
+            {
+                Rules = new List<CellHighlightingRule>
+                {
+                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = valueWhenConfigured, Font = new Font("Segoe UI", 9F, FontStyle.Bold) },
+                }
+            };
+
         private static ColumnMetadata Hidden(int displayIndex) =>
             new() { Visible = false, DisplayIndex = displayIndex };
 
@@ -311,7 +286,7 @@ namespace DBADashGUI.LogShipping
                         ["MaxDateOfLastBackupRestored"] = new ColumnMetadata { DisplayIndex = 18, Alias = "Backup Date of Newest File" },
                         ["MinLastRestoreCompleted"] = new ColumnMetadata { DisplayIndex = 19, Alias = "Restore Date of Oldest File" },
                         ["MaxLastRestoreCompleted"] = new ColumnMetadata { DisplayIndex = 20, Alias = "Restore Date of Newest File" },
-                        ["Configure"] = new ColumnMetadata { DisplayIndex = 21, Alias = "Configure", Link = new LogShippingConfigureThresholdLink { DatabaseLevel = false }, Description = "Configure instance-level thresholds" },
+                        ["Configure"] = new ColumnMetadata { DisplayIndex = 21, Alias = "Configure", Link = new LogShippingConfigureThresholdLink { DatabaseLevel = false }, Description = "Configure instance-level thresholds", Highlighting = ConfiguredHighlight("InstanceLevelThreshold", "True") },
                         // Numeric (minutes) columns - hidden by default, available via the column chooser.
                         ["MaxTotalTimeBehind"] = Hidden(22),
                         ["MinTotalTimeBehind"] = Hidden(23),
@@ -348,7 +323,7 @@ namespace DBADashGUI.LogShipping
                         ["SnapshotDate"] = new ColumnMetadata { DisplayIndex = 12, Alias = "Snapshot Date" },
                         ["last_file"] = new ColumnMetadata { DisplayIndex = 13, Alias = "Last File" },
                         ["ThresholdConfiguredLevel"] = new ColumnMetadata { DisplayIndex = 14, Alias = "Threshold Level" },
-                        ["Configure"] = new ColumnMetadata { DisplayIndex = 15, Alias = "Configure", Link = new LogShippingConfigureThresholdLink { DatabaseLevel = true }, Description = "Configure database-level thresholds" },
+                        ["Configure"] = new ColumnMetadata { DisplayIndex = 15, Alias = "Configure", Link = new LogShippingConfigureThresholdLink { DatabaseLevel = true }, Description = "Configure database-level thresholds", Highlighting = ConfiguredHighlight("ThresholdConfiguredLevel", "Database") },
                         // Numeric (minutes) columns - hidden by default, available via the column chooser.
                         ["TotalTimeBehind"] = Hidden(16),
                         ["LatencyOfLast"] = Hidden(17),

--- a/DBADashGUI/HA/LogShippingView.cs
+++ b/DBADashGUI/HA/LogShippingView.cs
@@ -237,7 +237,7 @@ namespace DBADashGUI.LogShipping
             {
                 Rules = new List<CellHighlightingRule>
                 {
-                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = valueWhenConfigured, Font = new Font("Segoe UI", 9F, FontStyle.Bold) },
+                    new() { ConditionType = CellHighlightingRule.ConditionTypes.Equals, Value1 = valueWhenConfigured, RelativeFontStyle = FontStyle.Bold },
                 }
             };
 


### PR DESCRIPTION
Use cell highlighting rules where possible.
Ensure highlighting remains in place when the grid is sorted. Fix: Files, SQL Patching, Backups & Log Shipping tabs