### PR TITLE
CollectionDatesThresholds fix

### DIFF
--- a/DBADashDB/Script.PostDeployment1.sql
+++ b/DBADashDB/Script.PostDeployment1.sql
@@ -1485,6 +1485,33 @@ BEGIN
 	INSERT INTO dbo.Settings(SettingName,SettingValue) VALUES('CollectionDatesLegacyThresholdsMigrated',1)
 END
 
+-- Separate gate from CollectionDatesLegacyThresholdsMigrated above (even though both are one-time
+-- threshold migrations) - a beta user may have already deployed a build that ran that gate before this
+-- Disabled backfill existed, which would leave their flag already set and this logic permanently skipped
+-- if it were folded into the same gate.
+--
+-- Before the Disabled column existed, WarningThreshold=NULL AND CriticalThreshold=NULL was the ONLY way
+-- to represent "monitoring disabled" for a reference - there was no separate flag, and the
+-- multiplier/buffer columns (which now distinguish that from Schedule Based) didn't exist either.
+-- Without this, every pre-existing "disabled" row would silently pick up Disabled's new default of 0 and
+-- re-enable alerting on upgrade.  Require the multiplier/buffer columns to be NULL too - a real legacy row
+-- will always have them NULL (they didn't exist yet), whereas the current GUI always writes non-null
+-- values for Schedule Based, so this can't misfire on a row saved by current code.
+IF NOT EXISTS(SELECT 1 FROM dbo.Settings WHERE SettingName = 'CollectionDatesThresholdsDisabledFlagMigrated')
+BEGIN
+	UPDATE dbo.CollectionDatesThresholds
+	SET Disabled = 1
+	WHERE WarningThreshold IS NULL
+	AND CriticalThreshold IS NULL
+	AND WarningMultiplier IS NULL
+	AND CriticalMultiplier IS NULL
+	AND WarningBufferMinutes IS NULL
+	AND CriticalBufferMinutes IS NULL
+	AND Disabled = 0
+
+	INSERT INTO dbo.Settings(SettingName,SettingValue) VALUES('CollectionDatesThresholdsDisabledFlagMigrated',1)
+END
+
 -- SchemaSnapshot's "last collected" date is not a reliable staleness signal even when it's configured and
 -- running - a configured DB pattern (e.g. "*") can still match zero databases at runtime. Disable alerting
 -- for it by default at root level; an admin can still re-enable/configure it explicitly per instance or

--- a/DBADashDB/dbo/Stored Procedures/CollectionDatesThresholds_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/CollectionDatesThresholds_Upd.sql
@@ -11,13 +11,54 @@ CREATE PROC CollectionDatesThresholds_Upd(
 	@Disabled BIT=0
 )
 AS
+-- Validate/normalize @WarningThreshold etc before touching the table at all - if this throws, the
+-- existing row (if any) must still be intact rather than having already been deleted below.
+IF @Inherit = 0
+BEGIN
+	IF @Disabled = 1
+	BEGIN
+		-- Disabled always means every threshold/multiplier/buffer column is NULL, regardless of whatever
+		-- else was passed in - normalize here so the row can never disagree with its own Disabled flag.
+		SET @WarningThreshold = NULL;
+		SET @CriticalThreshold = NULL;
+		SET @WarningMultiplier = NULL;
+		SET @CriticalMultiplier = NULL;
+		SET @WarningBufferMinutes = NULL;
+		SET @CriticalBufferMinutes = NULL;
+	END
+	ELSE IF @WarningThreshold IS NOT NULL OR @CriticalThreshold IS NOT NULL
+	BEGIN
+		-- Explicit: both thresholds are required together, and the multiplier/buffer columns (which only
+		-- apply to Schedule Based) are cleared so a stale value can't linger from a previous save.
+		IF @WarningThreshold IS NULL OR @CriticalThreshold IS NULL
+		BEGIN;
+			THROW 51000, 'Explicit thresholds require both @WarningThreshold and @CriticalThreshold to be set', 1;
+		END
+		SET @WarningMultiplier = NULL;
+		SET @CriticalMultiplier = NULL;
+		SET @WarningBufferMinutes = NULL;
+		SET @CriticalBufferMinutes = NULL;
+	END
+	ELSE
+	BEGIN
+		-- Schedule Based: the caller must supply all four - this proc deliberately doesn't fall back to
+		-- its own copy of the app-shipped defaults (those already live in DBADashGUI.CollectionDates.
+		-- CollectionDatesThresholds' Default* constants and dbo.CollectionDatesStatus's Auto CROSS APPLY;
+		-- a third copy here would be one more place for them to drift out of sync).
+		IF @WarningMultiplier IS NULL OR @CriticalMultiplier IS NULL OR @WarningBufferMinutes IS NULL OR @CriticalBufferMinutes IS NULL
+		BEGIN;
+			THROW 51001, 'Schedule Based thresholds require @WarningMultiplier, @CriticalMultiplier, @WarningBufferMinutes and @CriticalBufferMinutes to all be set', 1;
+		END
+	END;
+END
+
 -- @Inherit=1 means "no override at this level, defer to the next one down" (instance -> root ->
 -- built-in system default) - just remove the row rather than storing a marker. The Inherited/
 -- ConfiguredLevel logic in CollectionDatesThresholds_Get.sql and dbo.CollectionDatesStatus already
 -- derives that state correctly from the row's absence.
 DELETE dbo.CollectionDatesThresholds
 WHERE Reference = @Reference
-AND InstanceID = @InstanceID
+AND InstanceID = @InstanceID;
 
 IF @Inherit = 0
 BEGIN
@@ -43,5 +84,5 @@ BEGIN
 		@WarningBufferMinutes,
 		@CriticalBufferMinutes,
 		@Disabled
-		)
+		);
 END


### PR DESCRIPTION
If the thresholds are all NULL, this previously meant the threshold is disabled.  There is now a Disabled flag.  The NULL values now cause the disabled thresholds to use the default.  Add a 1 time migration, plus checks to threshold update proc.