### PR TITLE
Workflow fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,16 +136,13 @@ jobs:
           ./Scripts/Get-LogContent -LogPath  "C:\DBADashTest\Logs" -ThrowError
 
       - name: Run Pester Tests
-        shell: powershell
-        run: |     
-          try { $null = Get-PSRepository -Name PSGallery -ErrorAction Stop } catch {
-            Register-PSRepository -Default -ErrorAction SilentlyContinue
-            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
-              Register-PSRepository -Name PSGallery -SourceLocation https://www.powershellgallery.com/api/v2 -InstallationPolicy Trusted
-            }
+        shell: pwsh
+        run: |
+          # pwsh ships Pester 5.x preinstalled; only install if it is missing
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
           }
-          Install-Module Pester -Force -SkipPublisherCheck
-          Import-Module Pester -PassThru
+          Import-Module Pester -MinimumVersion 5.0.0
           Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
 
       - name: Output Table Counts Following Delete

--- a/.github/workflows/ci_BucketDestination.yml
+++ b/.github/workflows/ci_BucketDestination.yml
@@ -305,22 +305,24 @@ jobs:
           ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromBucket\Logs" -ThrowError
 
       - name: Run Pester Tests FromBucket
-        shell: powershell
-        run: |     
-          try { $null = Get-PSRepository -Name PSGallery -ErrorAction Stop } catch {
-            Register-PSRepository -Default -ErrorAction SilentlyContinue
-            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
-              Register-PSRepository -Name PSGallery -SourceLocation https://www.powershellgallery.com/api/v2 -InstallationPolicy Trusted
-            }
+        shell: pwsh
+        run: |
+          # pwsh ships Pester 5.x preinstalled; only install if it is missing
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
           }
-          Install-Module Pester -Force -SkipPublisherCheck
-          Import-Module Pester -PassThru
+          Import-Module Pester -MinimumVersion 5.0.0
           $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_FromBucket" }
           Invoke-Pester -Container $container -Output Detailed
 
       - name: Run Pester Tests Direct
-        shell: powershell
-        run: |     
-            $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
-            Invoke-Pester -Container $container -Output Detailed
+        shell: pwsh
+        run: |
+          # pwsh ships Pester 5.x preinstalled; only install if it is missing
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
+          }
+          Import-Module Pester -MinimumVersion 5.0.0
+          $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
+          Invoke-Pester -Container $container -Output Detailed
     

--- a/.github/workflows/ci_FolderDestination.yml
+++ b/.github/workflows/ci_FolderDestination.yml
@@ -201,22 +201,24 @@ jobs:
           ./Scripts/Get-LogContent -LogPath  "C:\DBADashReadFromFolder\Logs" -ThrowError
 
       - name: Run Pester Tests FromFolder
-        shell: powershell
-        run: |     
-          try { $null = Get-PSRepository -Name PSGallery -ErrorAction Stop } catch {
-            Register-PSRepository -Default -ErrorAction SilentlyContinue
-            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
-              Register-PSRepository -Name PSGallery -SourceLocation https://www.powershellgallery.com/api/v2 -InstallationPolicy Trusted
-            }
+        shell: pwsh
+        run: |
+          # pwsh ships Pester 5.x preinstalled; only install if it is missing
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
           }
-          Install-Module Pester -Force -SkipPublisherCheck
-          Import-Module Pester -PassThru
+          Import-Module Pester -MinimumVersion 5.0.0
           $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_FromFolder" }
           Invoke-Pester -Container $container -Output Detailed
 
       - name: Run Pester Tests Direct
-        shell: powershell
-        run: |     
-            $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
-            Invoke-Pester -Container $container -Output Detailed
+        shell: pwsh
+        run: |
+          # pwsh ships Pester 5.x preinstalled; only install if it is missing
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
+          }
+          Import-Module Pester -MinimumVersion 5.0.0
+          $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Database = "DBADashDB_Direct" }
+          Invoke-Pester -Container $container -Output Detailed
       

--- a/.github/workflows/ci_MinimalPermissions.yml
+++ b/.github/workflows/ci_MinimalPermissions.yml
@@ -152,15 +152,12 @@ jobs:
           ./Scripts/Get-LogContent -LogPath  "C:\DBADashTest\Logs" -ThrowError
 
       - name: Run Pester Tests
-        shell: powershell
-        run: |     
-          try { $null = Get-PSRepository -Name PSGallery -ErrorAction Stop } catch {
-            Register-PSRepository -Default -ErrorAction SilentlyContinue
-            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
-              Register-PSRepository -Name PSGallery -SourceLocation https://www.powershellgallery.com/api/v2 -InstallationPolicy Trusted
-            }
+        shell: pwsh
+        run: |
+          # pwsh ships Pester 5.x preinstalled; only install if it is missing
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
           }
-          Install-Module Pester -Force -SkipPublisherCheck
-          Import-Module Pester -PassThru
+          Import-Module Pester -MinimumVersion 5.0.0
           $NoWMI=$true
           Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1


### PR DESCRIPTION
Fix intermittent CI failures caused by corrupted PSGallery repository metadata under Windows PowerShell 5.1.

The Pester test steps previously ran under `shell: powershell` (Windows PowerShell 5.1) and installed Pester from the PSGallery on every run. Windows PowerShell 5.1's PowerShellGet repository store intermittently becomes corrupt (`Value cannot be null. Parameter name: source`), which breaks `Install-Module` and fails the job. The earlier repair attempt did not work because its fallback tried to register a repository named `PSGallery` with a custom source, which is invalid (that name is reserved for `Register-PSRepository -Default`).

The Pester steps now run under `shell: pwsh` (PowerShell 7), which uses a separate PowerShellGet store (immune to the 5.1 corruption) and ships Pester 5.x preinstalled, so the PSGallery install path is skipped in the normal case. A conditional install remains only as a fallback.

Scope: only the Pester test steps were moved to PowerShell 7. The remaining steps intentionally stay on Windows PowerShell 5.1 as they do not hit the PSGallery issue.