### PR TITLE
Add Schedule Info collection type

### DIFF
--- a/DBADash/CollectionSchedule.cs
+++ b/DBADash/CollectionSchedule.cs
@@ -73,6 +73,8 @@ namespace DBADashService
 
                             {CollectionType.TableSize, new CollectionSchedule() {Schedule = disabled, RunOnServiceStart = false} },
                             {CollectionType.FailedLogins, new CollectionSchedule() {Schedule = disabled, RunOnServiceStart = false} },
+
+                            {CollectionType.ScheduleInfo, new CollectionSchedule() {Schedule = disabled, RunOnServiceStart = true} },
         };
 
         public static readonly CollectionSchedules DefaultSchedules

--- a/DBADash/Cron/CronNextFireTime.cs
+++ b/DBADash/Cron/CronNextFireTime.cs
@@ -1,0 +1,33 @@
+using System;
+using Quartz;
+
+namespace DBADash
+{
+    /// <summary>
+    /// Computes the next occurrence of a Quartz cron expression on demand, rather than persisting
+    /// a next-fire timestamp that would go stale the moment the job actually fires.
+    /// </summary>
+    public static class CronNextFireTime
+    {
+        public static DateTime? TryGetNextFireTimeUtc(string normalizedCron, DateTimeOffset afterUtc)
+        {
+            if (string.IsNullOrEmpty(normalizedCron)) return null;
+            if (int.TryParse(normalizedCron, out var seconds))
+            {
+                // Integer-seconds interval schedule rather than a cron expression - there's no fixed
+                // anchor to compute an exact next fire time from, so approximate as one interval from now
+                // (same assumption CronParser.TryGetMaxIntervalMinutes makes for these schedules).
+                return seconds > 0 ? afterUtc.AddSeconds(seconds).UtcDateTime : null;
+            }
+            try
+            {
+                var expr = new CronExpression(normalizedCron);
+                return expr.GetNextValidTimeAfter(afterUtc)?.UtcDateTime;
+            }
+            catch (FormatException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/DBADash/Cron/CronParser.cs
+++ b/DBADash/Cron/CronParser.cs
@@ -1,3 +1,5 @@
+using Humanizer;
+using Quartz;
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -469,6 +471,111 @@ namespace DBADash
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Compute the maximum number of minutes that can elapse between firings for a recognized cron
+        /// expression - used to size an auto-threshold that tolerates the longest normal gap (e.g. a
+        /// day-of-week restriction) rather than the average, which would false-alarm after the longest
+        /// legitimate gap.
+        /// </summary>
+        /// <param name="cron">Cron expression to evaluate.</param>
+        /// <param name="minutes">Maximum interval in minutes when the expression is recognized; otherwise 0.</param>
+        /// <returns>True if a maximum interval could be derived; false for unrecognized/custom expressions.</returns>
+        public static bool TryGetMaxIntervalMinutes(string cron, out double minutes)
+        {
+            minutes = 0;
+            if (int.TryParse(cron, out var seconds))
+            {
+                // Integer-seconds interval schedule (e.g. "30") rather than a cron expression -
+                // same format GetScheduleDescription already recognizes.
+                minutes = seconds / 60.0;
+                return minutes > 0;
+            }
+            if (!TryParseCronState(cron, out var state)) return false;
+
+            var hasDayRestriction = state.SelectedDays is { Length: > 0 };
+            // dayGap is the largest number of days between consecutive active days (cyclic); 1 when every day is active.
+            var dayGap = hasDayRestriction ? MaxDayGap(state.SelectedDays) : 1;
+
+            minutes = state.Mode switch
+            {
+                FrequencyMode.EveryNSeconds => (dayGap - 1) * 1440.0 + state.Interval / 60.0,
+                FrequencyMode.EveryNMinutes => (dayGap - 1) * 1440.0 + state.Interval,
+                FrequencyMode.EveryNHours => (dayGap - 1) * 1440.0 + state.Interval * 60.0,
+                FrequencyMode.Daily => 1440.0,
+                FrequencyMode.Weekly => dayGap * 1440.0,
+                _ => 0
+            };
+            return minutes > 0;
+        }
+
+        /// <summary>
+        /// Largest cyclic gap in days between consecutive entries in a set of selected days (e.g. MON+WED
+        /// selected returns 5, the Wed-to-Mon gap). Returns 1 when every day is selected (no real restriction).
+        /// </summary>
+        private static int MaxDayGap(string[] selectedDays)
+        {
+            var names = DayNames();
+            var indices = selectedDays
+                .Select(d => Array.IndexOf(names, d.Trim().ToUpperInvariant()))
+                .Where(i => i >= 0)
+                .Distinct()
+                .OrderBy(i => i)
+                .ToArray();
+            if (indices.Length == 0) return 1;
+
+            var maxGap = 0;
+            for (var k = 0; k < indices.Length; k++)
+            {
+                var gap = indices[(k + 1) % indices.Length] - indices[k];
+                if (gap <= 0) gap += 7;
+                maxGap = Math.Max(maxGap, gap);
+            }
+            return maxGap;
+        }
+
+        /// <summary>
+        /// Build a human-readable description of a schedule (cron expression, integer-seconds interval, or empty/disabled).
+        /// </summary>
+        /// <param name="schedule">Cron expression, integer seconds interval, or empty string for disabled.</param>
+        /// <param name="runOnServiceStart">
+        /// When <paramref name="schedule"/> is empty, distinguishes a collection that only ever runs once at
+        /// service start from one that's genuinely disabled - both are represented the same way (empty
+        /// schedule) but "Disabled" would be misleading for the former.
+        /// </param>
+        /// <exception cref="ArgumentException">Thrown when the schedule is a non-empty string that isn't a valid cron expression.</exception>
+        public static string GetScheduleDescription(string schedule, bool runOnServiceStart = false)
+        {
+            if (string.IsNullOrEmpty(schedule))
+            {
+                return runOnServiceStart ? "Startup Only" : "Disabled";
+            }
+            if (int.TryParse(schedule, out int seconds))
+            {
+                return TimeSpan.FromSeconds(seconds).Humanize(5);
+            }
+            if (!CronExpression.IsValidExpression(schedule))
+            {
+                throw new ArgumentException("Invalid cron expression", nameof(schedule));
+            }
+            return CronExpressionDescriptor.ExpressionDescriptor.GetDescription(schedule);
+        }
+
+        /// <summary>
+        /// <see cref="GetScheduleDescription"/>, falling back to <paramref name="invalidFallback"/> (or the
+        /// raw schedule string when not supplied) if the schedule can't be parsed as a cron expression.
+        /// </summary>
+        public static string GetScheduleDescriptionSafe(string schedule, string invalidFallback = null, bool runOnServiceStart = false)
+        {
+            try
+            {
+                return GetScheduleDescription(schedule, runOnServiceStart);
+            }
+            catch (ArgumentException)
+            {
+                return invalidFallback ?? schedule;
+            }
         }
 
         /// <summary>

--- a/DBADash/DBADash.csproj
+++ b/DBADash/DBADash.csproj
@@ -121,6 +121,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="4.0.100" />
     <PackageReference Include="Azure.Core" Version="1.59.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="CronExpressionDescriptor" Version="2.50.0" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
@@ -144,6 +145,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Polly.Core" Version="8.7.0" />
+    <PackageReference Include="Quartz" Version="3.18.2" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="SerilogTimings" Version="3.1.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.9" />

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -83,7 +83,8 @@ namespace DBADash
         InstanceMetadata,
         FailedLogins,
         ResourceGovernorWorkloadGroups,
-        ResourceGovernorResourcePools
+        ResourceGovernorResourcePools,
+        ScheduleInfo
     }
 
     public enum HostPlatform
@@ -705,6 +706,12 @@ namespace DBADash
             }
             else if (collectionType == CollectionType.InstanceMetadata && (IsAzureDB || IsRDS || noWMI))
             {
+                return false;
+            }
+            else if (collectionType == CollectionType.ScheduleInfo)
+            {
+                // Reported independently of the monitored instance (see ScheduleInfoReporter) - should
+                // never reach the normal per-instance collection pipeline.
                 return false;
             }
             if (collectionType == CollectionType.ResourceGovernorWorkloadGroups || collectionType == CollectionType.ResourceGovernorResourcePools)

--- a/DBADash/DBImporter.cs
+++ b/DBADash/DBImporter.cs
@@ -396,11 +396,43 @@ namespace DBADash
             await cmd.ExecuteNonQueryAsync();
         }
 
+        /// <summary>
+        /// Schedule info is reported independently of a full instance snapshot (see ScheduleInfoReporter) -
+        /// resolved/created by ConnectionID rather than requiring a pre-resolved InstanceID, since it must
+        /// work even when the instance has never had a normal collection succeed (offline, or an Azure DB
+        /// discovered on the fly).
+        /// </summary>
+        private async Task UpdateScheduleInfoAsync()
+        {
+            var agentRow = data.Tables["DBADash"]!.Rows[0];
+            var collectAgent = GetAgent(agentRow);
+            snapshotDate = (DateTime)agentRow["SnapshotDateUTC"];
+            var connectionID = (string)agentRow["ConnectionID"];
+            var dt = data.Tables["ScheduleInfo"];
+            await using var cn = new SqlConnection(connectionString);
+            await using var cmd = new SqlCommand("dbo.ScheduleInfo_Upd", cn) { CommandTimeout = CommandTimeout, CommandType = CommandType.StoredProcedure };
+            await cn.OpenAsync();
+            cmd.Parameters.AddWithValue("ConnectionID", connectionID);
+            cmd.Parameters.AddWithValue("CollectAgentID", collectAgent.GetDBADashAgentID(connectionString));
+            cmd.Parameters.AddWithValue("ImportAgentID", importAgent.GetDBADashAgentID(connectionString));
+            cmd.Parameters.AddWithValue("SnapshotDate", snapshotDate);
+            if (dt.Rows.Count > 0)
+            {
+                cmd.Parameters.AddWithValue("ScheduleInfo", dt);
+            }
+            await cmd.ExecuteNonQueryAsync();
+        }
+
         public async Task UpdateAsync()
         {
             if (data.DataSetName == "OfflineInstances")
             {
                 await UpdateOfflineAsync();
+                return;
+            }
+            if (data.DataSetName == "ScheduleInfo")
+            {
+                await UpdateScheduleInfoAsync();
                 return;
             }
             List<Exception> exceptions = new();

--- a/DBADash/ScheduleInfoReporter.cs
+++ b/DBADash/ScheduleInfoReporter.cs
@@ -61,6 +61,14 @@ namespace DBADashService
 
             foreach (var (type, schedule) in effectiveSchedule)
             {
+                if (type == CollectionType.SchemaSnapshot && source.SchemaSnapshotDBs is not { Length: > 0 })
+                {
+                    // SchedulerService only ever schedules a SchemaSnapshot job when at least one DB is
+                    // configured for it - otherwise it never collects, so reporting a schedule for it here
+                    // would make it look like a permanently-stale/Critical reference instead of simply not
+                    // applicable to this instance.
+                    continue;
+                }
                 AddRow(dt, type.ToString(), schedule,
                     source.CollectionSchedules != null && source.CollectionSchedules.ContainsKey(type));
             }

--- a/DBADash/ScheduleInfoReporter.cs
+++ b/DBADash/ScheduleInfoReporter.cs
@@ -1,0 +1,91 @@
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using DBADash;
+
+namespace DBADashService
+{
+    /// <summary>
+    /// Reports each instance's effective collection schedule to the repository independently of the normal
+    /// per-instance collection pipeline. Schedule info comes entirely from the service's own in-memory
+    /// config and never needs to query the monitored instance, so it must not be gated behind a live
+    /// connection to that instance - e.g. an offline instance, or an Azure DB discovered on the fly whose
+    /// first connection attempt hasn't necessarily succeeded yet.
+    /// </summary>
+    public static class ScheduleInfoReporter
+    {
+        public static async Task ReportAsync(DBADashSource source, CollectionSchedules effectiveSchedule,
+            Dictionary<string, CustomCollection> effectiveCustomCollections, CollectionConfig config)
+        {
+            if (string.IsNullOrEmpty(source.ConnectionID))
+            {
+                Log.Warning("Skipping schedule info report for {connection} - ConnectionID isn't known yet (instance has never connected)",
+                    source.SourceConnection.ConnectionForPrint);
+                return;
+            }
+
+            var ds = BuildDataSet(source, effectiveSchedule, effectiveCustomCollections);
+            var fileName = DBADashSource.GenerateFileName(source.SourceConnection.ConnectionForFileName + "_ScheduleInfo");
+            await DestinationHandling.WriteAllDestinationsAsync(ds, fileName, config);
+        }
+
+        private static DataSet BuildDataSet(DBADashSource source, CollectionSchedules effectiveSchedule,
+            Dictionary<string, CustomCollection> effectiveCustomCollections)
+        {
+            var ds = new DataSet("ScheduleInfo");
+
+            var dtAgent = new DataTable("DBADash");
+            DBCollector.AddDBADashServiceMetadata(ref dtAgent);
+            dtAgent.Columns.Add("SnapshotDateUTC", typeof(DateTime));
+            // Folder/bucket destinations (DirectoryWorkItem/S3WorkItem) identify a deserialized file by
+            // Tables["DBADash"].Rows[0]["Instance"]/["DBName"] before importing it - these columns aren't
+            // otherwise needed here, but must be present or that lookup throws (logged as "Error getting
+            // ID from DataSet") and falls back to a shared "DEFAULT" key, serializing unrelated instances'
+            // file processing against each other.
+            dtAgent.Columns.Add("Instance", typeof(string));
+            dtAgent.Columns.Add("DBName", typeof(string));
+            dtAgent.Rows[0]["ConnectionID"] = source.ConnectionID;
+            dtAgent.Rows[0]["SnapshotDateUTC"] = DateTime.UtcNow;
+            dtAgent.Rows[0]["Instance"] = source.ConnectionID;
+            dtAgent.Rows[0]["DBName"] = "ScheduleInfo";
+            ds.Tables.Add(dtAgent);
+
+            var dt = new DataTable("ScheduleInfo");
+            dt.Columns.Add("Reference", typeof(string));
+            dt.Columns.Add("Schedule", typeof(string));
+            dt.Columns.Add("RunOnServiceStart", typeof(bool));
+            dt.Columns.Add("MaxIntervalMinutes", typeof(decimal));
+            dt.Columns.Add("IsInstanceOverride", typeof(bool));
+
+            foreach (var (type, schedule) in effectiveSchedule)
+            {
+                AddRow(dt, type.ToString(), schedule,
+                    source.CollectionSchedules != null && source.CollectionSchedules.ContainsKey(type));
+            }
+
+            // Custom collections self-report to dbo.CollectionDates as 'UserData.{name}' (see the generated
+            // _Upd proc in ManageCustomCollections) - matching that same Reference here lets the existing
+            // CollectionDatesStatus join pick them up with no further schema/view changes.
+            foreach (var (name, custom) in effectiveCustomCollections ?? new())
+            {
+                AddRow(dt, "UserData." + name, custom,
+                    source.CustomCollections != null && source.CustomCollections.ContainsKey(name));
+            }
+            ds.Tables.Add(dt);
+            return ds;
+        }
+
+        private static void AddRow(DataTable dt, string reference, CollectionSchedule schedule, bool isInstanceOverride)
+        {
+            var row = dt.NewRow();
+            row["Reference"] = reference;
+            row["Schedule"] = schedule.NormalizedSchedule ?? string.Empty;
+            row["RunOnServiceStart"] = schedule.RunOnServiceStart;
+            row["MaxIntervalMinutes"] = CronParser.TryGetMaxIntervalMinutes(schedule.Schedule, out var minutes) ? (decimal)minutes : DBNull.Value;
+            row["IsInstanceOverride"] = isInstanceOverride;
+            dt.Rows.Add(row);
+        }
+    }
+}

--- a/DBADash/SchemaSnapshotDB.cs
+++ b/DBADash/SchemaSnapshotDB.cs
@@ -954,6 +954,7 @@ namespace DBADash
             }
             Log.Information("DB Snapshots from instance {source}", src.SourceConnection.ConnectionForPrint);
 
+            var matchedCount = 0;
             foreach (Database db in instance.Databases)
             {
                 if (!db.IsUpdateable || !db.IsAccessible || db.IsSystemObject) continue;
@@ -961,6 +962,7 @@ namespace DBADash
                 var include = dbs.Any(strDB => strDB == "*" || string.Equals(strDB, db.Name, StringComparison.OrdinalIgnoreCase)) &&
                               !dbs.Any(strDB => strDB.StartsWith('-') && string.Equals(strDB[1..], db.Name, StringComparison.OrdinalIgnoreCase));
                 if (!include) continue;
+                matchedCount++;
 
                 Log.Information("DB Snapshot {db} from instance {instance}", db.Name, builder.DataSource);
                 DataTable dt = null;
@@ -987,6 +989,15 @@ namespace DBADash
                     dsSnapshot.Tables.Remove(dt);
                 }
                 collector.ClearErrors();
+            }
+
+            if (matchedCount == 0)
+            {
+                // The job "ran" but did nothing - no error to catch, so nothing else would otherwise
+                // surface this. Without at least one match, dbo.CollectionDates for SchemaSnapshot never
+                // gets touched here, so its age grows indefinitely with no other indication why.
+                Log.Warning("SchemaSnapshotDBs ({schemaSnapshotDBs}) matched no databases on {instance} - schema snapshot will not run until this is corrected",
+                    src.SchemaSnapshotDBs, src.SourceConnection.ConnectionForPrint);
             }
         }
     }

--- a/DBADashDB/Alert/Procedures/CollectionDatesAlert_Upd.sql
+++ b/DBADashDB/Alert/Procedures/CollectionDatesAlert_Upd.sql
@@ -51,10 +51,11 @@ OUTER APPLY(SELECT 	NULLIF(TRY_CAST(JSON_VALUE(R.Details,'$.Reference') AS VARCH
 					ISNULL(TRY_CAST(JSON_VALUE(R.Details,'$.UseCriticalStatus') AS BIT),0) AS UseCriticalStatus
 		) AS Calc
 CROSS APPLY Alert.ApplicableInstances_Get(R.ApplyToTagID,R.ApplyToInstanceID,R.AlertKey,R.ApplyToHidden) I
-JOIN dbo.CollectionDatesStatus CDS ON CDS.InstanceID = I.InstanceID 
+JOIN dbo.CollectionDatesStatus CDS ON CDS.InstanceID = I.InstanceID
 		AND (CDS.Status=1 OR Calc.UseCriticalStatus=0)
 		AND (CDS.SnapshotAge >= R.Threshold OR R.Threshold IS NULL)
 		AND (CDS.Reference = Calc.Reference OR Calc.Reference IS NULL)
+		AND CDS.Status <> 8 /* Never alert on collection types disabled in the schedule */
 WHERE R.Type = @Type
 AND R.IsActive=1
 

--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -212,6 +212,9 @@
     <Build Include="dbo\Tables\TraceFlags.sql" />
     <Build Include="dbo\Stored Procedures\TraceFlags_Upd.sql" />
     <Build Include="dbo\User Defined Types\TraceFlags.sql" />
+    <Build Include="dbo\Tables\ScheduleInfo.sql" />
+    <Build Include="dbo\Stored Procedures\ScheduleInfo_Upd.sql" />
+    <Build Include="dbo\User Defined Types\ScheduleInfo.sql" />
     <Build Include="Report\Stored Procedures\TraceFlags_Get.sql" />
     <Build Include="Report\Stored Procedures\DBADashErrorLog.sql" />
     <Build Include="Report\Stored Procedures\DatabaseGrowth_Get.sql" />

--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -19,7 +19,7 @@ GRANT EXECUTE ON OBJECT::AI.ServiceConfig_Get TO AIUser;
 DECLARE @ProductMajorVersion INT = TRY_CAST(SERVERPROPERTY('ProductMajorVersion') AS INT);
 IF ISNULL(@ProductMajorVersion, 0) >= 16
 BEGIN
-	/*	
+	/*
 		Grant UNMASK on ApiKey column of AI.ServiceConfig to AIService and AIUser roles.  Revoke DB level UNMASK which might have been granted on older SQL versions.
 		Dynamic SQL to avoid syntax errors in older versions of SQL Server that do not support column-level UNMASK permissions
 	*/
@@ -42,7 +42,7 @@ DECLARE @GrantAppReadOnlySQL NVARCHAR(MAX);
 WITH Grants AS (
 		SELECT CONCAT('GRANT EXECUTE ON ',QUOTENAME(SCHEMA_NAME(schema_id)),'.',QUOTENAME(name),' TO AppReadOnly') GrantSQL
 		FROM sys.objects
-		WHERE name LIKE '%_Get' 
+		WHERE name LIKE '%_Get'
 		AND type = 'P'
 		AND SCHEMA_NAME(schema_id) IN('dbo','DBADash','Alert')
 		UNION ALL
@@ -65,7 +65,7 @@ GRANT EXEC ON TYPE::dbo.IDs TO AppReadOnly
 -- for setting timezone & theme
 GRANT EXEC ON DBADash.User_Upd TO AppReadOnly
 
-EXEC sp_executesql @GrantAppReadOnlySQL 
+EXEC sp_executesql @GrantAppReadOnlySQL
 
 /************/
 MERGE INTO [dbo].[SysConfigOptions] AS [Target]
@@ -178,20 +178,20 @@ USING (VALUES
 ) AS [Source] ([configuration_id],[name],[description],[is_dynamic],[is_advanced],[default_value],[minimum],[maximum])
 ON ([Target].[configuration_id] = [Source].[configuration_id])
 WHEN MATCHED AND (
-	NULLIF([Source].[name], [Target].[name]) IS NOT NULL OR NULLIF([Target].[name], [Source].[name]) IS NOT NULL OR 
-	NULLIF([Source].[description], [Target].[description]) IS NOT NULL OR NULLIF([Target].[description], [Source].[description]) IS NOT NULL OR 
-	NULLIF([Source].[is_dynamic], [Target].[is_dynamic]) IS NOT NULL OR NULLIF([Target].[is_dynamic], [Source].[is_dynamic]) IS NOT NULL OR 
-	NULLIF([Source].[is_advanced], [Target].[is_advanced]) IS NOT NULL OR NULLIF([Target].[is_advanced], [Source].[is_advanced]) IS NOT NULL OR 
-	NULLIF([Source].[default_value], [Target].[default_value]) IS NOT NULL OR NULLIF([Target].[default_value], [Source].[default_value]) IS NOT NULL OR 
-	NULLIF([Source].[minimum], [Target].[minimum]) IS NOT NULL OR NULLIF([Target].[minimum], [Source].[minimum]) IS NOT NULL OR 
+	NULLIF([Source].[name], [Target].[name]) IS NOT NULL OR NULLIF([Target].[name], [Source].[name]) IS NOT NULL OR
+	NULLIF([Source].[description], [Target].[description]) IS NOT NULL OR NULLIF([Target].[description], [Source].[description]) IS NOT NULL OR
+	NULLIF([Source].[is_dynamic], [Target].[is_dynamic]) IS NOT NULL OR NULLIF([Target].[is_dynamic], [Source].[is_dynamic]) IS NOT NULL OR
+	NULLIF([Source].[is_advanced], [Target].[is_advanced]) IS NOT NULL OR NULLIF([Target].[is_advanced], [Source].[is_advanced]) IS NOT NULL OR
+	NULLIF([Source].[default_value], [Target].[default_value]) IS NOT NULL OR NULLIF([Target].[default_value], [Source].[default_value]) IS NOT NULL OR
+	NULLIF([Source].[minimum], [Target].[minimum]) IS NOT NULL OR NULLIF([Target].[minimum], [Source].[minimum]) IS NOT NULL OR
 	NULLIF([Source].[maximum], [Target].[maximum]) IS NOT NULL OR NULLIF([Target].[maximum], [Source].[maximum]) IS NOT NULL) THEN
  UPDATE SET
-  [Target].[name] = [Source].[name], 
-  [Target].[description] = [Source].[description], 
-  [Target].[is_dynamic] = [Source].[is_dynamic], 
-  [Target].[is_advanced] = [Source].[is_advanced], 
-  [Target].[default_value] = [Source].[default_value], 
-  [Target].[minimum] = [Source].[minimum], 
+  [Target].[name] = [Source].[name],
+  [Target].[description] = [Source].[description],
+  [Target].[is_dynamic] = [Source].[is_dynamic],
+  [Target].[is_advanced] = [Source].[is_advanced],
+  [Target].[default_value] = [Source].[default_value],
+  [Target].[minimum] = [Source].[minimum],
   [Target].[maximum] = [Source].[maximum]
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([configuration_id],[name],[description],[is_dynamic],[is_advanced],[default_value],[minimum],[maximum])
@@ -1133,10 +1133,10 @@ USING (VALUES
 ) AS [Source] ([WaitType],[IsCriticalWait],[Description])
 ON ([Target].[WaitType] = [Source].[WaitType])
 WHEN MATCHED AND (
-	NULLIF([Source].[IsCriticalWait], [Target].[IsCriticalWait]) IS NOT NULL OR NULLIF([Target].[IsCriticalWait], [Source].[IsCriticalWait]) IS NOT NULL OR 
+	NULLIF([Source].[IsCriticalWait], [Target].[IsCriticalWait]) IS NOT NULL OR NULLIF([Target].[IsCriticalWait], [Source].[IsCriticalWait]) IS NOT NULL OR
 	NULLIF([Source].[Description], [Target].[Description]) IS NOT NULL OR NULLIF([Target].[Description], [Source].[Description]) IS NOT NULL) THEN
  UPDATE SET
-  [Target].[IsCriticalWait] = [Source].[IsCriticalWait], 
+  [Target].[IsCriticalWait] = [Source].[IsCriticalWait],
   [Target].[Description] = [Source].[Description]
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([WaitType],[IsCriticalWait],[Description])
@@ -1217,7 +1217,7 @@ FROM (VALUES('dbo','ObjectExecutionStats',120),
 				('dbo','ResourceGovernorWorkloadGroupsMetrics',90),
 				('dbo','ResourceGovernorResourcePoolsMetrics',90)
 				) AS t(SchemaName,TableName,RetentionDays)
-WHERE NOT EXISTS(SELECT 1 
+WHERE NOT EXISTS(SELECT 1
 				FROM dbo.DataRetention DR
 				WHERE DR.TableName = T.TableName
 				AND DR.SchemaName = T.SchemaName)
@@ -1231,34 +1231,34 @@ WHERE IsSystem=1
 MERGE INTO dbo.OSLoadedModulesStatus AS [Target]
 USING (
 	VALUES
-	( N'%', N'%', N'XTP Native DLL', 4,NULL,1 ), 
-	( N'%', N'Microsoft Corporation', N'%', 4,NULL,1 ), 
-	( N'%', N'Корпорация Майкрософт', N'%', 4, NULL,1 ), 
-	( N'%\ENTAPI.DLL', N'%', N'%', 1, N'McAfee VirusScan Enterprise',1 ), 
-	( N'%\HcApi.dll', N'%', N'%', 1, N'McAfee Host Intrusion',1  ), 
-	( N'%\HcSQL.dll', N'%', N'%', 1, N'McAfee Host Intrusion',1  ), 
-	( N'%\HcThe.dll', N'%', N'%', 1, N'McAfee Host Intrusion',1  ), 
-	( N'%\HIPI.DLL', N'%', N'%', 1, N'McAfee Host Intrusion',1  ), 
-	( N'%\PIOLEDB.DLL', N'%', N'%', 1, N'OSISoft PI data access',1  ), 
-	( N'%\PISDK.DLL', N'%', N'%', 1, N'OSISoft PI data access',1   ), 
-	( N'%\SOPHOS_DETOURED.DLL', N'%', N'%', 1,N'Sophos AV',1  ), 
-	( N'%\SOPHOS_DETOURED_x64.DLL', N'%', N'%', 1,N'Sophos AV',1  ), 
-	( N'%\SOPHOS~%.dll', N'%', N'%', 1,N'Sophos AV',1  ), 
-	( N'%\SWI_IFSLSP_64.dll', N'%', N'%', 1, N'Sophos AV',1  ), 
-	( N'%IisRTL.DLL', N'%', N'%', 4, NULL,1 ), 
-	( N'%iisutil.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%instapi.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%MSDART.DLL', N'%', N'%', 4, NULL,1 ), 
-	( N'%msxml3.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%msxmlsql.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%ODBC32.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%oledb32.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%OLEDB32R.DLL', N'%', N'%', 4, NULL,1 ), 
-	( N'%ScriptControl64%.dll', N'%', N'%', 1, N'CrowdStrike',1 ), 
-	( N'%UMPDC.dll', N'%', N'%', 4, NULL,1 ), 
-	( N'%umppc%.dll', N'%', N'%', 1, N'CrowdStrike',1 ), 
-	( N'%w3ctrs.dll', N'%', N'%', 4 , NULL,1 ), 
-	( N'%XmlLite.dll', N'%', N'%', 4, NULL,1 ), 
+	( N'%', N'%', N'XTP Native DLL', 4,NULL,1 ),
+	( N'%', N'Microsoft Corporation', N'%', 4,NULL,1 ),
+	( N'%', N'Корпорация Майкрософт', N'%', 4, NULL,1 ),
+	( N'%\ENTAPI.DLL', N'%', N'%', 1, N'McAfee VirusScan Enterprise',1 ),
+	( N'%\HcApi.dll', N'%', N'%', 1, N'McAfee Host Intrusion',1  ),
+	( N'%\HcSQL.dll', N'%', N'%', 1, N'McAfee Host Intrusion',1  ),
+	( N'%\HcThe.dll', N'%', N'%', 1, N'McAfee Host Intrusion',1  ),
+	( N'%\HIPI.DLL', N'%', N'%', 1, N'McAfee Host Intrusion',1  ),
+	( N'%\PIOLEDB.DLL', N'%', N'%', 1, N'OSISoft PI data access',1  ),
+	( N'%\PISDK.DLL', N'%', N'%', 1, N'OSISoft PI data access',1   ),
+	( N'%\SOPHOS_DETOURED.DLL', N'%', N'%', 1,N'Sophos AV',1  ),
+	( N'%\SOPHOS_DETOURED_x64.DLL', N'%', N'%', 1,N'Sophos AV',1  ),
+	( N'%\SOPHOS~%.dll', N'%', N'%', 1,N'Sophos AV',1  ),
+	( N'%\SWI_IFSLSP_64.dll', N'%', N'%', 1, N'Sophos AV',1  ),
+	( N'%IisRTL.DLL', N'%', N'%', 4, NULL,1 ),
+	( N'%iisutil.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%instapi.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%MSDART.DLL', N'%', N'%', 4, NULL,1 ),
+	( N'%msxml3.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%msxmlsql.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%ODBC32.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%oledb32.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%OLEDB32R.DLL', N'%', N'%', 4, NULL,1 ),
+	( N'%ScriptControl64%.dll', N'%', N'%', 1, N'CrowdStrike',1 ),
+	( N'%UMPDC.dll', N'%', N'%', 4, NULL,1 ),
+	( N'%umppc%.dll', N'%', N'%', 1, N'CrowdStrike',1 ),
+	( N'%w3ctrs.dll', N'%', N'%', 4 , NULL,1 ),
+	( N'%XmlLite.dll', N'%', N'%', 4, NULL,1 ),
 	( N'%xpsqlbot.dll', N'%', N'%', 4, NULL,1 ),
 	( N'%perfiCrcPerfMonMgr.DLL',N'%',N'%',1,N'Trend Micro',1),
 	( N'%MFEBOPK.SYS',N'%',N'%',1,N'McAfee VirusScan Enterprise',1),
@@ -1274,17 +1274,17 @@ USING (
 	)  [Source](Name,Company,Description,Status,Notes,IsSystem)
 ON ([Target].[Name] = [Source].[Name] AND [Target].[Company] = [Source].[Company] AND [Target].[Description] = [Source].[Description])
 WHEN MATCHED AND (
-	NULLIF([Source].[Status], [Target].[Status]) IS NOT NULL OR NULLIF([Target].[Status], [Source].[Status]) IS NOT NULL OR 
-	NULLIF([Source].[Notes], [Target].[Notes]) IS NOT NULL OR NULLIF([Target].[Notes], [Source].[Notes]) IS NOT NULL OR 
+	NULLIF([Source].[Status], [Target].[Status]) IS NOT NULL OR NULLIF([Target].[Status], [Source].[Status]) IS NOT NULL OR
+	NULLIF([Source].[Notes], [Target].[Notes]) IS NOT NULL OR NULLIF([Target].[Notes], [Source].[Notes]) IS NOT NULL OR
 	NULLIF([Source].[IsSystem], [Target].[IsSystem]) IS NOT NULL OR NULLIF([Target].[IsSystem], [Source].[IsSystem]) IS NOT NULL) THEN
 UPDATE SET
-  [Target].[Status] = [Source].[Status], 
-  [Target].[Notes] = [Source].[Notes], 
+  [Target].[Status] = [Source].[Status],
+  [Target].[Notes] = [Source].[Notes],
   [Target].[IsSystem] = [Source].[IsSystem]
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([Name],[Company],[Description],[Status],[Notes],[IsSystem])
  VALUES([Source].[Name],[Source].[Company],[Source].[Description],[Source].[Status],[Source].[Notes],[Source].[IsSystem])
-WHEN NOT MATCHED BY SOURCE AND [Target].IsSystem=1 THEN 
+WHEN NOT MATCHED BY SOURCE AND [Target].IsSystem=1 THEN
  DELETE;
 
  IF @@ROWCOUNT>0
@@ -1293,7 +1293,7 @@ WHEN NOT MATCHED BY SOURCE AND [Target].IsSystem=1 THEN
  END
 
 IF NOT EXISTS(SELECT 1 FROM dbo.DriveThresholds)
-BEGIN 
+BEGIN
 	INSERT INTO dbo.DriveThresholds
 	(
 		InstanceID,
@@ -1382,7 +1382,7 @@ USING(
 	('TR','Trigger')
 	) AS S (ObjectType,TypeDescription)
 ON S.ObjectType = T.ObjectType
-WHEN MATCHED 
+WHEN MATCHED
 AND EXISTS (SELECT T.TypeDescription
 			EXCEPT
 			SELECT S.TypeDescription
@@ -1485,14 +1485,28 @@ BEGIN
 	INSERT INTO dbo.Settings(SettingName,SettingValue) VALUES('CollectionDatesLegacyThresholdsMigrated',1)
 END
 
+-- SchemaSnapshot's "last collected" date is not a reliable staleness signal even when it's configured and
+-- running - a configured DB pattern (e.g. "*") can still match zero databases at runtime. Disable alerting
+-- for it by default at root level; an admin can still re-enable/configure it explicitly per instance or
+-- root.  One-time seed only (gated below), so a later admin change isn't overwritten on next deploy.
+IF NOT EXISTS(SELECT 1 FROM dbo.Settings WHERE SettingName = 'SchemaSnapshotAlertingDisabledByDefault')
+BEGIN
+	IF NOT EXISTS(SELECT 1 FROM dbo.CollectionDatesThresholds WHERE InstanceID = -1 AND Reference = 'SchemaSnapshot')
+	BEGIN
+		INSERT INTO dbo.CollectionDatesThresholds(InstanceID,Reference,Disabled)
+		VALUES(-1,'SchemaSnapshot',1)
+	END
+	INSERT INTO dbo.Settings(SettingName,SettingValue) VALUES('SchemaSnapshotAlertingDisabledByDefault',1)
+END
+
 UPDATE dbo.CollectionDates
 	SET Reference = 'DatabasesHADR'
 WHERE Reference = 'DatabaseHADR'
 
-DELETE CD 
+DELETE CD
 FROM dbo.CollectionDates CD
 WHERE Reference='DatabasesHADR'
-AND NOT EXISTS(SELECT 1 
+AND NOT EXISTS(SELECT 1
 		FROM dbo.DatabasesHADR HA
 		JOIN dbo.Databases D ON D.DatabaseID = HA.DatabaseID
 		WHERE D.InstanceID = CD.InstanceID)
@@ -1555,10 +1569,10 @@ USING (VALUES
 ) AS [Source] ([configuration_id],[name],[default_value])
 ON ([Target].[configuration_id] = [Source].[configuration_id])
 WHEN MATCHED AND (
-	NULLIF([Source].[name], [Target].[name]) IS NOT NULL OR NULLIF([Target].[name], [Source].[name]) IS NOT NULL OR 
+	NULLIF([Source].[name], [Target].[name]) IS NOT NULL OR NULLIF([Target].[name], [Source].[name]) IS NOT NULL OR
 	NULLIF([Source].[default_value], [Target].[default_value]) IS NOT NULL OR NULLIF([Target].[default_value], [Source].[default_value]) IS NOT NULL) THEN
  UPDATE SET
-  [Target].[name] = [Source].[name], 
+  [Target].[name] = [Source].[name],
   [Target].[default_value] = [Source].[default_value]
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([configuration_id],[name],[default_value])
@@ -1614,7 +1628,7 @@ WHEN MATCHED AND (
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([object_name],[counter_name],[base_counter_name])
  VALUES([Source].[object_name],[Source].[counter_name],[Source].[base_counter_name])
-WHEN NOT MATCHED BY SOURCE THEN 
+WHEN NOT MATCHED BY SOURCE THEN
 	DELETE;
 
  IF NOT EXISTS(SELECT 1 FROM dbo.AzureDBElasticPoolStorageThresholds)
@@ -1648,10 +1662,10 @@ BEGIN
 		-1,
 		0.2,
 		0.1,
-		'%',  
-		0.8, 
-		0.9, 
-		1 
+		'%',
+		0.8,
+		0.9,
+		1
 		)
 END
 IF NOT EXISTS(SELECT 1 FROM dbo.DBFileThresholds WHERE InstanceID =-1 AND DatabaseID = -1 AND data_space_id=0)
@@ -1675,9 +1689,9 @@ BEGIN
 		0,
 		0.2,
 		0.1,
-		'%',  
-		0.8, 
-		0.9, 
+		'%',
+		0.8,
+		0.9,
 		0
 		)
 END
@@ -1703,7 +1717,7 @@ BEGIN
 			SUM(PC.Value),
 			MIN(PC.Value),
 			MAX(PC.Value),
-			COUNT(*)  
+			COUNT(*)
 	FROM dbo.PerformanceCounters PC
 	CROSS APPLY [dbo].[DateGroupingMins](PC.SnapshotDate,60) DG
 	GROUP BY  PC.InstanceID,
@@ -1825,20 +1839,20 @@ USING (VALUES
 ('USERSTORE_TOKENPERM','TokenAndPermUserStore is a single SOS user store that keeps track of security entries for security context, login, user, permission, and audit. Multiple hash tables are allocated to store these objects.')
 ) AS S(MemoryClerkType,MemoryClerkDescription)
 ON S.MemoryClerkType = T.MemoryClerkType
-WHEN MATCHED AND (NULLIF(S.MemoryClerkDescription,T.MemoryClerkDescription) IS NOT NULL OR NULLIF(T.MemoryClerkDescription,S.MemoryClerkDescription) IS NOT NULL) THEN 
-UPDATE SET 
+WHEN MATCHED AND (NULLIF(S.MemoryClerkDescription,T.MemoryClerkDescription) IS NOT NULL OR NULLIF(T.MemoryClerkDescription,S.MemoryClerkDescription) IS NOT NULL) THEN
+UPDATE SET
 T.MemoryClerkDescription = S.MemoryClerkDescription
 WHEN NOT MATCHED BY TARGET THEN
 INSERT(MemoryClerkType,MemoryClerkDescription)
 VALUES(S.MemoryClerkType,S.MemoryClerkDescription);
 
-IF NOT EXISTS(SELECT 1 
+IF NOT EXISTS(SELECT 1
 			FROM dbo.Settings
 			WHERE SettingName = 'InstanceTagIDsMigratedDate'
 			)
 BEGIN
 	PRINT 'Migrating Tags'
-	/* 
+	/*
 		Migrate tags from InstanceTags to InstanceIDsTags table
 		Excluding user tags on AzureDB
 	*/
@@ -1848,19 +1862,19 @@ BEGIN
 	)
 	SELECT I.InstanceID,
 			IT.TagID
-	FROM dbo.InstanceTags IT 
-	JOIN dbo.Instances I ON IT.Instance = I.Instance 
+	FROM dbo.InstanceTags IT
+	JOIN dbo.Instances I ON IT.Instance = I.Instance
 	JOIN dbo.Tags T ON IT.TagID = T.TagID
 	WHERE NOT (I.EngineEdition=5 AND T.TagName NOT LIKE '{%')
-	AND NOT EXISTS(SELECT 1 
-					FROM dbo.InstanceIDsTags IDT 
-					WHERE IT.TagID = IDT.TagID 
+	AND NOT EXISTS(SELECT 1
+					FROM dbo.InstanceIDsTags IDT
+					WHERE IT.TagID = IDT.TagID
 					AND I.InstanceID = IDT.InstanceID
 					)
 
-	DELETE IT 
-	FROM dbo.InstanceTags IT 
-	JOIN dbo.Instances I ON IT.Instance = I.Instance 
+	DELETE IT
+	FROM dbo.InstanceTags IT
+	JOIN dbo.Instances I ON IT.Instance = I.Instance
 	JOIN dbo.Tags T ON IT.TagID = T.TagID
 	WHERE NOT (I.EngineEdition=5 AND T.TagName NOT LIKE '{%')
 
@@ -1878,16 +1892,16 @@ USING (VALUES
 	('Plan Cache','Cache Object Counts','_Total',0,200,200,1000,NULL,NULL),
 	('General Statistics','Processes blocked','',50,9999999999999999999.999999999,1,50,0,0)
 ) AS S (object_name,counter_name,instance_name,SystemCriticalFrom,SystemCriticalTo,SystemWarningFrom,SystemWarningTo,SystemGoodFrom,SystemGoodTo)
-ON T.object_name = S.object_name AND T.counter_name = S.counter_name AND T.instance_name = S.instance_name 
-WHEN MATCHED THEN 
+ON T.object_name = S.object_name AND T.counter_name = S.counter_name AND T.instance_name = S.instance_name
+WHEN MATCHED THEN
 UPDATE SET T.SystemCriticalFrom = S.SystemCriticalFrom,
 			T.SystemCriticalTo = S.SystemCriticalTo,
 			T.SystemWarningFrom = S.SystemWarningfrom,
 			T.SystemWarningTo = S.SystemWarningTo,
 			T.SystemGoodFrom = S.SystemGoodFrom,
 			T.SystemGoodTo = S.SystemGoodTo,
-			/* 
-				Set user values to NULL if they match system value and system value isn't set yet.  Handling upgrades before System columns were added 
+			/*
+				Set user values to NULL if they match system value and system value isn't set yet.  Handling upgrades before System columns were added
 				System thresholds can always be updated now without impacting user preferences
 			*/
 			T.CriticalFrom = CASE WHEN T.CriticalFrom = S.SystemCriticalFrom AND T.SystemCriticalFrom IS NULL THEN NULL  ELSE T.CriticalFrom END,
@@ -1916,12 +1930,12 @@ WHEN MATCHED AND (
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([ViewTypeID],[ViewType])
  VALUES([Source].[ViewTypeID],[Source].[ViewType])
-WHEN NOT MATCHED BY SOURCE THEN 
+WHEN NOT MATCHED BY SOURCE THEN
  DELETE;
 
 IF NOT EXISTS(
-		SELECT 1 
-		FROM DBADash.Users 
+		SELECT 1
+		FROM DBADash.Users
 		WHERE UserID=-1
 		)
 BEGIN
@@ -1935,7 +1949,7 @@ BEGIN
 	SET IDENTITY_INSERT DBADash.Users OFF
 END
 
-IF NOT EXISTS(SELECT 1 
+IF NOT EXISTS(SELECT 1
 			FROM dbo.IdentityColumnThresholds
 			WHERE InstanceID=-1
 			AND DatabaseID=-1
@@ -1970,7 +1984,7 @@ WHEN MATCHED AND (
 WHEN NOT MATCHED BY TARGET THEN
  INSERT([NotificationChannelTypeID],[NotificationChannelType])
  VALUES([Source].[NotificationChannelTypeID],[Source].[NotificationChannelType])
-WHEN NOT MATCHED BY SOURCE THEN 
+WHEN NOT MATCHED BY SOURCE THEN
  DELETE;
 
 /* Add default notification channel group. */
@@ -1981,7 +1995,7 @@ BEGIN
 	SET IDENTITY_INSERT Alert.NotificationChannelGroup OFF
 END
 
-/* 
+/*
 	ResourceGovernorConfiguration collection no longer run non-enterprise edition engines.
 	Remove the row from CollectionDates to prevent warnings about snapshot age for this collection
 	where it's no longer applicable.
@@ -1996,7 +2010,7 @@ AND NOT EXISTS(SELECT 1
 	AND I.EngineEdition = 3 /* Enterprise */
 )
 
-UPDATE dbo.Instances 
+UPDATE dbo.Instances
 	SET ProductMinorVersion = TRY_CAST(PARSENAME(ProductVersion,3) AS INT),
 		ProductBuild= TRY_CAST(PARSENAME(ProductVersion,2) AS INT),
 		ProductRevision = TRY_CAST(PARSENAME(ProductVersion,1) AS INT)
@@ -2008,7 +2022,7 @@ INSERT INTO dbo.Counters(
 	instance_name,
 	CounterType
 )
-SELECT object_name,counter_name,instance_name,CounterType 
+SELECT object_name,counter_name,instance_name,CounterType
 FROM (VALUES('Running Queries','Running Query Count','',2),
 	('Running Queries','Blocked Query Count','',2),
 	('Running Queries','Oldest Transaction (ms)','',2),
@@ -2035,8 +2049,8 @@ FROM (VALUES('Running Queries','Running Query Count','',2),
 	('sys.dm_db_resource_stats', 'cpu_limit','',4)
 	) VirtualCounters(object_name,counter_name,instance_name,CounterType)
 WHERE NOT EXISTS(
-				SELECT 1 
-				FROM dbo.Counters C 
+				SELECT 1
+				FROM dbo.Counters C
 				WHERE C.counter_name = VirtualCounters.counter_name
 				AND C.object_name = VirtualCounters.object_name
 				AND C.instance_name = VirtualCounters.instance_name
@@ -2087,7 +2101,7 @@ FROM (VALUES -- AG aggregate
 			('Databases Dropped',1,0,'Databases')
 		) M(MetricName,IsAggregate,IsEnabled,MetricType)
 WHERE NOT EXISTS(
-				SELECT 1 
+				SELECT 1
 				FROM dbo.RepositoryMetricsConfig AGM
 				WHERE M.MetricName = AGM.MetricName
 				AND AGM.InstanceID = -1
@@ -2252,7 +2266,7 @@ BEGIN
 END
 /* Migrate LogRestores data from old schema */
 IF OBJECT_ID('dbo.LogRestoresTemp') IS NOT NULL
-BEGIN 
+BEGIN
 
 	INSERT INTO dbo.LogRestores(
 			InstanceID,
@@ -2267,11 +2281,11 @@ BEGIN
 			T.restore_date,
 			T.backup_start_date,
 			T.last_file,
-			T.backup_time_zone	 
+			T.backup_time_zone
 	FROM dbo.LogRestoresTemp T
 	JOIN dbo.Databases D ON D.DatabaseID = T.DatabaseID
-	WHERE NOT EXISTS(SELECT 1 
-					FROM dbo.LogRestores LR 
+	WHERE NOT EXISTS(SELECT 1
+					FROM dbo.LogRestores LR
 					WHERE LR.InstanceID = D.InstanceID
 					AND LR.DatabaseID = T.DatabaseID
 					)
@@ -2290,7 +2304,7 @@ END
 ALTER TABLE dbo.DBFiles SET (LOCK_ESCALATION = DISABLE);
 ALTER TABLE dbo.DBFileSnapshot SET (LOCK_ESCALATION = DISABLE);
 
-/* 
+/*
 	Changes between 4.7.1 and 4.8.0 resulted in Alert.ActiveAlerts table rebuild which can reset the identity value.
 	This can cause issues closing alerts due to re-use of identity values.  The proc below will detect and fix the issue for existing deployments.
 */
@@ -2303,7 +2317,7 @@ BEGIN
 		(N'claude-opus-4-7', N'Claude Opus 4.7', 2, 1);
 END
 
-/* 
+/*
 	Update extended property to indicate that a DB deployment is no longer in progress, allowing the GUI to continue loading.
 */
 EXECUTE sp_updateextendedproperty

--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -1393,73 +1393,11 @@ WHEN NOT MATCHED BY TARGET THEN
 INSERT(ObjectType,TypeDescription)
 VALUES(S.ObjectType,S.TypeDescription);
 
-INSERT INTO dbo.CollectionDatesThresholds
-(
-    InstanceID,
-    Reference,
-    WarningThreshold,
-    CriticalThreshold
-)
-
-SELECT T.InstanceID,
-       T.Reference,
-       T.WarningThreshold,
-       T.CriticalThreshold
-FROM 
-(VALUES
-(-1,'DBFiles',125,180),
-(-1,'ServerExtraProperties',125,180),
-(-1,'OSLoadedModules',1445,2880),
-(-1,'TraceFlags',125,180),
-(-1,'ServerProperties',125,180),
-(-1,'LogRestores',125,180),
-(-1,'DatabasesHADR',5,10),
-(-1,'LastGoodCheckDB',125,180),
-(-1,'Alerts',125,180),
-(-1,'DBTuningOptions',125,180),
-(-1,'DBConfig',125,180),
-(-1,'OSInfo',5,10),
-(-1,'Drives',125,180),
-(-1,'Databases',125,180),
-(-1,'Instance',125,180),
-(-1,'Drivers',1445,2880),
-(-1,'SysConfig',125,180),
-(-1,'Backups',125,180),
-(-1,'AzureDBServiceObjectives',125,180),
-(-1,'Corruption',125,180),
-(-1,'RunningQueries',5,10),
-(-1,'CPU',5,10),
-(-1,'IOStats',5,10),
-(-1,'ObjectExecutionStats',5,10),
-(-1,'SlowQueries',5,10),
-(-1,'SlowQueriesStats',5,10),
-(-1,'AzureDBElasticPoolResourceStat',5,10),
-(-1,'Waits',5,10),
-(-1,'AzureDBResourceStats',5,10),
-(-1,'DatabasePrincipals',1445,2880),
-(-1,'ServerPermissions',1445,2880),
-(-1,'ServerPrincipals',1445,2880),
-(-1,'DatabasePermissions',1445,2880),
-(-1,'ServerRoleMembers',1445,2880),
-(-1,'DatabaseRoleMembers',1445,2880),
-(-1,'DatabaseMirroring',125,180),
-(-1,'Jobs',1445,2880),
-(-1,'JobHistory',5,10),
-(-1,'VLF',1445,2880),
-(-1,'CustomChecks',125,180),
-(-1,'PerformanceCounters',5,10),
-(-1,'DatabaseQueryStoreOptions',1445,2880),
-(-1,'AzureDBResourceGovernance',125,180),
-(-1,'ResourceGovernorConfiguration',1445,2880),
-(-1,'MemoryUsage',5,10),
-(-1,'IdentityColumns',10080,20160),
-(-1,'RunningJobs',5,10),
-(-1,'TableSize',4320,11520),
-(-1,'ServerServices',1445,2880),
-(-1,'FailedLogins',1445,2880),
-(-1,'ResourceGovernorWorkloadGroups',5,10)
-) T(InstanceID,Reference,WarningThreshold,CriticalThreshold)
-WHERE NOT EXISTS(SELECT 1 FROM dbo.CollectionDatesThresholds CDT WHERE CDT.InstanceID = T.InstanceID AND CDT.Reference = T.Reference)
+-- Note: static per-reference root thresholds are no longer seeded here - schedule-based thresholds
+-- (interval x multiplier + buffer, see dbo.CollectionDatesStatus) now compute a threshold from each
+-- collection type's actual configured schedule, so new installs get a sensible default automatically.
+-- See the migration below, which removes any leftover rows from the old hardcoded defaults so existing
+-- installs pick up schedule-based thresholds too.
 
 -- Delete thresholds for legacy collections
 DELETE dbo.CollectionDatesThresholds WHERE Reference IN('AgentJobs','BlockingSnapshot','Database','DatabaseHADR')
@@ -1468,13 +1406,84 @@ DELETE dbo.CollectionDatesThresholds WHERE Reference IN('AgentJobs','BlockingSna
 DELETE dbo.CollectionDates
 WHERE Reference IN('AgentJobs','BlockingSnapshot','Database')
 
---replace old defaults
-UPDATE dbo.CollectionDatesThresholds
-SET WarningThreshold=1445,
-	CriticalThreshold=2880
-WHERE Reference IN('Drivers','OSLoadedModules')
-AND WarningThreshold=125
-AND CriticalThreshold=180
+-- One-time migration only (gated below) - a value-matching DELETE/UPDATE like this must not run on
+-- every deployment, or it would keep wiping out a user's threshold if they ever set it back to a value
+-- that happens to match one of these old hardcoded defaults.
+IF NOT EXISTS(SELECT 1 FROM dbo.Settings WHERE SettingName = 'CollectionDatesLegacyThresholdsMigrated')
+BEGIN
+	--replace old defaults
+	UPDATE dbo.CollectionDatesThresholds
+	SET WarningThreshold=1445,
+		CriticalThreshold=2880
+	WHERE Reference IN('Drivers','OSLoadedModules')
+	AND WarningThreshold=125
+	AND CriticalThreshold=180
+
+	-- Remove root threshold rows that still match a historical hardcoded default (i.e. were never
+	-- customized), so schedule-based auto thresholds take over for them going forward. Rows that don't
+	-- match exactly (because a user changed them, or InstanceID>0 overrides) are left alone.
+	DELETE CDT
+	FROM dbo.CollectionDatesThresholds CDT
+	JOIN (VALUES
+	(-1,'DBFiles',125,180),
+	(-1,'ServerExtraProperties',125,180),
+	(-1,'OSLoadedModules',1445,2880),
+	(-1,'TraceFlags',125,180),
+	(-1,'ServerProperties',125,180),
+	(-1,'LogRestores',125,180),
+	(-1,'DatabasesHADR',5,10),
+	(-1,'LastGoodCheckDB',125,180),
+	(-1,'Alerts',125,180),
+	(-1,'DBTuningOptions',125,180),
+	(-1,'DBConfig',125,180),
+	(-1,'OSInfo',5,10),
+	(-1,'Drives',125,180),
+	(-1,'Databases',125,180),
+	(-1,'Instance',125,180),
+	(-1,'Drivers',1445,2880),
+	(-1,'SysConfig',125,180),
+	(-1,'Backups',125,180),
+	(-1,'AzureDBServiceObjectives',125,180),
+	(-1,'Corruption',125,180),
+	(-1,'RunningQueries',5,10),
+	(-1,'CPU',5,10),
+	(-1,'IOStats',5,10),
+	(-1,'ObjectExecutionStats',5,10),
+	(-1,'SlowQueries',5,10),
+	(-1,'SlowQueriesStats',5,10),
+	(-1,'AzureDBElasticPoolResourceStat',5,10),
+	(-1,'Waits',5,10),
+	(-1,'AzureDBResourceStats',5,10),
+	(-1,'DatabasePrincipals',1445,2880),
+	(-1,'ServerPermissions',1445,2880),
+	(-1,'ServerPrincipals',1445,2880),
+	(-1,'DatabasePermissions',1445,2880),
+	(-1,'ServerRoleMembers',1445,2880),
+	(-1,'DatabaseRoleMembers',1445,2880),
+	(-1,'DatabaseMirroring',125,180),
+	(-1,'Jobs',1445,2880),
+	(-1,'JobHistory',5,10),
+	(-1,'VLF',1445,2880),
+	(-1,'CustomChecks',125,180),
+	(-1,'PerformanceCounters',5,10),
+	(-1,'DatabaseQueryStoreOptions',1445,2880),
+	(-1,'AzureDBResourceGovernance',125,180),
+	(-1,'ResourceGovernorConfiguration',1445,2880),
+	(-1,'MemoryUsage',5,10),
+	(-1,'IdentityColumns',10080,20160),
+	(-1,'RunningJobs',5,10),
+	(-1,'TableSize',4320,11520),
+	(-1,'ServerServices',1445,2880),
+	(-1,'FailedLogins',1445,2880),
+	(-1,'ResourceGovernorWorkloadGroups',5,10)
+	) T(InstanceID,Reference,WarningThreshold,CriticalThreshold)
+	ON CDT.InstanceID = T.InstanceID
+	AND CDT.Reference = T.Reference
+	AND CDT.WarningThreshold = T.WarningThreshold
+	AND CDT.CriticalThreshold = T.CriticalThreshold
+
+	INSERT INTO dbo.Settings(SettingName,SettingValue) VALUES('CollectionDatesLegacyThresholdsMigrated',1)
+END
 
 UPDATE dbo.CollectionDates
 	SET Reference = 'DatabasesHADR'

--- a/DBADashDB/dbo/Stored Procedures/CollectionDatesThresholds_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/CollectionDatesThresholds_Get.sql
@@ -1,27 +1,42 @@
-﻿CREATE PROC dbo.CollectionDatesThresholds_Get(
+CREATE PROC dbo.CollectionDatesThresholds_Get(
 	@InstanceID INT,
 	@Reference VARCHAR(30)=NULL
 )
 AS
-SELECT InstanceID,
-        Reference,
-        WarningThreshold,
-        CriticalThreshold,
-		CAST(0 AS BIT) AS Inherited
-FROM dbo.CollectionDatesThresholds
-WHERE InstanceID=@InstanceID
-AND (Reference = @Reference OR @Reference IS NULL)
-UNION ALL
-SELECT InstanceID,
-        Reference,
-        WarningThreshold,
-        CriticalThreshold,
-		CAST(1 AS BIT) AS Inherited
-FROM dbo.CollectionDatesThresholds rootT
-WHERE InstanceID=-1
-AND (Reference = @Reference OR @Reference IS NULL)
-AND NOT EXISTS(SELECT 1 
-			FROM dbo.CollectionDatesThresholds instanceT
-			WHERE instanceT.InstanceID = @InstanceID
-			AND instanceT.Reference = rootT.Reference)
-ORDER BY Reference
+-- Driven from dbo.CollectionDates (every reference actually collected in this scope) rather than
+-- dbo.CollectionDatesThresholds, so references with no threshold row yet still appear in the list
+-- (unconfigured, using the schedule-based default) and can be selected/saved.
+SELECT @InstanceID AS InstanceID,
+       R.Reference,
+       T.WarningThreshold,
+       T.CriticalThreshold,
+       T.WarningMultiplier,
+       T.CriticalMultiplier,
+       T.WarningBufferMinutes,
+       T.CriticalBufferMinutes,
+       ISNULL(T.Disabled,0) AS Disabled,
+       -- "Inherited" (shown as the Inherit/Default radio) whenever there's no local override at this
+       -- exact level: either nothing configured anywhere (T.InstanceID IS NULL) or the resolved value
+       -- came from a different level (root, or the built-in system default).
+       CAST(CASE WHEN T.InstanceID IS NULL OR T.InstanceID <> @InstanceID THEN 1 ELSE 0 END AS BIT) AS Inherited
+FROM (
+	SELECT DISTINCT Reference
+	FROM dbo.CollectionDates
+	WHERE (@InstanceID = -1 OR InstanceID = @InstanceID)
+) R
+OUTER APPLY (
+	SELECT TOP(1) CDT.WarningThreshold,
+		CDT.CriticalThreshold,
+		CDT.WarningMultiplier,
+		CDT.CriticalMultiplier,
+		CDT.WarningBufferMinutes,
+		CDT.CriticalBufferMinutes,
+		CDT.Disabled,
+		CDT.InstanceID
+	FROM dbo.CollectionDatesThresholds CDT
+	WHERE (CDT.InstanceID = @InstanceID OR CDT.InstanceID = -1)
+	AND CDT.Reference = R.Reference
+	ORDER BY CDT.InstanceID DESC
+) T
+WHERE (R.Reference = @Reference OR @Reference IS NULL)
+ORDER BY R.Reference

--- a/DBADashDB/dbo/Stored Procedures/CollectionDatesThresholds_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/CollectionDatesThresholds_Upd.sql
@@ -1,33 +1,47 @@
-﻿CREATE PROC CollectionDatesThresholds_Upd(
+CREATE PROC CollectionDatesThresholds_Upd(
 	@InstanceID INT,
 	@Reference VARCHAR(30),
 	@WarningThreshold INT,
 	@CriticalThreshold INT,
-	@Inherit BIT=0
+	@Inherit BIT=0,
+	@WarningMultiplier DECIMAL(9,2)=NULL,
+	@CriticalMultiplier DECIMAL(9,2)=NULL,
+	@WarningBufferMinutes DECIMAL(9,2)=NULL,
+	@CriticalBufferMinutes DECIMAL(9,2)=NULL,
+	@Disabled BIT=0
 )
 AS
-IF @Inherit=1 AND @InstanceID=-1
-BEGIN
-	RAISERROR('Invalid @Inherit value',11,1);
-	RETURN;
-END
-DELETE dbo.CollectionDatesThresholds 
-WHERE Reference = @Reference 
+-- @Inherit=1 means "no override at this level, defer to the next one down" (instance -> root ->
+-- built-in system default) - just remove the row rather than storing a marker. The Inherited/
+-- ConfiguredLevel logic in CollectionDatesThresholds_Get.sql and dbo.CollectionDatesStatus already
+-- derives that state correctly from the row's absence.
+DELETE dbo.CollectionDatesThresholds
+WHERE Reference = @Reference
 AND InstanceID = @InstanceID
 
-IF @Inherit=0
+IF @Inherit = 0
 BEGIN
 	INSERT INTO dbo.CollectionDatesThresholds
 	(
 		InstanceID,
 		Reference,
 		WarningThreshold,
-		CriticalThreshold
+		CriticalThreshold,
+		WarningMultiplier,
+		CriticalMultiplier,
+		WarningBufferMinutes,
+		CriticalBufferMinutes,
+		Disabled
 	)
 	VALUES
-	(   @InstanceID, 
-		@Reference, 
-		@WarningThreshold, 
-		@CriticalThreshold 
+	(   @InstanceID,
+		@Reference,
+		@WarningThreshold,
+		@CriticalThreshold,
+		@WarningMultiplier,
+		@CriticalMultiplier,
+		@WarningBufferMinutes,
+		@CriticalBufferMinutes,
+		@Disabled
 		)
 END

--- a/DBADashDB/dbo/Stored Procedures/CollectionDates_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/CollectionDates_Get.sql
@@ -1,9 +1,10 @@
-﻿CREATE PROC dbo.CollectionDates_Get(
+CREATE PROC dbo.CollectionDates_Get(
 	@InstanceIDs VARCHAR(MAX)=NULL,
 	@IncludeCritical BIT=1,
 	@IncludeWarning BIT=1,
 	@IncludeNA BIT=1,
 	@IncludeOK BIT=1,
+	@IncludeDisabled BIT=1,
 	@ShowHidden BIT=1
 )
 AS
@@ -19,8 +20,11 @@ WITH Statuses AS(
 	SELECT 3
 	WHERE @IncludeNA=1
 	UNION ALL
-	SELECT 4 
+	SELECT 4
 	WHERE @IncludeOK=1
+	UNION ALL
+	SELECT 8
+	WHERE @IncludeDisabled=1
 )
 SELECT CD.InstanceID,
 	   I.ConnectionID,
@@ -33,6 +37,11 @@ SELECT CD.InstanceID,
 	   CD.HumanSnapshotAge,
        CD.SnapshotDate,
        CD.ConfiguredLevel,
+	   CD.IsScheduleThreshold,
+	   SI.Schedule,
+	   SI.RunOnServiceStart,
+	   SI.MaxIntervalMinutes,
+	   SI.IsInstanceOverride,
 	   ImportAgentID,
 	   CollectAgentID,
 	   CASE WHEN IA.MessagingEnabled=1 AND CA.MessagingEnabled=1 THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS MessagingEnabled
@@ -40,10 +49,11 @@ FROM dbo.CollectionDatesStatus CD
 JOIN dbo.Instances I ON I.InstanceID = CD.InstanceID
 JOIN dbo.DBADashAgent IA ON I.ImportAgentID = IA.DBADashAgentID
 JOIN dbo.DBADashAgent CA ON I.CollectAgentID = CA.DBADashAgentID
+LEFT JOIN dbo.ScheduleInfo SI ON SI.InstanceID = CD.InstanceID AND SI.Reference = CD.Reference
 WHERE EXISTS(SELECT 1 FROM Statuses s WHERE CD.Status=s.Status)
 ' + CASE WHEN @InstanceIDs IS NULL THEN '' ELSE 'AND EXISTS(SELECT 1 FROM STRING_SPLIT(@InstanceIDs,'','') ss WHERE SS.value =  CD.InstanceID)' END + '
 ' + CASE WHEN @ShowHidden=1 THEN '' ELSE 'AND I.ShowInSummary=1' END + ''
 
 EXEC sp_executesql @SQL,
-				N'@InstanceIDs VARCHAR(MAX),@IncludeCritical BIT,@IncludeWarning BIT,@IncludeNA BIT,@IncludeOK BIT',
-				@InstanceIDs,@IncludeCritical,@IncludeWarning,@IncludeNA,@IncludeOK
+				N'@InstanceIDs VARCHAR(MAX),@IncludeCritical BIT,@IncludeWarning BIT,@IncludeNA BIT,@IncludeOK BIT,@IncludeDisabled BIT',
+				@InstanceIDs,@IncludeCritical,@IncludeWarning,@IncludeNA,@IncludeOK,@IncludeDisabled

--- a/DBADashDB/dbo/Stored Procedures/Instance_Del.sql
+++ b/DBADashDB/dbo/Stored Procedures/Instance_Del.sql
@@ -518,6 +518,9 @@ BEGIN
 	DELETE dbo.ResourceGovernorResourcePools 
 	WHERE InstanceID = @InstanceID
 
+	DELETE dbo.ScheduleInfo
+	WHERE InstanceID = @InstanceID
+
 	IF EXISTS(SELECT 1 
 			FROM dbo.InstanceMetadataHistory
 			WHERE InstanceID = @InstanceID)

--- a/DBADashDB/dbo/Stored Procedures/ScheduleInfo_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/ScheduleInfo_Upd.sql
@@ -1,0 +1,60 @@
+CREATE PROC [dbo].[ScheduleInfo_Upd](
+	@ConnectionID NVARCHAR(128),
+	@CollectAgentID INT,
+	@ImportAgentID INT,
+	@SnapshotDate DATETIME2(2),
+	@ScheduleInfo dbo.ScheduleInfo READONLY
+)
+AS
+SET XACT_ABORT ON
+
+-- 1. Ensure the Instance exists (Stub creation)
+DECLARE @InstanceID INT = (SELECT InstanceID FROM dbo.Instances WHERE ConnectionID = @ConnectionID)
+
+IF @InstanceID IS NULL
+BEGIN
+	BEGIN TRY
+		INSERT INTO dbo.Instances(ConnectionID,Instance,IsActive,CollectAgentID,ImportAgentID)
+		VALUES(@ConnectionID, @ConnectionID, CAST(1 AS BIT), @CollectAgentID, @ImportAgentID)
+		SET @InstanceID = SCOPE_IDENTITY()
+	END TRY
+	BEGIN CATCH
+		-- Handle concurrent insert race condition gracefully
+		IF ERROR_NUMBER() NOT IN (2601,2627) THROW;
+		SET @InstanceID = (SELECT InstanceID FROM dbo.Instances WHERE ConnectionID = @ConnectionID)
+	END CATCH
+END
+
+-- 2. Process Schedule Info Update
+DECLARE @Ref VARCHAR(30)='ScheduleInfo'
+IF NOT EXISTS(SELECT 1 FROM dbo.CollectionDates WHERE SnapshotDate>=@SnapshotDate AND InstanceID = @InstanceID AND Reference=@Ref)
+BEGIN
+	BEGIN TRAN
+
+	DELETE FROM dbo.ScheduleInfo
+	WHERE InstanceID = @InstanceID
+
+	INSERT INTO dbo.ScheduleInfo
+	(
+		InstanceID,
+		Reference,
+		Schedule,
+		RunOnServiceStart,
+		MaxIntervalMinutes,
+		IsInstanceOverride,
+		SnapshotDate
+	)
+	SELECT @InstanceID,
+		S.Reference,
+		S.Schedule,
+		S.RunOnServiceStart,
+		S.MaxIntervalMinutes,
+		S.IsInstanceOverride,
+		@SnapshotDate
+	FROM @ScheduleInfo S
+
+	EXEC dbo.CollectionDates_Upd @InstanceID = @InstanceID,
+	                             @Reference = @Ref,
+	                             @SnapshotDate = @SnapshotDate
+	COMMIT
+END

--- a/DBADashDB/dbo/Stored Procedures/Summary_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/Summary_Upd.sql
@@ -109,7 +109,7 @@ SELECT InstanceID,
 	MIN(SnapshotDate) AS OldestSnapshot
 INTO #CollectionStatus
 FROM dbo.CollectionDatesStatus C
-WHERE Status<>3
+WHERE Status NOT IN (3,8) /* Exclude NA and Disabled from the rollup */
 GROUP BY InstanceID
 
 SELECT InstanceID,

--- a/DBADashDB/dbo/Tables/CollectionDatesThresholds.sql
+++ b/DBADashDB/dbo/Tables/CollectionDatesThresholds.sql
@@ -1,8 +1,13 @@
 ﻿CREATE TABLE [dbo].[CollectionDatesThresholds] (
-    [InstanceID]        INT          NOT NULL,
-    [Reference]         VARCHAR (30) NOT NULL,
-    [WarningThreshold]  INT          NULL,
-    [CriticalThreshold] INT          NULL,
+    [InstanceID]        INT             NOT NULL,
+    [Reference]         VARCHAR (30)    NOT NULL,
+    [WarningThreshold]  INT             NULL,
+    [CriticalThreshold] INT             NULL,
+    [WarningMultiplier]     DECIMAL (9, 2)  NULL,
+    [CriticalMultiplier]    DECIMAL (9, 2)  NULL,
+    [WarningBufferMinutes]  DECIMAL (9, 2)  NULL,
+    [CriticalBufferMinutes] DECIMAL (9, 2)  NULL,
+    [Disabled]              BIT             NOT NULL CONSTRAINT DF_CollectionDatesThresholds_Disabled DEFAULT (0),
     CONSTRAINT [PK_CollectionDatesThresholds] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [Reference] ASC)
 );
 

--- a/DBADashDB/dbo/Tables/ScheduleInfo.sql
+++ b/DBADashDB/dbo/Tables/ScheduleInfo.sql
@@ -1,0 +1,12 @@
+CREATE TABLE [dbo].[ScheduleInfo] (
+    [InstanceID]              INT             NOT NULL,
+    [Reference]               VARCHAR (100)   NOT NULL,
+    [Schedule]                VARCHAR (100)   NOT NULL,
+    [RunOnServiceStart]       BIT             NOT NULL,
+    [MaxIntervalMinutes]      DECIMAL (18, 2) NULL,
+    [IsInstanceOverride]      BIT             NOT NULL,
+    [SnapshotDate]            DATETIME2 (2)   NOT NULL,
+    [IsEnabled] AS (CASE WHEN [Schedule] = '' THEN CONVERT(BIT,0) ELSE CONVERT(BIT,1) END),
+    CONSTRAINT [PK_ScheduleInfo] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [Reference] ASC),
+    CONSTRAINT [FK_ScheduleInfo_Instances] FOREIGN KEY ([InstanceID]) REFERENCES [dbo].[Instances] ([InstanceID])
+);

--- a/DBADashDB/dbo/User Defined Types/ScheduleInfo.sql
+++ b/DBADashDB/dbo/User Defined Types/ScheduleInfo.sql
@@ -1,0 +1,7 @@
+CREATE TYPE [dbo].[ScheduleInfo] AS TABLE (
+    [Reference]               VARCHAR (100)   NOT NULL,
+    [Schedule]                VARCHAR (100)   NOT NULL,
+    [RunOnServiceStart]       BIT             NOT NULL,
+    [MaxIntervalMinutes]      DECIMAL (18, 2) NULL,
+    [IsInstanceOverride]      BIT             NOT NULL
+);

--- a/DBADashDB/dbo/Views/CollectionDatesStatus.sql
+++ b/DBADashDB/dbo/Views/CollectionDatesStatus.sql
@@ -1,23 +1,43 @@
-﻿CREATE VIEW dbo.CollectionDatesStatus
+CREATE VIEW dbo.CollectionDatesStatus
 AS
 SELECT CD.InstanceID,
-	  CD.Reference, 
-	  CASE WHEN DATEDIFF(mi,CD.SnapshotDate,GETUTCDATE())  > T.CriticalThreshold THEN  1 
-			WHEN DATEDIFF(mi,CD.SnapshotDate,GETUTCDATE()) > T.WarningThreshold THEN 2
-			WHEN T.WarningThreshold IS NULL AND T.CriticalThreshold IS NULL THEN 3
+	  CD.Reference,
+	  CASE WHEN SI.IsEnabled = 0 THEN 8 /* Schedule disabled */
+			WHEN T.Disabled = 1 THEN 3 /* Threshold monitoring explicitly disabled */
+			WHEN DATEDIFF(mi,CD.SnapshotDate,GETUTCDATE())  > COALESCE(T.CriticalThreshold,Auto.CriticalThreshold) THEN  1
+			WHEN DATEDIFF(mi,CD.SnapshotDate,GETUTCDATE()) > COALESCE(T.WarningThreshold,Auto.WarningThreshold) THEN 2
+			-- Warning (not NA) only when the *instance* has never reported any ScheduleInfo at all (old
+			-- service version, or not restarted since upgrading) - once it has, a reference that still has
+			-- no SI row (e.g. a custom collection, which ScheduleInfo doesn't cover) correctly falls to NA
+			-- below instead of being stuck on Warning forever.
+			WHEN T.WarningThreshold IS NULL AND T.CriticalThreshold IS NULL AND Auto.WarningThreshold IS NULL AND NOT EXISTS(SELECT 1 FROM dbo.ScheduleInfo SI2 WHERE SI2.InstanceID = CD.InstanceID) THEN 2
+			WHEN T.WarningThreshold IS NULL AND T.CriticalThreshold IS NULL AND Auto.WarningThreshold IS NULL THEN 3
 			ELSE 4 END AS Status,
-	T.WarningThreshold,
-	T.CriticalThreshold,
+	CASE WHEN T.Disabled = 1 THEN NULL ELSE COALESCE(T.WarningThreshold,Auto.WarningThreshold) END AS WarningThreshold,
+	CASE WHEN T.Disabled = 1 THEN NULL ELSE COALESCE(T.CriticalThreshold,Auto.CriticalThreshold) END AS CriticalThreshold,
 	DATEDIFF(mi,CD.SnapshotDate,GETUTCDATE()) AS SnapshotAge,
 	HD.HumanDuration AS HumanSnapshotAge,
 	CD.SnapshotDate,
-	CASE WHEN T.InstanceID >0 THEN 'Instance' ELSE 'Root' END AS ConfiguredLevel
-FROM dbo.CollectionDates CD 
+	CASE WHEN T.InstanceID > 0 THEN 'Instance' WHEN T.InstanceID = -1 THEN 'Root' ELSE 'Default' END AS ConfiguredLevel,
+	CASE WHEN ISNULL(T.Disabled,0) = 0 AND T.WarningThreshold IS NULL AND T.CriticalThreshold IS NULL AND Auto.WarningThreshold IS NOT NULL THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END AS IsScheduleThreshold
+FROM dbo.CollectionDates CD
 CROSS APPLY dbo.SecondsToHumanDuration(DATEDIFF(s,CD.SnapshotDate,GETUTCDATE())) HD
 OUTER APPLY(SELECT TOP(1) CDT.WarningThreshold,
 				CDT.CriticalThreshold,
+				CDT.WarningMultiplier,
+				CDT.CriticalMultiplier,
+				CDT.WarningBufferMinutes,
+				CDT.CriticalBufferMinutes,
+				CDT.Disabled,
 				CDT.InstanceID
-		FROM dbo.CollectionDatesThresholds CDT 
+		FROM dbo.CollectionDatesThresholds CDT
 		WHERE (CD.InstanceID = CDT.InstanceID OR CDT.InstanceID=-1)
 		AND CDT.Reference = CD.Reference
 		ORDER BY InstanceID DESC) T
+LEFT JOIN dbo.ScheduleInfo SI ON SI.InstanceID = CD.InstanceID AND SI.Reference = CD.Reference
+-- App-shipped defaults (not user-configurable - instance/root level already provides the supported way to
+-- override). Keep these in sync with DBADashGUI.CollectionDates.CollectionDatesThresholds' Default* constants.
+CROSS APPLY(SELECT
+		CAST(CEILING(SI.MaxIntervalMinutes * COALESCE(T.WarningMultiplier,2.0) + COALESCE(T.WarningBufferMinutes,3.0)) AS INT) AS WarningThreshold,
+		CAST(CEILING(SI.MaxIntervalMinutes * COALESCE(T.CriticalMultiplier,4.0) + COALESCE(T.CriticalBufferMinutes,6.0)) AS INT) AS CriticalThreshold
+	) Auto

--- a/DBADashGUI/CollectionDates/CollectionDates.Designer.cs
+++ b/DBADashGUI/CollectionDates/CollectionDates.Designer.cs
@@ -44,18 +44,25 @@ namespace DBADashGUI.CollectionDates
             tsTriggerSelected = new System.Windows.Forms.ToolStripMenuItem();
             tsTriggerAll = new System.Windows.Forms.ToolStripMenuItem();
             dgvCollectionDates = new DBADashDataGridView();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
             Instance = new System.Windows.Forms.DataGridViewTextBoxColumn();
             Reference = new System.Windows.Forms.DataGridViewTextBoxColumn();
             WarningThreshold = new System.Windows.Forms.DataGridViewTextBoxColumn();
             CriticalThreshold = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            IsScheduleThreshold = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             SnapshotAge = new System.Windows.Forms.DataGridViewTextBoxColumn();
             SnapshotDate = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            NextFireTime = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ScheduleLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            CronExpression = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            ScheduleDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            RunOnServiceStart = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            MaxIntervalMinutes = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ConfiguredLevel = new System.Windows.Forms.DataGridViewTextBoxColumn();
             Configure = new System.Windows.Forms.DataGridViewLinkColumn();
             ConfigureRoot = new System.Windows.Forms.DataGridViewLinkColumn();
             colRun = new System.Windows.Forms.DataGridViewLinkColumn();
-            statusStrip1 = new System.Windows.Forms.StatusStrip();
-            lblStatus = new System.Windows.Forms.ToolStripStatusLabel();
             toolStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)dgvCollectionDates).BeginInit();
             statusStrip1.SuspendLayout();
@@ -167,7 +174,7 @@ namespace DBADashGUI.CollectionDates
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             dgvCollectionDates.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             dgvCollectionDates.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dgvCollectionDates.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { Instance, Reference, WarningThreshold, CriticalThreshold, SnapshotAge, SnapshotDate, ConfiguredLevel, Configure, ConfigureRoot, colRun });
+            dgvCollectionDates.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { Instance, Reference, WarningThreshold, CriticalThreshold, IsScheduleThreshold, SnapshotAge, SnapshotDate, NextFireTime, ScheduleLevel, CronExpression, ScheduleDescription, RunOnServiceStart, MaxIntervalMinutes, ConfiguredLevel, Configure, ConfigureRoot, colRun });
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(241, 241, 246);
             dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI", 9F);
@@ -189,103 +196,6 @@ namespace DBADashGUI.CollectionDates
             dgvCollectionDates.CellContentClick += Dgv_CellContentClick;
             dgvCollectionDates.RowsAdded += Dgv_RowsAdded;
             // 
-            // Instance
-            // 
-            Instance.DataPropertyName = "InstanceDisplayName";
-            Instance.HeaderText = "Instance";
-            Instance.MinimumWidth = 6;
-            Instance.Name = "Instance";
-            Instance.ReadOnly = true;
-            Instance.Width = 90;
-            // 
-            // Reference
-            // 
-            Reference.DataPropertyName = "Reference";
-            Reference.HeaderText = "Reference";
-            Reference.MinimumWidth = 6;
-            Reference.Name = "Reference";
-            Reference.ReadOnly = true;
-            Reference.Width = 103;
-            // 
-            // WarningThreshold
-            // 
-            WarningThreshold.DataPropertyName = "WarningThreshold";
-            WarningThreshold.HeaderText = "Warning Threshold";
-            WarningThreshold.MinimumWidth = 6;
-            WarningThreshold.Name = "WarningThreshold";
-            WarningThreshold.ReadOnly = true;
-            WarningThreshold.Width = 154;
-            // 
-            // CriticalThreshold
-            // 
-            CriticalThreshold.DataPropertyName = "CriticalThreshold";
-            CriticalThreshold.HeaderText = "Critical Threshold";
-            CriticalThreshold.MinimumWidth = 6;
-            CriticalThreshold.Name = "CriticalThreshold";
-            CriticalThreshold.ReadOnly = true;
-            CriticalThreshold.Width = 135;
-            // 
-            // SnapshotAge
-            // 
-            SnapshotAge.DataPropertyName = "HumanSnapshotAge";
-            SnapshotAge.HeaderText = "Snapshot Age";
-            SnapshotAge.MinimumWidth = 6;
-            SnapshotAge.Name = "SnapshotAge";
-            SnapshotAge.ReadOnly = true;
-            SnapshotAge.Width = 122;
-            // 
-            // SnapshotDate
-            // 
-            SnapshotDate.DataPropertyName = "SnapshotDate";
-            SnapshotDate.HeaderText = "Snapshot Date";
-            SnapshotDate.MinimumWidth = 6;
-            SnapshotDate.Name = "SnapshotDate";
-            SnapshotDate.ReadOnly = true;
-            SnapshotDate.Width = 120;
-            // 
-            // ConfiguredLevel
-            // 
-            ConfiguredLevel.DataPropertyName = "ConfiguredLevel";
-            ConfiguredLevel.HeaderText = "Configured Level";
-            ConfiguredLevel.MinimumWidth = 6;
-            ConfiguredLevel.Name = "ConfiguredLevel";
-            ConfiguredLevel.ReadOnly = true;
-            ConfiguredLevel.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            ConfiguredLevel.Width = 132;
-            // 
-            // Configure
-            // 
-            Configure.HeaderText = "Configure Instance";
-            Configure.LinkColor = System.Drawing.Color.FromArgb(0, 79, 131);
-            Configure.MinimumWidth = 6;
-            Configure.Name = "Configure";
-            Configure.ReadOnly = true;
-            Configure.Text = "Configure Instance";
-            Configure.UseColumnTextForLinkValue = true;
-            Configure.Width = 119;
-            // 
-            // ConfigureRoot
-            // 
-            ConfigureRoot.HeaderText = "Configure Root";
-            ConfigureRoot.LinkColor = System.Drawing.Color.FromArgb(0, 79, 131);
-            ConfigureRoot.MinimumWidth = 6;
-            ConfigureRoot.Name = "ConfigureRoot";
-            ConfigureRoot.ReadOnly = true;
-            ConfigureRoot.Text = "Configure Root";
-            ConfigureRoot.UseColumnTextForLinkValue = true;
-            ConfigureRoot.Width = 98;
-            // 
-            // colRun
-            // 
-            colRun.HeaderText = "Run";
-            colRun.LinkColor = System.Drawing.Color.FromArgb(0, 79, 131);
-            colRun.MinimumWidth = 6;
-            colRun.Name = "colRun";
-            colRun.ReadOnly = true;
-            colRun.Text = "Run Now";
-            colRun.UseColumnTextForLinkValue = true;
-            colRun.Width = 125;
-            // 
             // statusStrip1
             // 
             statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
@@ -301,6 +211,183 @@ namespace DBADashGUI.CollectionDates
             lblStatus.Name = "lblStatus";
             lblStatus.Size = new System.Drawing.Size(50, 20);
             lblStatus.Text = "Ready";
+            // 
+            // Instance
+            // 
+            Instance.DataPropertyName = "InstanceDisplayName";
+            Instance.HeaderText = "Instance";
+            Instance.MinimumWidth = 6;
+            Instance.Name = "Instance";
+            Instance.ReadOnly = true;
+            Instance.ToolTipText = "The name of the instance";
+            Instance.Width = 90;
+            // 
+            // Reference
+            // 
+            Reference.DataPropertyName = "Reference";
+            Reference.HeaderText = "Reference";
+            Reference.MinimumWidth = 6;
+            Reference.Name = "Reference";
+            Reference.ReadOnly = true;
+            Reference.ToolTipText = "The name of the collection";
+            Reference.Width = 103;
+            // 
+            // WarningThreshold
+            // 
+            WarningThreshold.DataPropertyName = "WarningThreshold";
+            WarningThreshold.HeaderText = "Warning Threshold";
+            WarningThreshold.MinimumWidth = 6;
+            WarningThreshold.Name = "WarningThreshold";
+            WarningThreshold.ReadOnly = true;
+            WarningThreshold.ToolTipText = "If the collection hasn't run in this number of minutes, it will be highlighted in yellow";
+            WarningThreshold.Width = 154;
+            // 
+            // CriticalThreshold
+            // 
+            CriticalThreshold.DataPropertyName = "CriticalThreshold";
+            CriticalThreshold.HeaderText = "Critical Threshold";
+            CriticalThreshold.MinimumWidth = 6;
+            CriticalThreshold.Name = "CriticalThreshold";
+            CriticalThreshold.ReadOnly = true;
+            CriticalThreshold.ToolTipText = "If the collection hasn't run in this number of minutes, it will be highlighted in red";
+            CriticalThreshold.Width = 135;
+            // 
+            // IsScheduleThreshold
+            // 
+            IsScheduleThreshold.DataPropertyName = "IsScheduleThreshold";
+            IsScheduleThreshold.HeaderText = "Scheduled Threshold";
+            IsScheduleThreshold.MinimumWidth = 6;
+            IsScheduleThreshold.Name = "IsScheduleThreshold";
+            IsScheduleThreshold.ReadOnly = true;
+            IsScheduleThreshold.ToolTipText = "Checked when the thresholds shown are computed from the collection schedule rather than explicitly configured";
+            IsScheduleThreshold.Width = 110;
+            // 
+            // SnapshotAge
+            // 
+            SnapshotAge.DataPropertyName = "HumanSnapshotAge";
+            SnapshotAge.HeaderText = "Snapshot Age";
+            SnapshotAge.MinimumWidth = 6;
+            SnapshotAge.Name = "SnapshotAge";
+            SnapshotAge.ReadOnly = true;
+            SnapshotAge.ToolTipText = "How long since the collection last ran (at last report refresh)";
+            SnapshotAge.Width = 122;
+            // 
+            // SnapshotDate
+            // 
+            SnapshotDate.DataPropertyName = "SnapshotDate";
+            SnapshotDate.HeaderText = "Snapshot Date";
+            SnapshotDate.MinimumWidth = 6;
+            SnapshotDate.Name = "SnapshotDate";
+            SnapshotDate.ReadOnly = true;
+            SnapshotDate.ToolTipText = "The date/time the collection last ran";
+            SnapshotDate.Width = 120;
+            // 
+            // NextFireTime
+            // 
+            NextFireTime.DataPropertyName = "NextFireTime";
+            NextFireTime.HeaderText = "Next Fire Time";
+            NextFireTime.MinimumWidth = 6;
+            NextFireTime.Name = "NextFireTime";
+            NextFireTime.ReadOnly = true;
+            NextFireTime.ToolTipText = "The time the collection is next scheduled to run, calculated from the schedule (cron expression or interval)";
+            NextFireTime.Width = 120;
+            // 
+            // ScheduleLevel
+            // 
+            ScheduleLevel.DataPropertyName = "ScheduleLevel";
+            ScheduleLevel.HeaderText = "Schedule Level";
+            ScheduleLevel.MinimumWidth = 6;
+            ScheduleLevel.Name = "ScheduleLevel";
+            ScheduleLevel.ReadOnly = true;
+            ScheduleLevel.ToolTipText = "Indicates whether the schedule is configured at service level or customized for this instance. Schedules are configured using the service configuration tool.";
+            ScheduleLevel.Width = 110;
+            // 
+            // CronExpression
+            // 
+            CronExpression.DataPropertyName = "Schedule";
+            CronExpression.HeaderText = "Schedule";
+            CronExpression.MinimumWidth = 6;
+            CronExpression.Name = "CronExpression";
+            CronExpression.ReadOnly = true;
+            CronExpression.ToolTipText = "Cron expression or interval (in seconds) used to calculate the frequency of the collection";
+            CronExpression.Width = 130;
+            // 
+            // ScheduleDescription
+            // 
+            ScheduleDescription.DataPropertyName = "ScheduleDescription";
+            ScheduleDescription.HeaderText = "Schedule Description";
+            ScheduleDescription.MinimumWidth = 6;
+            ScheduleDescription.Name = "ScheduleDescription";
+            ScheduleDescription.ReadOnly = true;
+            ScheduleDescription.ToolTipText = "Description of the collection schedule calculated from the cron expression";
+            ScheduleDescription.Width = 160;
+            // 
+            // RunOnServiceStart
+            // 
+            RunOnServiceStart.DataPropertyName = "RunOnServiceStart";
+            RunOnServiceStart.HeaderText = "Run On Service Start";
+            RunOnServiceStart.MinimumWidth = 6;
+            RunOnServiceStart.Name = "RunOnServiceStart";
+            RunOnServiceStart.ReadOnly = true;
+            RunOnServiceStart.ToolTipText = "Indicates whether the collection runs when the service is started instead of waiting for the next scheduled execution";
+            RunOnServiceStart.Width = 130;
+            // 
+            // MaxIntervalMinutes
+            // 
+            MaxIntervalMinutes.DataPropertyName = "MaxIntervalMinutes";
+            MaxIntervalMinutes.HeaderText = "Max Interval (mins)";
+            MaxIntervalMinutes.MinimumWidth = 6;
+            MaxIntervalMinutes.Name = "MaxIntervalMinutes";
+            MaxIntervalMinutes.ReadOnly = true;
+            MaxIntervalMinutes.ToolTipText = resources.GetString("MaxIntervalMinutes.ToolTipText");
+            MaxIntervalMinutes.Width = 140;
+            // 
+            // ConfiguredLevel
+            // 
+            ConfiguredLevel.DataPropertyName = "ConfiguredLevel";
+            ConfiguredLevel.HeaderText = "Configured Level";
+            ConfiguredLevel.MinimumWidth = 6;
+            ConfiguredLevel.Name = "ConfiguredLevel";
+            ConfiguredLevel.ReadOnly = true;
+            ConfiguredLevel.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            ConfiguredLevel.ToolTipText = "Indicates whether the warning/critical thresholds use the application defaults, or have been overridden at root or instance level.";
+            ConfiguredLevel.Width = 132;
+            // 
+            // Configure
+            // 
+            Configure.HeaderText = "Configure Instance";
+            Configure.LinkColor = System.Drawing.Color.FromArgb(0, 79, 131);
+            Configure.MinimumWidth = 6;
+            Configure.Name = "Configure";
+            Configure.ReadOnly = true;
+            Configure.Text = "Configure Instance";
+            Configure.ToolTipText = "Configure the warning/critical thresholds for this collection at the instance level. The collection is highlighted when it hasn't run successfully within the specified period of time.";
+            Configure.UseColumnTextForLinkValue = true;
+            Configure.Width = 119;
+            // 
+            // ConfigureRoot
+            // 
+            ConfigureRoot.HeaderText = "Configure Root";
+            ConfigureRoot.LinkColor = System.Drawing.Color.FromArgb(0, 79, 131);
+            ConfigureRoot.MinimumWidth = 6;
+            ConfigureRoot.Name = "ConfigureRoot";
+            ConfigureRoot.ReadOnly = true;
+            ConfigureRoot.Text = "Configure Root";
+            ConfigureRoot.ToolTipText = "Configure the warning/critical thresholds for this collection at the root level, applying to all instances. The collection is highlighted when it hasn't run successfully within the specified period of time.";
+            ConfigureRoot.UseColumnTextForLinkValue = true;
+            ConfigureRoot.Width = 98;
+            // 
+            // colRun
+            // 
+            colRun.HeaderText = "Run";
+            colRun.LinkColor = System.Drawing.Color.FromArgb(0, 79, 131);
+            colRun.MinimumWidth = 6;
+            colRun.Name = "colRun";
+            colRun.ReadOnly = true;
+            colRun.Text = "Run Now";
+            colRun.ToolTipText = "Trigger the collection to run now";
+            colRun.UseColumnTextForLinkValue = true;
+            colRun.Width = 125;
             // 
             // CollectionDates
             // 
@@ -329,16 +416,6 @@ namespace DBADashGUI.CollectionDates
         private System.Windows.Forms.ToolStripButton tsCopy;
         private System.Windows.Forms.ToolStripButton tsExcel;
         private StatusFilterToolStrip statusFilterToolStrip1;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Instance;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Reference;
-        private System.Windows.Forms.DataGridViewTextBoxColumn WarningThreshold;
-        private System.Windows.Forms.DataGridViewTextBoxColumn CriticalThreshold;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SnapshotAge;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SnapshotDate;
-        private System.Windows.Forms.DataGridViewTextBoxColumn ConfiguredLevel;
-        private System.Windows.Forms.DataGridViewLinkColumn Configure;
-        private System.Windows.Forms.DataGridViewLinkColumn ConfigureRoot;
-        private System.Windows.Forms.DataGridViewLinkColumn colRun;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripButton tsClearFilter;
         private System.Windows.Forms.ToolStripDropDownButton tsTriggerMenu;
@@ -346,5 +423,22 @@ namespace DBADashGUI.CollectionDates
         private System.Windows.Forms.ToolStripMenuItem tsTriggerSelected;
         private System.Windows.Forms.ToolStripMenuItem tsTriggerAll;
         private System.Windows.Forms.ToolStripStatusLabel lblStatus;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Instance;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Reference;
+        private System.Windows.Forms.DataGridViewTextBoxColumn WarningThreshold;
+        private System.Windows.Forms.DataGridViewTextBoxColumn CriticalThreshold;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn IsScheduleThreshold;
+        private System.Windows.Forms.DataGridViewTextBoxColumn SnapshotAge;
+        private System.Windows.Forms.DataGridViewTextBoxColumn SnapshotDate;
+        private System.Windows.Forms.DataGridViewTextBoxColumn NextFireTime;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ScheduleLevel;
+        private System.Windows.Forms.DataGridViewTextBoxColumn CronExpression;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ScheduleDescription;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn RunOnServiceStart;
+        private System.Windows.Forms.DataGridViewTextBoxColumn MaxIntervalMinutes;
+        private System.Windows.Forms.DataGridViewTextBoxColumn ConfiguredLevel;
+        private System.Windows.Forms.DataGridViewLinkColumn Configure;
+        private System.Windows.Forms.DataGridViewLinkColumn ConfigureRoot;
+        private System.Windows.Forms.DataGridViewLinkColumn colRun;
     }
 }

--- a/DBADashGUI/CollectionDates/CollectionDates.cs
+++ b/DBADashGUI/CollectionDates/CollectionDates.cs
@@ -21,6 +21,7 @@ namespace DBADashGUI.CollectionDates
             dgvCollectionDates.RegisterClearFilter(tsClearFilter);
             dgvCollectionDates.GridFilterChanged += ((_, _) => PersistFilter = dgvCollectionDates.RowFilter);
             statusFilterToolStrip1.AcknowledgedVisible = false;
+            statusFilterToolStrip1.DisabledVisible = true;
         }
 
         private string PersistFilter;
@@ -52,6 +53,12 @@ namespace DBADashGUI.CollectionDates
             get => statusFilterToolStrip1.OK; set => statusFilterToolStrip1.OK = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool IncludeDisabled
+        {
+            get => statusFilterToolStrip1.Disabled; set => statusFilterToolStrip1.Disabled = value;
+        }
+
         private static readonly string[] NoTriggerCollectionTypes = new[] { "QueryPlans", "QueryText", "SlowQueriesStats", "InternalPerformanceCounters", "SessionWaits" };
 
         private DataTable GetCollectionDates()
@@ -65,8 +72,40 @@ namespace DBADashGUI.CollectionDates
             cmd.Parameters.AddWithValue("ShowHidden", InstanceIDs.Count == 1 || Common.ShowHidden);
             DataTable dt = new();
             da.Fill(dt);
+            AddScheduleColumns(dt);
             DateHelper.ConvertUTCToAppTimeZone(ref dt);
             return dt;
+        }
+
+        /// <summary>
+        /// Derives display-only schedule columns from the raw cron/interval string reported by the service.
+        /// Next fire time is computed on demand rather than persisted, since it changes every time the job
+        /// actually runs - only the schedule definition itself is static.  Added before the timezone conversion
+        /// pass so NextFireTime converts along with the other datetime columns.
+        /// </summary>
+        private static void AddScheduleColumns(DataTable dt)
+        {
+            dt.Columns.Add("NextFireTime", typeof(DateTime));
+            dt.Columns.Add("ScheduleDescription", typeof(string));
+            dt.Columns.Add("ScheduleLevel", typeof(string));
+            var now = DateTimeOffset.UtcNow;
+            foreach (DataRow row in dt.Rows)
+            {
+                var schedule = row["Schedule"] == DBNull.Value ? null : (string)row["Schedule"];
+                // No ScheduleInfo row at all (schedule is null) means the service hasn't reported its
+                // schedule yet - distinct from an explicitly disabled schedule (schedule == "").
+                var notReported = schedule == null;
+                // An empty schedule with RunOnServiceStart set (e.g. ScheduleInfo itself) means the
+                // collection only ever runs once at service start, not that it's disabled.
+                var runOnServiceStart = row["RunOnServiceStart"] != DBNull.Value && (bool)row["RunOnServiceStart"];
+                var disabledLabel = runOnServiceStart ? "Startup Only" : "Disabled";
+                row["NextFireTime"] = (object)CronNextFireTime.TryGetNextFireTimeUtc(schedule, now) ?? DBNull.Value;
+                row["ScheduleDescription"] = notReported ? "Not Reported" : CronParser.GetScheduleDescriptionSafe(schedule, runOnServiceStart: runOnServiceStart);
+                row["ScheduleLevel"] = row["IsInstanceOverride"] == DBNull.Value
+                    ? string.Empty
+                    : (bool)row["IsInstanceOverride"] ? "Instance" : "Service";
+                row["Schedule"] = notReported ? "Not Reported" : (string.IsNullOrEmpty(schedule) ? disabledLabel : schedule);
+            }
         }
 
         private DBADashContext CurrentContext;
@@ -81,6 +120,7 @@ namespace DBADashGUI.CollectionDates
             IncludeWarning = true;
             IncludeNA = _context.InstanceID > 0;
             IncludeOK = _context.InstanceID > 0;
+            IncludeDisabled = _context.InstanceID > 0;
             lblStatus.Visible = false;
             RefreshData();
         }
@@ -114,16 +154,18 @@ namespace DBADashGUI.CollectionDates
             {
                 InstanceID = InstanceID
             };
-            if (row["WarningThreshold"] == DBNull.Value || row["CriticalThreshold"] == DBNull.Value)
-            {
-                frm.Disabled = true;
-            }
-            else
+            // Just a display default shown briefly before CollectionDatesThresholds_Load re-reads the
+            // authoritative config (if any) from CollectionDatesThresholds_Get - null here just means no
+            // effective threshold could be computed yet (e.g. no schedule info collected), not that
+            // monitoring was explicitly disabled, so leave the dialog's Auto default in that case.
+            if (row["WarningThreshold"] != DBNull.Value && row["CriticalThreshold"] != DBNull.Value)
             {
                 frm.WarningThreshold = (int)row["WarningThreshold"];
                 frm.CriticalThreshold = (int)row["CriticalThreshold"];
             }
-            if ((string)row["ConfiguredLevel"] != "Instance")
+            // Only pre-select Inherit when there's an actual root-level override to inherit from -
+            // "Default" means no config exists anywhere, which isn't the same thing.
+            if ((string)row["ConfiguredLevel"] == "Root")
             {
                 frm.Inherit = true;
             }
@@ -187,7 +229,9 @@ namespace DBADashGUI.CollectionDates
 
                 dgvCollectionDates.Rows[idx].Cells["SnapshotAge"].SetStatusColor(Status);
 
-                dgvCollectionDates.Rows[idx].Cells["Configure"].Style.Font = (string)row["ConfiguredLevel"] == "Instance" ? new Font(dgvCollectionDates.Font, FontStyle.Bold) : new Font(dgvCollectionDates.Font, FontStyle.Regular);
+                var configuredLevel = (string)row["ConfiguredLevel"];
+                dgvCollectionDates.Rows[idx].Cells["Configure"].Style.Font = configuredLevel == "Instance" ? new Font(dgvCollectionDates.Font, FontStyle.Bold) : new Font(dgvCollectionDates.Font, FontStyle.Regular);
+                dgvCollectionDates.Rows[idx].Cells["ConfigureRoot"].Style.Font = configuredLevel == "Root" ? new Font(dgvCollectionDates.Font, FontStyle.Bold) : new Font(dgvCollectionDates.Font, FontStyle.Regular);
             }
         }
 

--- a/DBADashGUI/CollectionDates/CollectionDates.resx
+++ b/DBADashGUI/CollectionDates/CollectionDates.resx
@@ -153,6 +153,9 @@
   <metadata name="SnapshotDate.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="MaxIntervalMinutes.ToolTipText" xml:space="preserve">
+    <value>The interval between collections in minutes, calculated from the cron expression. If the interval isn't constant (e.g. it runs on specific days of the week), this is the maximum interval between collections.</value>
+  </data>
   <metadata name="ConfiguredLevel.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/DBADashGUI/CollectionDates/CollectionDatesThresholds.Designer.cs
+++ b/DBADashGUI/CollectionDates/CollectionDatesThresholds.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace DBADashGUI.CollectionDates
+namespace DBADashGUI.CollectionDates
 {
     partial class CollectionDatesThresholds
     {
@@ -28,212 +28,367 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.label10 = new System.Windows.Forms.Label();
-            this.label8 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.label9 = new System.Windows.Forms.Label();
-            this.numWarning = new System.Windows.Forms.NumericUpDown();
-            this.numCritical = new System.Windows.Forms.NumericUpDown();
-            this.bttnCancel = new System.Windows.Forms.Button();
-            this.bttnUpdate = new System.Windows.Forms.Button();
-            this.optInherit = new System.Windows.Forms.RadioButton();
-            this.OptDisabled = new System.Windows.Forms.RadioButton();
-            this.optEnabled = new System.Windows.Forms.RadioButton();
-            this.pnlThresholds = new System.Windows.Forms.Panel();
-            this.chkReferences = new System.Windows.Forms.CheckedListBox();
-            this.chkCheckAll = new System.Windows.Forms.CheckBox();
-            ((System.ComponentModel.ISupportInitialize)(this.numWarning)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numCritical)).BeginInit();
-            this.pnlThresholds.SuspendLayout();
-            this.SuspendLayout();
+            label10 = new System.Windows.Forms.Label();
+            label8 = new System.Windows.Forms.Label();
+            label7 = new System.Windows.Forms.Label();
+            label9 = new System.Windows.Forms.Label();
+            numWarning = new System.Windows.Forms.NumericUpDown();
+            numCritical = new System.Windows.Forms.NumericUpDown();
+            labelWarningMultiplier = new System.Windows.Forms.Label();
+            numWarningMultiplier = new System.Windows.Forms.NumericUpDown();
+            labelWarningMultiplierSuffix = new System.Windows.Forms.Label();
+            labelCriticalMultiplier = new System.Windows.Forms.Label();
+            numCriticalMultiplier = new System.Windows.Forms.NumericUpDown();
+            labelCriticalMultiplierSuffix = new System.Windows.Forms.Label();
+            numWarningBuffer = new System.Windows.Forms.NumericUpDown();
+            labelWarningBufferSuffix = new System.Windows.Forms.Label();
+            numCriticalBuffer = new System.Windows.Forms.NumericUpDown();
+            labelCriticalBufferSuffix = new System.Windows.Forms.Label();
+            bttnCancel = new System.Windows.Forms.Button();
+            bttnUpdate = new System.Windows.Forms.Button();
+            optInherit = new System.Windows.Forms.RadioButton();
+            OptDisabled = new System.Windows.Forms.RadioButton();
+            optExplicit = new System.Windows.Forms.RadioButton();
+            optSchedule = new System.Windows.Forms.RadioButton();
+            pnlThresholds = new System.Windows.Forms.Panel();
+            pnlSchedule = new System.Windows.Forms.Panel();
+            chkReferences = new System.Windows.Forms.CheckedListBox();
+            chkCheckAll = new System.Windows.Forms.CheckBox();
+            ((System.ComponentModel.ISupportInitialize)numWarning).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numCritical).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numWarningMultiplier).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numCriticalMultiplier).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numWarningBuffer).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numCriticalBuffer).BeginInit();
+            pnlThresholds.SuspendLayout();
+            pnlSchedule.SuspendLayout();
+            SuspendLayout();
             // 
             // label10
             // 
-            this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(228, 16);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(37, 17);
-            this.label10.TabIndex = 52;
-            this.label10.Text = "mins";
+            label10.AutoSize = true;
+            label10.Location = new System.Drawing.Point(227, 10);
+            label10.Name = "label10";
+            label10.Size = new System.Drawing.Size(40, 20);
+            label10.TabIndex = 52;
+            label10.Text = "mins";
             // 
             // label8
             // 
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(228, 49);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(37, 17);
-            this.label8.TabIndex = 51;
-            this.label8.Text = "mins";
+            label8.AutoSize = true;
+            label8.Location = new System.Drawing.Point(227, 48);
+            label8.Name = "label8";
+            label8.Size = new System.Drawing.Size(40, 20);
+            label8.TabIndex = 51;
+            label8.Text = "mins";
             // 
             // label7
             // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(4, 46);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(54, 17);
-            this.label7.TabIndex = 47;
-            this.label7.Text = "Critical:";
+            label7.AutoSize = true;
+            label7.Location = new System.Drawing.Point(4, 48);
+            label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label7.Name = "label7";
+            label7.Size = new System.Drawing.Size(58, 20);
+            label7.TabIndex = 47;
+            label7.Text = "Critical:";
             // 
             // label9
             // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(4, 11);
-            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(65, 17);
-            this.label9.TabIndex = 46;
-            this.label9.Text = "Warning:";
+            label9.AutoSize = true;
+            label9.Location = new System.Drawing.Point(4, 8);
+            label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label9.Name = "label9";
+            label9.Size = new System.Drawing.Size(67, 20);
+            label9.TabIndex = 46;
+            label9.Text = "Warning:";
             // 
             // numWarning
             // 
-            this.numWarning.Location = new System.Drawing.Point(121, 11);
-            this.numWarning.Margin = new System.Windows.Forms.Padding(4);
-            this.numWarning.Maximum = new decimal(new int[] {
-            2147483647,
-            0,
-            0,
-            0});
-            this.numWarning.Name = "numWarning";
-            this.numWarning.Size = new System.Drawing.Size(100, 22);
-            this.numWarning.TabIndex = 48;
+            numWarning.Location = new System.Drawing.Point(140, 6);
+            numWarning.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            numWarning.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            numWarning.Name = "numWarning";
+            numWarning.Size = new System.Drawing.Size(80, 27);
+            numWarning.TabIndex = 48;
             // 
             // numCritical
             // 
-            this.numCritical.Location = new System.Drawing.Point(121, 44);
-            this.numCritical.Margin = new System.Windows.Forms.Padding(4);
-            this.numCritical.Maximum = new decimal(new int[] {
-            2147483647,
-            0,
-            0,
-            0});
-            this.numCritical.Name = "numCritical";
-            this.numCritical.Size = new System.Drawing.Size(100, 22);
-            this.numCritical.TabIndex = 49;
+            numCritical.Location = new System.Drawing.Point(140, 46);
+            numCritical.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            numCritical.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            numCritical.Name = "numCritical";
+            numCritical.Size = new System.Drawing.Size(80, 27);
+            numCritical.TabIndex = 49;
+            // 
+            // labelWarningMultiplier
+            // 
+            labelWarningMultiplier.AutoSize = true;
+            labelWarningMultiplier.Location = new System.Drawing.Point(4, 8);
+            labelWarningMultiplier.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            labelWarningMultiplier.Name = "labelWarningMultiplier";
+            labelWarningMultiplier.Size = new System.Drawing.Size(135, 20);
+            labelWarningMultiplier.TabIndex = 63;
+            labelWarningMultiplier.Text = "Warning multiplier:";
+            // 
+            // numWarningMultiplier
+            // 
+            numWarningMultiplier.DecimalPlaces = 1;
+            numWarningMultiplier.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            numWarningMultiplier.Location = new System.Drawing.Point(140, 5);
+            numWarningMultiplier.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            numWarningMultiplier.Minimum = new decimal(new int[] { 1, 0, 0, 65536 });
+            numWarningMultiplier.Name = "numWarningMultiplier";
+            numWarningMultiplier.Size = new System.Drawing.Size(80, 27);
+            numWarningMultiplier.TabIndex = 64;
+            numWarningMultiplier.Value = new decimal(new int[] { 3, 0, 0, 0 });
+            // 
+            // labelWarningMultiplierSuffix
+            // 
+            labelWarningMultiplierSuffix.AutoSize = true;
+            labelWarningMultiplierSuffix.Location = new System.Drawing.Point(227, 8);
+            labelWarningMultiplierSuffix.Name = "labelWarningMultiplierSuffix";
+            labelWarningMultiplierSuffix.Size = new System.Drawing.Size(151, 20);
+            labelWarningMultiplierSuffix.TabIndex = 65;
+            labelWarningMultiplierSuffix.Text = "* collection interval +";
+            // 
+            // labelCriticalMultiplier
+            // 
+            labelCriticalMultiplier.AutoSize = true;
+            labelCriticalMultiplier.Location = new System.Drawing.Point(4, 48);
+            labelCriticalMultiplier.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            labelCriticalMultiplier.Name = "labelCriticalMultiplier";
+            labelCriticalMultiplier.Size = new System.Drawing.Size(126, 20);
+            labelCriticalMultiplier.TabIndex = 70;
+            labelCriticalMultiplier.Text = "Critical multiplier:";
+            // 
+            // numCriticalMultiplier
+            // 
+            numCriticalMultiplier.DecimalPlaces = 1;
+            numCriticalMultiplier.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
+            numCriticalMultiplier.Location = new System.Drawing.Point(140, 45);
+            numCriticalMultiplier.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            numCriticalMultiplier.Minimum = new decimal(new int[] { 1, 0, 0, 65536 });
+            numCriticalMultiplier.Name = "numCriticalMultiplier";
+            numCriticalMultiplier.Size = new System.Drawing.Size(80, 27);
+            numCriticalMultiplier.TabIndex = 71;
+            numCriticalMultiplier.Value = new decimal(new int[] { 6, 0, 0, 0 });
+            // 
+            // labelCriticalMultiplierSuffix
+            // 
+            labelCriticalMultiplierSuffix.AutoSize = true;
+            labelCriticalMultiplierSuffix.Location = new System.Drawing.Point(227, 48);
+            labelCriticalMultiplierSuffix.Name = "labelCriticalMultiplierSuffix";
+            labelCriticalMultiplierSuffix.Size = new System.Drawing.Size(151, 20);
+            labelCriticalMultiplierSuffix.TabIndex = 72;
+            labelCriticalMultiplierSuffix.Text = "* collection interval +";
+            // 
+            // numWarningBuffer
+            // 
+            numWarningBuffer.DecimalPlaces = 1;
+            numWarningBuffer.Location = new System.Drawing.Point(386, 8);
+            numWarningBuffer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            numWarningBuffer.Maximum = new decimal(new int[] { 1440, 0, 0, 0 });
+            numWarningBuffer.Name = "numWarningBuffer";
+            numWarningBuffer.Size = new System.Drawing.Size(80, 27);
+            numWarningBuffer.TabIndex = 67;
+            numWarningBuffer.Value = new decimal(new int[] { 5, 0, 0, 0 });
+            // 
+            // labelWarningBufferSuffix
+            // 
+            labelWarningBufferSuffix.AutoSize = true;
+            labelWarningBufferSuffix.Location = new System.Drawing.Point(473, 11);
+            labelWarningBufferSuffix.Name = "labelWarningBufferSuffix";
+            labelWarningBufferSuffix.Size = new System.Drawing.Size(40, 20);
+            labelWarningBufferSuffix.TabIndex = 68;
+            labelWarningBufferSuffix.Text = "mins";
+            // 
+            // numCriticalBuffer
+            // 
+            numCriticalBuffer.DecimalPlaces = 1;
+            numCriticalBuffer.Location = new System.Drawing.Point(386, 45);
+            numCriticalBuffer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            numCriticalBuffer.Maximum = new decimal(new int[] { 1440, 0, 0, 0 });
+            numCriticalBuffer.Name = "numCriticalBuffer";
+            numCriticalBuffer.Size = new System.Drawing.Size(80, 27);
+            numCriticalBuffer.TabIndex = 74;
+            numCriticalBuffer.Value = new decimal(new int[] { 5, 0, 0, 0 });
+            // 
+            // labelCriticalBufferSuffix
+            // 
+            labelCriticalBufferSuffix.AutoSize = true;
+            labelCriticalBufferSuffix.Location = new System.Drawing.Point(473, 48);
+            labelCriticalBufferSuffix.Name = "labelCriticalBufferSuffix";
+            labelCriticalBufferSuffix.Size = new System.Drawing.Size(40, 20);
+            labelCriticalBufferSuffix.TabIndex = 75;
+            labelCriticalBufferSuffix.Text = "mins";
             // 
             // bttnCancel
             // 
-            this.bttnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bttnCancel.Location = new System.Drawing.Point(290, 467);
-            this.bttnCancel.Name = "bttnCancel";
-            this.bttnCancel.Size = new System.Drawing.Size(75, 23);
-            this.bttnCancel.TabIndex = 56;
-            this.bttnCancel.Text = "Cancel";
-            this.bttnCancel.UseVisualStyleBackColor = true;
-            this.bttnCancel.Click += new System.EventHandler(this.BttnCancel_Click);
+            bttnCancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            bttnCancel.Location = new System.Drawing.Point(435, 605);
+            bttnCancel.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            bttnCancel.Name = "bttnCancel";
+            bttnCancel.Size = new System.Drawing.Size(75, 29);
+            bttnCancel.TabIndex = 56;
+            bttnCancel.Text = "Cancel";
+            bttnCancel.UseVisualStyleBackColor = true;
+            bttnCancel.Click += BttnCancel_Click;
             // 
             // bttnUpdate
             // 
-            this.bttnUpdate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.bttnUpdate.Location = new System.Drawing.Point(371, 467);
-            this.bttnUpdate.Name = "bttnUpdate";
-            this.bttnUpdate.Size = new System.Drawing.Size(75, 23);
-            this.bttnUpdate.TabIndex = 55;
-            this.bttnUpdate.Text = "Update";
-            this.bttnUpdate.UseVisualStyleBackColor = true;
-            this.bttnUpdate.Click += new System.EventHandler(this.BttnUpdate_Click);
+            bttnUpdate.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            bttnUpdate.Location = new System.Drawing.Point(516, 605);
+            bttnUpdate.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            bttnUpdate.Name = "bttnUpdate";
+            bttnUpdate.Size = new System.Drawing.Size(75, 29);
+            bttnUpdate.TabIndex = 55;
+            bttnUpdate.Text = "Update";
+            bttnUpdate.UseVisualStyleBackColor = true;
+            bttnUpdate.Click += BttnUpdate_Click;
             // 
             // optInherit
             // 
-            this.optInherit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.optInherit.AutoSize = true;
-            this.optInherit.Location = new System.Drawing.Point(209, 329);
-            this.optInherit.Margin = new System.Windows.Forms.Padding(4);
-            this.optInherit.Name = "optInherit";
-            this.optInherit.Size = new System.Drawing.Size(68, 21);
-            this.optInherit.TabIndex = 59;
-            this.optInherit.Text = "Inherit";
-            this.optInherit.UseVisualStyleBackColor = true;
-            this.optInherit.CheckedChanged += new System.EventHandler(this.OptInherit_CheckedChanged);
+            optInherit.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            optInherit.AutoSize = true;
+            optInherit.Location = new System.Drawing.Point(341, 459);
+            optInherit.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            optInherit.Name = "optInherit";
+            optInherit.Size = new System.Drawing.Size(72, 24);
+            optInherit.TabIndex = 59;
+            optInherit.Text = "Inherit";
+            optInherit.UseVisualStyleBackColor = true;
+            optInherit.CheckedChanged += OptInherit_CheckedChanged;
             // 
             // OptDisabled
             // 
-            this.OptDisabled.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.OptDisabled.AutoSize = true;
-            this.OptDisabled.Location = new System.Drawing.Point(102, 329);
-            this.OptDisabled.Margin = new System.Windows.Forms.Padding(4);
-            this.OptDisabled.Name = "OptDisabled";
-            this.OptDisabled.Size = new System.Drawing.Size(84, 21);
-            this.OptDisabled.TabIndex = 58;
-            this.OptDisabled.Text = "Disabled";
-            this.OptDisabled.UseVisualStyleBackColor = true;
-            this.OptDisabled.CheckedChanged += new System.EventHandler(this.OptDisabled_CheckedChanged);
+            OptDisabled.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            OptDisabled.AutoSize = true;
+            OptDisabled.Location = new System.Drawing.Point(246, 459);
+            OptDisabled.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            OptDisabled.Name = "OptDisabled";
+            OptDisabled.Size = new System.Drawing.Size(89, 24);
+            OptDisabled.TabIndex = 58;
+            OptDisabled.Text = "Disabled";
+            OptDisabled.UseVisualStyleBackColor = true;
+            OptDisabled.CheckedChanged += OptDisabled_CheckedChanged;
             // 
-            // optEnabled
+            // optExplicit
             // 
-            this.optEnabled.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.optEnabled.AutoSize = true;
-            this.optEnabled.Checked = true;
-            this.optEnabled.Location = new System.Drawing.Point(13, 329);
-            this.optEnabled.Margin = new System.Windows.Forms.Padding(4);
-            this.optEnabled.Name = "optEnabled";
-            this.optEnabled.Size = new System.Drawing.Size(81, 21);
-            this.optEnabled.TabIndex = 57;
-            this.optEnabled.TabStop = true;
-            this.optEnabled.Text = "Enabled";
-            this.optEnabled.UseVisualStyleBackColor = true;
-            this.optEnabled.CheckedChanged += new System.EventHandler(this.OptEnabled_CheckedChanged);
+            optExplicit.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            optExplicit.AutoSize = true;
+            optExplicit.Location = new System.Drawing.Point(156, 459);
+            optExplicit.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            optExplicit.Name = "optExplicit";
+            optExplicit.Size = new System.Drawing.Size(78, 24);
+            optExplicit.TabIndex = 57;
+            optExplicit.Text = "Explicit";
+            optExplicit.UseVisualStyleBackColor = true;
+            optExplicit.CheckedChanged += OptExplicit_CheckedChanged;
+            // 
+            // optSchedule
+            // 
+            optSchedule.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            optSchedule.AutoSize = true;
+            optSchedule.Checked = true;
+            optSchedule.Location = new System.Drawing.Point(14, 459);
+            optSchedule.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            optSchedule.Name = "optSchedule";
+            optSchedule.Size = new System.Drawing.Size(134, 24);
+            optSchedule.TabIndex = 69;
+            optSchedule.TabStop = true;
+            optSchedule.Text = "Schedule Based";
+            optSchedule.UseVisualStyleBackColor = true;
+            optSchedule.CheckedChanged += OptSchedule_CheckedChanged;
             // 
             // pnlThresholds
             // 
-            this.pnlThresholds.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.pnlThresholds.Controls.Add(this.label9);
-            this.pnlThresholds.Controls.Add(this.numCritical);
-            this.pnlThresholds.Controls.Add(this.numWarning);
-            this.pnlThresholds.Controls.Add(this.label7);
-            this.pnlThresholds.Controls.Add(this.label8);
-            this.pnlThresholds.Controls.Add(this.label10);
-            this.pnlThresholds.Location = new System.Drawing.Point(12, 357);
-            this.pnlThresholds.Name = "pnlThresholds";
-            this.pnlThresholds.Size = new System.Drawing.Size(386, 85);
-            this.pnlThresholds.TabIndex = 60;
+            pnlThresholds.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            pnlThresholds.Controls.Add(label9);
+            pnlThresholds.Controls.Add(numCritical);
+            pnlThresholds.Controls.Add(numWarning);
+            pnlThresholds.Controls.Add(label7);
+            pnlThresholds.Controls.Add(label8);
+            pnlThresholds.Controls.Add(label10);
+            pnlThresholds.Location = new System.Drawing.Point(14, 492);
+            pnlThresholds.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            pnlThresholds.Name = "pnlThresholds";
+            pnlThresholds.Size = new System.Drawing.Size(386, 89);
+            pnlThresholds.TabIndex = 60;
+            // 
+            // pnlSchedule
+            // 
+            pnlSchedule.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            pnlSchedule.Controls.Add(labelWarningMultiplier);
+            pnlSchedule.Controls.Add(numWarningMultiplier);
+            pnlSchedule.Controls.Add(labelWarningMultiplierSuffix);
+            pnlSchedule.Controls.Add(labelCriticalMultiplier);
+            pnlSchedule.Controls.Add(numCriticalMultiplier);
+            pnlSchedule.Controls.Add(labelCriticalMultiplierSuffix);
+            pnlSchedule.Controls.Add(numWarningBuffer);
+            pnlSchedule.Controls.Add(labelWarningBufferSuffix);
+            pnlSchedule.Controls.Add(numCriticalBuffer);
+            pnlSchedule.Controls.Add(labelCriticalBufferSuffix);
+            pnlSchedule.Location = new System.Drawing.Point(13, 492);
+            pnlSchedule.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            pnlSchedule.Name = "pnlSchedule";
+            pnlSchedule.Size = new System.Drawing.Size(578, 89);
+            pnlSchedule.TabIndex = 76;
             // 
             // chkReferences
             // 
-            this.chkReferences.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkReferences.CheckOnClick = true;
-            this.chkReferences.FormattingEnabled = true;
-            this.chkReferences.Location = new System.Drawing.Point(12, 46);
-            this.chkReferences.Name = "chkReferences";
-            this.chkReferences.Size = new System.Drawing.Size(434, 276);
-            this.chkReferences.TabIndex = 61;
+            chkReferences.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            chkReferences.CheckOnClick = true;
+            chkReferences.FormattingEnabled = true;
+            chkReferences.Location = new System.Drawing.Point(12, 58);
+            chkReferences.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            chkReferences.Name = "chkReferences";
+            chkReferences.Size = new System.Drawing.Size(590, 378);
+            chkReferences.TabIndex = 61;
             // 
             // chkCheckAll
             // 
-            this.chkCheckAll.AutoSize = true;
-            this.chkCheckAll.Location = new System.Drawing.Point(13, 12);
-            this.chkCheckAll.Name = "chkCheckAll";
-            this.chkCheckAll.Size = new System.Drawing.Size(88, 21);
-            this.chkCheckAll.TabIndex = 62;
-            this.chkCheckAll.Text = "Check All";
-            this.chkCheckAll.UseVisualStyleBackColor = true;
-            this.chkCheckAll.CheckedChanged += new System.EventHandler(this.ChkCheckAll_CheckedChanged);
+            chkCheckAll.AutoSize = true;
+            chkCheckAll.Location = new System.Drawing.Point(13, 15);
+            chkCheckAll.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            chkCheckAll.Name = "chkCheckAll";
+            chkCheckAll.Size = new System.Drawing.Size(92, 24);
+            chkCheckAll.TabIndex = 62;
+            chkCheckAll.Text = "Check All";
+            chkCheckAll.UseVisualStyleBackColor = true;
+            chkCheckAll.CheckedChanged += ChkCheckAll_CheckedChanged;
             // 
             // CollectionDatesThresholds
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(458, 503);
-            this.Controls.Add(this.chkCheckAll);
-            this.Controls.Add(this.chkReferences);
-            this.Controls.Add(this.pnlThresholds);
-            this.Controls.Add(this.optInherit);
-            this.Controls.Add(this.OptDisabled);
-            this.Controls.Add(this.bttnCancel);
-            this.Controls.Add(this.bttnUpdate);
-            this.Controls.Add(this.optEnabled);
-            this.Name = "CollectionDatesThresholds";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Collection Dates Thresholds";
-            this.Load += new System.EventHandler(this.CollectionDatesThresholds_Load);
-            ((System.ComponentModel.ISupportInitialize)(this.numWarning)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numCritical)).EndInit();
-            this.pnlThresholds.ResumeLayout(false);
-            this.pnlThresholds.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(614, 647);
+            Controls.Add(chkCheckAll);
+            Controls.Add(chkReferences);
+            Controls.Add(pnlSchedule);
+            Controls.Add(pnlThresholds);
+            Controls.Add(optInherit);
+            Controls.Add(OptDisabled);
+            Controls.Add(bttnCancel);
+            Controls.Add(bttnUpdate);
+            Controls.Add(optExplicit);
+            Controls.Add(optSchedule);
+            Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            Name = "CollectionDatesThresholds";
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Collection Dates Thresholds";
+            Load += CollectionDatesThresholds_Load;
+            ((System.ComponentModel.ISupportInitialize)numWarning).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numCritical).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numWarningMultiplier).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numCriticalMultiplier).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numWarningBuffer).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numCriticalBuffer).EndInit();
+            pnlThresholds.ResumeLayout(false);
+            pnlThresholds.PerformLayout();
+            pnlSchedule.ResumeLayout(false);
+            pnlSchedule.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
 
         }
 
@@ -245,12 +400,24 @@
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.NumericUpDown numWarning;
         private System.Windows.Forms.NumericUpDown numCritical;
+        private System.Windows.Forms.Label labelWarningMultiplier;
+        private System.Windows.Forms.NumericUpDown numWarningMultiplier;
+        private System.Windows.Forms.Label labelWarningMultiplierSuffix;
+        private System.Windows.Forms.Label labelCriticalMultiplier;
+        private System.Windows.Forms.NumericUpDown numCriticalMultiplier;
+        private System.Windows.Forms.Label labelCriticalMultiplierSuffix;
+        private System.Windows.Forms.NumericUpDown numWarningBuffer;
+        private System.Windows.Forms.Label labelWarningBufferSuffix;
+        private System.Windows.Forms.NumericUpDown numCriticalBuffer;
+        private System.Windows.Forms.Label labelCriticalBufferSuffix;
         private System.Windows.Forms.Button bttnCancel;
         private System.Windows.Forms.Button bttnUpdate;
         private System.Windows.Forms.RadioButton optInherit;
         private System.Windows.Forms.RadioButton OptDisabled;
-        private System.Windows.Forms.RadioButton optEnabled;
+        private System.Windows.Forms.RadioButton optExplicit;
+        private System.Windows.Forms.RadioButton optSchedule;
         private System.Windows.Forms.Panel pnlThresholds;
+        private System.Windows.Forms.Panel pnlSchedule;
         private System.Windows.Forms.CheckedListBox chkReferences;
         private System.Windows.Forms.CheckBox chkCheckAll;
     }

--- a/DBADashGUI/CollectionDates/CollectionDatesThresholds.cs
+++ b/DBADashGUI/CollectionDates/CollectionDatesThresholds.cs
@@ -1,4 +1,4 @@
-﻿using DBADashGUI.Theme;
+using DBADashGUI.Theme;
 using Microsoft.Data.SqlClient;
 using System;
 using System.ComponentModel;
@@ -51,31 +51,100 @@ namespace DBADashGUI.CollectionDates
             get => OptDisabled.Checked; set => OptDisabled.Checked = value;
         }
 
+        /// <summary>
+        /// True when thresholds are computed from the collection schedule (interval x multiplier + buffer)
+        /// rather than explicitly configured minute values.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool Scheduled
+        {
+            get => optSchedule.Checked; set => optSchedule.Checked = value;
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public decimal WarningMultiplier
+        {
+            get => numWarningMultiplier.Value; set => numWarningMultiplier.Value = value;
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public decimal CriticalMultiplier
+        {
+            get => numCriticalMultiplier.Value; set => numCriticalMultiplier.Value = value;
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public decimal WarningBufferMinutes
+        {
+            get => numWarningBuffer.Value; set => numWarningBuffer.Value = value;
+        }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public decimal CriticalBufferMinutes
+        {
+            get => numCriticalBuffer.Value; set => numCriticalBuffer.Value = value;
+        }
+
+        // What the inherited (fallback) config actually is, so that when Inherit/Default is checked the
+        // dialog can still show the right read-only panel (the values loaded above are already the
+        // inherited ones) instead of always defaulting to the schedule panel.
+        private bool _inheritedIsExplicit;
+
+        private bool _inheritedIsDisabled;
+
+        // App-shipped defaults, not user-configurable (instance/root level already provides the supported
+        // way to override). Keep these in sync with dbo.CollectionDatesStatus's Auto CROSS APPLY.
+        public const decimal DefaultWarningMultiplier = 2.0m;
+
+        public const decimal DefaultCriticalMultiplier = 4.0m;
+        public const decimal DefaultWarningBufferMinutes = 3.0m;
+        public const decimal DefaultCriticalBufferMinutes = 6.0m;
+
         private void GetThreshold()
         {
+            // Match the documented app-shipped defaults (also used by dbo.CollectionDatesStatus's Auto
+            // CROSS APPLY) so a never-configured reference saves the same values it would otherwise
+            // have gotten automatically, rather than whatever the designer happened to set.
+            WarningMultiplier = DefaultWarningMultiplier;
+            CriticalMultiplier = DefaultCriticalMultiplier;
+            WarningBufferMinutes = DefaultWarningBufferMinutes;
+            CriticalBufferMinutes = DefaultCriticalBufferMinutes;
+
             using var cn = new SqlConnection(Common.ConnectionString);
             using var cmd = new SqlCommand("CollectionDatesThresholds_Get", cn) { CommandType = CommandType.StoredProcedure };
 
             cn.Open();
             cmd.Parameters.AddWithValue("InstanceID", InstanceID);
             using var rdr = cmd.ExecuteReader();
+            var referenceFound = false;
             while (rdr.Read())
             {
                 var reference = Convert.ToString(rdr["Reference"]);
 
                 if (reference == _reference)
                 {
+                    referenceFound = true;
                     chkReferences.Items.Add(reference!, CheckState.Checked);
-                    if (rdr["WarningThreshold"] != DBNull.Value && rdr["CriticalThreshold"] != DBNull.Value)
+                    _inheritedIsExplicit = rdr["WarningThreshold"] != DBNull.Value && rdr["CriticalThreshold"] != DBNull.Value;
+                    _inheritedIsDisabled = Convert.ToBoolean(rdr["Disabled"]);
+                    if (_inheritedIsExplicit)
                     {
                         WarningThreshold = (int)rdr["WarningThreshold"];
                         CriticalThreshold = (int)rdr["CriticalThreshold"];
-                        optEnabled.Checked = true;
+                        optExplicit.Checked = true;
                     }
-                    else
+                    else if (_inheritedIsDisabled)
                     {
                         OptDisabled.Checked = true;
                     }
+                    else
+                    {
+                        optSchedule.Checked = true;
+                    }
+                    WarningMultiplier = rdr["WarningMultiplier"] == DBNull.Value ? DefaultWarningMultiplier : (decimal)rdr["WarningMultiplier"];
+                    CriticalMultiplier = rdr["CriticalMultiplier"] == DBNull.Value ? DefaultCriticalMultiplier : (decimal)rdr["CriticalMultiplier"];
+                    WarningBufferMinutes = rdr["WarningBufferMinutes"] == DBNull.Value ? DefaultWarningBufferMinutes : (decimal)rdr["WarningBufferMinutes"];
+                    CriticalBufferMinutes = rdr["CriticalBufferMinutes"] == DBNull.Value ? DefaultCriticalBufferMinutes : (decimal)rdr["CriticalBufferMinutes"];
                     if (Convert.ToBoolean(rdr["Inherited"]))
                     {
                         optInherit.Checked = true;
@@ -87,7 +156,15 @@ namespace DBADashGUI.CollectionDates
                 }
             }
 
-            optInherit.Enabled = InstanceID > 0;
+            if (!referenceFound && !string.IsNullOrEmpty(_reference))
+            {
+                // No threshold row exists yet for this reference at any level (root or instance) - add it
+                // as a checked entry anyway so it can still be saved. The dialog's defaults (Scheduled,
+                // default multiplier/buffer) apply until the user changes them.
+                chkReferences.Items.Add(_reference, CheckState.Checked);
+            }
+
+            UpdatePanelVisibility();
         }
 
         private void BttnUpdate_Click(object sender, EventArgs e)
@@ -107,17 +184,38 @@ namespace DBADashGUI.CollectionDates
 
                 cmd.Parameters.AddWithValue("InstanceID", InstanceID);
                 cmd.Parameters.AddWithValue("Reference", reference);
-                if (OptDisabled.Checked)
+                cmd.Parameters.AddWithValue("Inherit", Inherit);
+
+                if (Inherit)
                 {
+                    // Remove any override at this level (the stored proc deletes the row when @Inherit = 1).
+                    // Warning/Critical params are still required by the proc signature, so pass NULLs.
                     cmd.Parameters.AddWithValue("WarningThreshold", DBNull.Value);
                     cmd.Parameters.AddWithValue("CriticalThreshold", DBNull.Value);
+                    cmd.Parameters.AddWithValue("WarningMultiplier", DBNull.Value);
+                    cmd.Parameters.AddWithValue("CriticalMultiplier", DBNull.Value);
+                    cmd.Parameters.AddWithValue("WarningBufferMinutes", DBNull.Value);
+                    cmd.Parameters.AddWithValue("CriticalBufferMinutes", DBNull.Value);
+                    cmd.Parameters.AddWithValue("Disabled", false);
                 }
                 else
                 {
-                    cmd.Parameters.AddWithValue("WarningThreshold", WarningThreshold);
-                    cmd.Parameters.AddWithValue("CriticalThreshold", CriticalThreshold);
+                    if (optExplicit.Checked)
+                    {
+                        cmd.Parameters.AddWithValue("WarningThreshold", WarningThreshold);
+                        cmd.Parameters.AddWithValue("CriticalThreshold", CriticalThreshold);
+                    }
+                    else
+                    {
+                        cmd.Parameters.AddWithValue("WarningThreshold", DBNull.Value);
+                        cmd.Parameters.AddWithValue("CriticalThreshold", DBNull.Value);
+                    }
+                    cmd.Parameters.AddWithValue("WarningMultiplier", WarningMultiplier);
+                    cmd.Parameters.AddWithValue("CriticalMultiplier", CriticalMultiplier);
+                    cmd.Parameters.AddWithValue("WarningBufferMinutes", WarningBufferMinutes);
+                    cmd.Parameters.AddWithValue("CriticalBufferMinutes", CriticalBufferMinutes);
+                    cmd.Parameters.AddWithValue("Disabled", Disabled);
                 }
-                cmd.Parameters.AddWithValue("Inherit", Inherit);
                 cmd.ExecuteNonQuery();
                 DialogResult = DialogResult.OK;
             }
@@ -125,31 +223,55 @@ namespace DBADashGUI.CollectionDates
 
         private void CollectionDatesThresholds_Load(object sender, EventArgs e)
         {
-            chkCheckAll.Enabled = InstanceID != -1;
+            chkCheckAll.Enabled = true;
             if (InstanceID == -1)
             {
                 Text += " (Root)";
+                // At root there's no parent level to inherit from - this removes the override entirely,
+                // reverting to the built-in system default (schedule-based, default multiplier/buffer).
+                optInherit.Text = "Default";
             }
             else
             {
                 Text += " (Instance)";
+                optInherit.Text = "Inherit";
             }
             GetThreshold();
         }
 
         private void OptInherit_CheckedChanged(object sender, EventArgs e)
         {
-            pnlThresholds.Enabled = false;
+            UpdatePanelVisibility();
         }
 
         private void OptDisabled_CheckedChanged(object sender, EventArgs e)
         {
-            pnlThresholds.Enabled = false;
+            UpdatePanelVisibility();
         }
 
-        private void OptEnabled_CheckedChanged(object sender, EventArgs e)
+        private void OptExplicit_CheckedChanged(object sender, EventArgs e)
         {
-            pnlThresholds.Enabled = true;
+            UpdatePanelVisibility();
+        }
+
+        private void OptSchedule_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdatePanelVisibility();
+        }
+
+        private void UpdatePanelVisibility()
+        {
+            // While Inherit/Default is checked there's no local mode of its own - show whichever panel
+            // matches what's actually being inherited (already loaded into the fields by GetThreshold),
+            // read-only, so the dialog reflects the effective config rather than always defaulting to
+            // the schedule panel.
+            var showExplicit = optExplicit.Checked || (optInherit.Checked && _inheritedIsExplicit);
+            var showSchedule = optSchedule.Checked || (optInherit.Checked && !_inheritedIsExplicit && !_inheritedIsDisabled);
+
+            pnlThresholds.Visible = showExplicit;
+            pnlThresholds.Enabled = optExplicit.Checked;
+            pnlSchedule.Visible = showSchedule;
+            pnlSchedule.Enabled = optSchedule.Checked;
         }
 
         private void BttnCancel_Click(object sender, EventArgs e)

--- a/DBADashGUI/CollectionDates/CollectionDatesThresholds.resx
+++ b/DBADashGUI/CollectionDates/CollectionDatesThresholds.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/DBADashGUI/DBAChecksStatus.cs
+++ b/DBADashGUI/DBAChecksStatus.cs
@@ -13,7 +13,8 @@ namespace DBADashGUI
             OK = 4,
             Acknowledged = 5,
             WarningLow = 6,
-            Information = 7
+            Information = 7,
+            Disabled = 8
         }
 
         public static Color GetStatusBackColor(DBADashStatusEnum status)
@@ -27,6 +28,7 @@ namespace DBADashGUI
                 DBADashStatusEnum.Acknowledged => DBADashUser.SelectedTheme.AcknowledgedBackColor,
                 DBADashStatusEnum.WarningLow => DBADashUser.SelectedTheme.WarningLowBackColor,
                 DBADashStatusEnum.Information => DBADashUser.SelectedTheme.InformationBackColor,
+                DBADashStatusEnum.Disabled => DBADashUser.SelectedTheme.DisabledBackColor,
                 _ => DashColors.RedPale
             };
         }
@@ -42,6 +44,7 @@ namespace DBADashGUI
                 DBADashStatusEnum.Acknowledged => DBADashUser.SelectedTheme.AcknowledgedForeColor,
                 DBADashStatusEnum.WarningLow => DBADashUser.SelectedTheme.WarningLowForeColor,
                 DBADashStatusEnum.Information => DBADashUser.SelectedTheme.InformationForeColor,
+                DBADashStatusEnum.Disabled => DBADashUser.SelectedTheme.DisabledForeColor,
                 _ => DashColors.RedPale
             };
         }

--- a/DBADashGUI/StatusFilterToolStrip.cs
+++ b/DBADashGUI/StatusFilterToolStrip.cs
@@ -41,8 +41,12 @@ namespace DBADashGUI
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool Acknowledged { get => (MenuAcknowledged.Checked && AcknowledgedVisible) || AllUnchecked; set => MenuAcknowledged.Checked = value; }
 
-        public bool AllChecked => (MenuOK.Checked || !OKVisible) && (MenuWarning.Checked || !WarningVisible) && (MenuCritical.Checked || !CriticalVisible) && (MenuNA.Checked | !NAVisible) && (MenuAcknowledged.Checked || !AcknowledgedVisible);
-        public bool AnyChecked => (MenuOK.Checked && OKVisible) || (MenuWarning.Checked && WarningVisible) || (MenuCritical.Checked && CriticalVisible) || (MenuNA.Checked && NAVisible) || (MenuAcknowledged.Checked && AcknowledgedVisible);
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool Disabled { get => (MenuDisabled.Checked && DisabledVisible) || AllUnchecked; set => MenuDisabled.Checked = value; }
+
+        private IEnumerable<ToolStripMenuItem> StatusMenuItems => DropDownItems.OfType<ToolStripMenuItem>().Where(i => i != MenuCheckAll);
+        public bool AllChecked => StatusMenuItems.All(i => i.Checked || !i.Available);
+        public bool AnyChecked => StatusMenuItems.Any(i => i.Checked && i.Available);
         public bool AllUnchecked => !AnyChecked;
 
         private readonly ToolStripMenuItem MenuOK = new() { Text = "OK", BackColor = DBADashStatus.DBADashStatusEnum.OK.GetBackColor(), ForeColor = DBADashStatus.DBADashStatusEnum.OK.GetBackColor().ContrastColor(), CheckOnClick = true };
@@ -50,10 +54,14 @@ namespace DBADashGUI
         private readonly ToolStripMenuItem MenuCritical = new() { Text = "Critical", BackColor = DBADashStatus.DBADashStatusEnum.Critical.GetBackColor(), ForeColor = DBADashStatus.DBADashStatusEnum.Critical.GetBackColor().ContrastColor(), CheckOnClick = true };
         private readonly ToolStripMenuItem MenuNA = new() { Text = "N/A", BackColor = DBADashStatus.DBADashStatusEnum.NA.GetBackColor(), ForeColor = DBADashStatus.DBADashStatusEnum.NA.GetBackColor().ContrastColor(), CheckOnClick = true };
         private readonly ToolStripMenuItem MenuAcknowledged = new() { Text = "Acknowledged", BackColor = DBADashStatus.DBADashStatusEnum.Acknowledged.GetBackColor(), ForeColor = DBADashStatus.DBADashStatusEnum.Acknowledged.GetBackColor().ContrastColor(), CheckOnClick = true };
+        private readonly ToolStripMenuItem MenuDisabled = new() { Text = "Disabled", BackColor = DBADashStatus.DBADashStatusEnum.Disabled.GetBackColor(), ForeColor = DBADashStatus.DBADashStatusEnum.Disabled.GetBackColor().ContrastColor(), CheckOnClick = true, Available = false };
         private readonly ToolStripMenuItem MenuCheckAll = new() { Text = "Check ALL" };
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool AcknowledgedVisible { get => MenuAcknowledged.Available; set => MenuAcknowledged.Available = value; }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool DisabledVisible { get => MenuDisabled.Available; set => MenuDisabled.Available = value; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool CriticalVisible { get => MenuCritical.Available; set => MenuCritical.Available = value; }
@@ -75,18 +83,16 @@ namespace DBADashGUI
             if (NAVisible) { sqlParams.Add(new SqlParameter() { ParameterName = "IncludeNA", DbType = System.Data.DbType.Boolean, Value = NA }); }
             if (AcknowledgedVisible) { sqlParams.Add(new SqlParameter() { ParameterName = "IncludeACK", DbType = System.Data.DbType.Boolean, Value = Acknowledged }); }
             if (OKVisible) { sqlParams.Add(new SqlParameter() { ParameterName = "IncludeOK", DbType = System.Data.DbType.Boolean, Value = OK }); }
+            if (DisabledVisible) { sqlParams.Add(new SqlParameter() { ParameterName = "IncludeDisabled", DbType = System.Data.DbType.Boolean, Value = Disabled }); }
             return sqlParams.ToArray();
         }
 
         private void CheckAll()
         {
             bool isChecked = !AllChecked;
-            foreach (ToolStripMenuItem itm in DropDownItems.OfType<ToolStripMenuItem>())
+            foreach (var itm in StatusMenuItems)
             {
-                if (itm != MenuCheckAll)
-                {
-                    itm.Checked = isChecked && itm.Available;
-                }
+                itm.Checked = isChecked && itm.Available;
             }
         }
 
@@ -97,15 +103,17 @@ namespace DBADashGUI
             MenuWarning.CheckedChanged += StatusFilterChanged;
             MenuAcknowledged.CheckedChanged += StatusFilterChanged;
             MenuNA.CheckedChanged += StatusFilterChanged;
+            MenuDisabled.CheckedChanged += StatusFilterChanged;
 
             MenuCritical.Click += Status_Click;
             MenuOK.Click += Status_Click;
             MenuWarning.Click += Status_Click;
             MenuAcknowledged.Click += Status_Click;
             MenuNA.Click += Status_Click;
+            MenuDisabled.Click += Status_Click;
 
             MenuCheckAll.Click += MenuCheckAll_Click;
-            DropDownItems.AddRange(new ToolStripItem[] { MenuCritical, MenuWarning, MenuNA, MenuOK, MenuAcknowledged, new ToolStripSeparator(), MenuCheckAll });
+            DropDownItems.AddRange(new ToolStripItem[] { MenuCritical, MenuWarning, MenuNA, MenuOK, MenuAcknowledged, MenuDisabled, new ToolStripSeparator(), MenuCheckAll });
         }
 
         private void Status_Click(object sender, EventArgs e)
@@ -134,7 +142,7 @@ namespace DBADashGUI
             }
             else if (AnyChecked)
             {
-                Text = ((Critical ? ",Critical" : "") + (Warning ? ",Warning" : "") + (OK ? ",OK" : "") + (NA ? ",NA" : "") + (Acknowledged ? ",Acknowledged" : ""))[1..];
+                Text = ((Critical ? ",Critical" : "") + (Warning ? ",Warning" : "") + (OK ? ",OK" : "") + (NA ? ",NA" : "") + (Acknowledged ? ",Acknowledged" : "") + (Disabled ? ",Disabled" : ""))[1..];
                 Font = new Font(Font, FontStyle.Bold);
             }
             foreach (ToolStripMenuItem itm in DropDownItems.OfType<ToolStripMenuItem>())

--- a/DBADashService/WorkItem.cs
+++ b/DBADashService/WorkItem.cs
@@ -62,7 +62,29 @@ namespace DBADashService
 
             var dequeueLatencyMs = EnqueueSW.ElapsedMilliseconds;
             var collectJobs = Types.Contains(CollectionType.Jobs);
-            var types = collectJobs ? Types.Where(t => t != CollectionType.Jobs).ToArray() : Types;
+            var reportSchedule = Types.Contains(CollectionType.ScheduleInfo);
+            var types = (collectJobs || reportSchedule)
+                ? Types.Where(t => t != CollectionType.Jobs && t != CollectionType.ScheduleInfo).ToArray()
+                : Types;
+
+            if (reportSchedule)
+            {
+                // Reported independently of the rest of the collection below - schedule info comes entirely
+                // from the service's own config and never needs to query the instance, so it must not be
+                // blocked by the instance being offline (see ScheduleInfoReporter).
+                try
+                {
+                    var effectiveSchedule = Source.CollectionSchedules is { Count: > 0 }
+                        ? CollectionSchedules.Combine(config.GetSchedules(), Source.CollectionSchedules)
+                        : config.GetSchedules();
+                    var effectiveCustomCollections = Source.CustomCollections.CombineCollections(config.CustomCollections);
+                    await ScheduleInfoReporter.ReportAsync(Source, effectiveSchedule, effectiveCustomCollections, config);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error reporting schedule info for instance {instance}", Source.SourceConnection.ConnectionForPrint);
+                }
+            }
 
             try
             {

--- a/DBADashServiceConfig/ManageCustomCollections.cs
+++ b/DBADashServiceConfig/ManageCustomCollections.cs
@@ -108,7 +108,7 @@ namespace DBADashServiceConfig
 
             try
             {
-                lnkConfigureSchedule.Text = ScheduleConfig.GetScheduleDescription(schedule);
+                lnkConfigureSchedule.Text = CronParser.GetScheduleDescription(schedule, chkRunOnStart.Checked);
             }
             catch
             {
@@ -161,7 +161,7 @@ ORDER BY ProcName", cn);
             dgvCustom.Rows.Clear();
             foreach (var kvp in CustomCollections)
             {
-                dgvCustom.Rows.Add(kvp.Key, kvp.Value.ProcedureName, kvp.Value.Schedule, GetScheduleDescription(kvp.Value.Schedule),
+                dgvCustom.Rows.Add(kvp.Key, kvp.Value.ProcedureName, kvp.Value.Schedule, CronParser.GetScheduleDescriptionSafe(kvp.Value.Schedule, "Invalid Schedule", kvp.Value.RunOnServiceStart),
                     kvp.Value.CommandTimeout, kvp.Value.RunOnServiceStart);
             }
             dgvCustom.ApplyTheme();
@@ -572,10 +572,10 @@ ORDER BY ProcName", cn);
         private void CopyRecord(string name)
         {
             cboProcedureName.Text = CustomCollections[name].ProcedureName;
+            chkRunOnStart.Checked = CustomCollections[name].RunOnServiceStart;
             Schedule = CustomCollections[name].Schedule;
             chkDefaultTimeout.Checked = CustomCollections[name].CommandTimeout == null;
             numTimeout.Value = CustomCollections[name].CommandTimeout == null ? numTimeout.Value : Convert.ToDecimal(CustomCollections[name].CommandTimeout);
-            chkRunOnStart.Checked = CustomCollections[name].RunOnServiceStart;
             txtName.Text = name;
             if (!CustomCollections.TryGetValue(name, out var value)) return;
             KeyValuePair<string, CustomCollection> collection = new(name, value);
@@ -587,30 +587,19 @@ ORDER BY ProcName", cn);
         {
             if (collection.Value == null) return;
             cboProcedureName.Text = collection.Value.ProcedureName;
+            chkRunOnStart.Checked = collection.Value.RunOnServiceStart;
             Schedule = collection.Value.Schedule;
             chkDefaultTimeout.Checked = collection.Value.CommandTimeout == null;
             numTimeout.Value = collection.Value.CommandTimeout == null ? numTimeout.Value : Convert.ToDecimal(collection.Value.CommandTimeout);
-            chkRunOnStart.Checked = collection.Value.RunOnServiceStart;
             txtName.Text = collection.Key;
-        }
-
-        private static string GetScheduleDescription(string schedule)
-        {
-            try
-            {
-                return ScheduleConfig.GetScheduleDescription(schedule);
-            }
-            catch
-            {
-                return string.IsNullOrWhiteSpace(schedule) ? "Disabled" : "Invalid Schedule";
-            }
         }
 
         private void RefreshScheduleDescription(int rowIndex)
         {
             if (rowIndex < 0 || rowIndex >= dgvCustom.Rows.Count) return;
             var row = dgvCustom.Rows[rowIndex];
-            row.Cells["ScheduleDescription"].Value = GetScheduleDescription(Convert.ToString(row.Cells["Schedule"].Value));
+            var runOnServiceStart = Convert.ToBoolean(row.Cells["RunOnServiceStart"].Value);
+            row.Cells["ScheduleDescription"].Value = CronParser.GetScheduleDescriptionSafe(Convert.ToString(row.Cells["Schedule"].Value), "Invalid Schedule", runOnServiceStart);
         }
 
         private void OpenScheduleBuilder(int rowIndex)
@@ -628,7 +617,7 @@ ORDER BY ProcName", cn);
             if (dlg.ShowDialog(this) == DialogResult.OK)
             {
                 row.Cells["Schedule"].Value = dlg.CronExpression ?? string.Empty;
-                row.Cells["ScheduleDescription"].Value = GetScheduleDescription(Convert.ToString(row.Cells["Schedule"].Value));
+                RefreshScheduleDescription(rowIndex);
                 var name = Convert.ToString(row.Cells["Name"].Value);
                 if (!string.IsNullOrWhiteSpace(name) && CustomCollections.ContainsKey(name))
                 {
@@ -670,7 +659,7 @@ ORDER BY ProcName", cn);
             {
                 try
                 {
-                    ScheduleConfig.GetScheduleDescription(schedule);
+                    CronParser.GetScheduleDescription(schedule);
                 }
                 catch
                 {

--- a/DBADashServiceConfig/ScheduleConfig.cs
+++ b/DBADashServiceConfig/ScheduleConfig.cs
@@ -1,8 +1,6 @@
 ﻿using DBADash;
 using DBADashGUI.Theme;
 using DBADashService;
-using Humanizer;
-using Quartz;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -59,15 +57,17 @@ namespace DBADashServiceConfig
             {
                 foreach (var s in userSchedule)
                 {
-                    int idx = dgv.Rows.Add(Enum.GetName(typeof(CollectionType), s.Key), s.Value.Schedule, GetScheduleDescription(s.Value.Schedule), s.Value.RunOnServiceStart, false);
+                    if (s.Key == CollectionType.ScheduleInfo) continue; // Internal bookkeeping type - not user configurable
+                    int idx = dgv.Rows.Add(Enum.GetName(typeof(CollectionType), s.Key), s.Value.Schedule, CronParser.GetScheduleDescription(s.Value.Schedule, s.Value.RunOnServiceStart), s.Value.RunOnServiceStart, false);
                     FormatRow(idx);
                 }
             }
             foreach (var s in BaseSchedule)
             {
+                if (s.Key == CollectionType.ScheduleInfo) continue; // Internal bookkeeping type - not user configurable
                 if (userSchedule == null || !userSchedule.ContainsKey(s.Key))
                 {
-                    int idx = dgv.Rows.Add(Enum.GetName(typeof(CollectionType), s.Key), s.Value.Schedule, GetScheduleDescription(s.Value.Schedule), s.Value.RunOnServiceStart, true);
+                    int idx = dgv.Rows.Add(Enum.GetName(typeof(CollectionType), s.Key), s.Value.Schedule, CronParser.GetScheduleDescription(s.Value.Schedule, s.Value.RunOnServiceStart), s.Value.RunOnServiceStart, true);
                     FormatRow(idx);
                 }
             }
@@ -75,36 +75,14 @@ namespace DBADashServiceConfig
             this.ApplyTheme();
         }
 
-        public static string GetScheduleDescription(string schedule)
-        {
-            if (string.IsNullOrEmpty(schedule))
-            {
-                return "Disabled";
-            }
-            if (int.TryParse(schedule, out int seconds))
-            {
-                return TimeSpan.FromSeconds(seconds).Humanize(5);
-            }
-            else
-            {
-                if (CronExpression.IsValidExpression(schedule)) // Check expression is valid for Quartz
-                {
-                    return CronExpressionDescriptor.ExpressionDescriptor.GetDescription(schedule);
-                }
-                else
-                {
-                    throw new Exception("Invalid cron expression");
-                }
-            }
-        }
-
         private void Dgv_RowValidating(object sender, DataGridViewCellCancelEventArgs e)
         {
             var schedule = (string)dgv[1, e.RowIndex].Value;
+            var runOnServiceStart = Convert.ToBoolean(dgv.Rows[e.RowIndex].Cells["RunOnStart"].Value);
 
             try
             {
-                dgv[2, e.RowIndex].Value = GetScheduleDescription(schedule);
+                dgv[2, e.RowIndex].Value = CronParser.GetScheduleDescription(schedule, runOnServiceStart);
             }
             catch (Exception ex)
             {
@@ -153,7 +131,7 @@ namespace DBADashServiceConfig
                 row.Cells["Schedule"].Value = BaseSchedule[collectType].Schedule;
                 row.Cells["RunOnStart"].Value = BaseSchedule[collectType].RunOnServiceStart;
             }
-            row.Cells["ScheduleDescription"].Value = GetScheduleDescription(Convert.ToString(row.Cells["Schedule"].Value));
+            row.Cells["ScheduleDescription"].Value = CronParser.GetScheduleDescription(Convert.ToString(row.Cells["Schedule"].Value), Convert.ToBoolean(row.Cells["RunOnStart"].Value));
         }
 
  

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -2296,7 +2296,7 @@ namespace DBADashServiceConfig
             {
                 description = string.IsNullOrEmpty(collectionConfig.SummaryRefreshCron)
                     ? string.Empty
-                    : ScheduleConfig.GetScheduleDescription(collectionConfig.SummaryRefreshCron);
+                    : CronParser.GetScheduleDescription(collectionConfig.SummaryRefreshCron);
             }
             catch
             {

--- a/DBADashSharedGUI/Theme/BaseTheme.cs
+++ b/DBADashSharedGUI/Theme/BaseTheme.cs
@@ -49,6 +49,10 @@ namespace DBADashGUI.Theme
         public Color InformationBackColor { get; set; } = DashColors.Information;
         public Color InformationForeColor { get; set; } = DashColors.Information.ContrastColor();
 
+        public Color DisabledBackColor { get; set; } = DashColors.Gray3;
+
+        public Color DisabledForeColor { get; set; } = DashColors.Gray3.ContrastColor();
+
         public Color SearchBackColor { get; set; } = DashColors.GrayLight;
 
         public Color TimeZoneBackColor { get; set; } = DashColors.TrimbleBlue;

--- a/DBADashSharedGUI/Theme/DarkTheme.cs
+++ b/DBADashSharedGUI/Theme/DarkTheme.cs
@@ -20,6 +20,8 @@ namespace DBADashGUI.Theme
             LinkColor = DashColors.BluePale;
             NotApplicableBackColor = DashColors.Gray9;
             NotApplicableForeColor = DashColors.White;
+            DisabledBackColor = DashColors.Gray7;
+            DisabledForeColor = DashColors.White;
             SearchBackColor = DashColors.Gray9;
             TimeZoneBackColor = DashColors.Gray9;
             TimeZoneForeColor = DashColors.White;

--- a/Scripts/CI_Workflow.Tests.ps1
+++ b/Scripts/CI_Workflow.Tests.ps1
@@ -23,7 +23,6 @@ $TableCountGreaterThanZeroTestCases = @(
       @{TableName="dbo.AzureDBElasticPoolStorageThresholds"}
       @{TableName="dbo.BackupThresholds"}
       @{TableName="dbo.CollectionDates"}
-      @{TableName="dbo.CollectionDatesThresholds"}
       @{TableName="dbo.CounterMapping"}
       @{TableName="dbo.Counters"}
       @{TableName="dbo.CPU"}


### PR DESCRIPTION
Send the schedule info from the service to the repository database at service start.  Having the schedule info in the repository DB allows smarter alerting on the collection status based on the collection frequency.  If the collection is disabled, we can automatically mute the alert.  It's also useful to be able to view the schedules in the GUI. #956