### PR TITLE
RunningQueriesCursors trigger collection fix

### DIFF
--- a/DBADashGUI/CollectionDates/CollectionDates.cs
+++ b/DBADashGUI/CollectionDates/CollectionDates.cs
@@ -59,7 +59,7 @@ namespace DBADashGUI.CollectionDates
             get => statusFilterToolStrip1.Disabled; set => statusFilterToolStrip1.Disabled = value;
         }
 
-        private static readonly string[] NoTriggerCollectionTypes = new[] { "QueryPlans", "QueryText", "SlowQueriesStats", "InternalPerformanceCounters", "SessionWaits" };
+        private static readonly string[] NoTriggerCollectionTypes = new[] { "QueryPlans", "QueryText", "SlowQueriesStats", "InternalPerformanceCounters", "SessionWaits", "RunningQueriesCursors" };
 
         private DataTable GetCollectionDates()
         {


### PR DESCRIPTION
Fix issue triggering this collection type - It's part of the RunningQueries collection and can't be triggered by itself. #1987