### PR TITLE
Fix schema snapshot scheduling in queue-based mode

### DIFF
--- a/DBADash/CollectionSchedule.cs
+++ b/DBADash/CollectionSchedule.cs
@@ -110,7 +110,7 @@ namespace DBADashService
             get
             {
                 return this
-                    .Where(s => s.Key != CollectionType.SchemaSnapshot && !string.IsNullOrEmpty(s.Value.NormalizedSchedule))
+                    .Where(s => !string.IsNullOrEmpty(s.Value.NormalizedSchedule))
                     .GroupBy(s => s.Value.NormalizedSchedule)
                     .ToDictionary(g => g.Key, g => g.Select(s => s.Key).ToArray());
             }

--- a/DBADashService/ScheduledCollectionJob.cs
+++ b/DBADashService/ScheduledCollectionJob.cs
@@ -135,11 +135,15 @@ namespace DBADashService
 
             var typesSet = new HashSet<CollectionType>(collectionTypes);
             var hasSnapshot = typesSet.Contains(CollectionType.SchemaSnapshot);
+            // SchemaSnapshot is never collected as part of a normal WorkItem - it has its own work item.
             var typesWithoutSnapshot = hasSnapshot
                 ? collectionTypes.Where(c => c != CollectionType.SchemaSnapshot).ToArray()
                 : collectionTypes;
 
-            if (hasSnapshot)
+            // Only enqueue a schema snapshot when this instance actually has snapshot DBs configured.
+            // The schedule's type set is shared across all instances in the group, so hasSnapshot alone
+            // isn't enough - without this guard every instance on the schedule would attempt a snapshot.
+            if (hasSnapshot && source.SchemaSnapshotDBs is { Length: > 0 })
             {
                 var snapshotWorkItem = new SchemaSnapshotWorkItem
                 {
@@ -149,10 +153,12 @@ namespace DBADashService
 
                 enqueueTasks.Add(_workQueue.EnqueueAsync(snapshotWorkItem, context.CancellationToken));
                 enqueueCount++;
-                if (typesWithoutSnapshot.Length == 0 && customCollections.Count == 0)
-                {
-                    return enqueueCount;
-                }
+            }
+
+            if (typesWithoutSnapshot.Length == 0 && customCollections.Count == 0)
+            {
+                // Nothing left to collect (e.g. a snapshot-only schedule) - avoid enqueuing an empty work item.
+                return enqueueCount;
             }
 
             var workItem = new WorkItem

--- a/DBADashService/SchedulerService.cs
+++ b/DBADashService/SchedulerService.cs
@@ -580,12 +580,19 @@ namespace DBADashService
                         foreach (var s in groupedSchedule)
                         {
                             if (string.IsNullOrEmpty(s.Key)) continue; /* Collection is disabled */
-                            var collections = RemoveNotApplicableCollections(s.Value);
-
+                            // SchemaSnapshot is handled separately below, not as a regular collection job
+                            var collections = RemoveNotApplicableCollections(s.Value)
+                                .Where(c => c != CollectionType.SchemaSnapshot)
+                                .ToArray();
                             var custom = customCollections
                                 .Where(c => c.Value.NormalizedSchedule == s.Key)
                                 .ToDictionary(c => c.Key, c => c.Value);
-                            var job = GetJob(collections.ToArray(), src, cfgString, custom, s.Key);
+                            if (collections.Length == 0 && custom.Count == 0)
+                            {
+                                continue; // No collections to schedule for this time slot
+                            }
+
+                            var job = GetJob(collections, src, cfgString, custom, s.Key);
                             Log.Information("Add schedule for {source} to collect {collection},{custom} on schedule {schedule}", src.SourceConnection.ConnectionForPrint, collections, custom.Keys, s.Key);
                             ScheduleJob(s.Key, job);
                         }


### PR DESCRIPTION
SchemaSnapshot was explicitly excluded from GroupedBySchedule, preventing it from reaching ScheduledCollectionJob in queue-based mode. The job already has code to handle schema snapshots (if (hasSnapshot) check), but it was never receiving them.

Changes:
- Include SchemaSnapshot in GroupedBySchedule by removing the exclusion filter
- In traditional mode (ScheduleSourceAsync), skip SchemaSnapshot in the regular loop and let the dedicated SchemaSnapshotJob code handle it