### PR TITLE
Rename DriversWMI collection type to Drivers

### DIFF
--- a/DBADash.Test/CollectionSchedulesSerializationTests.cs
+++ b/DBADash.Test/CollectionSchedulesSerializationTests.cs
@@ -1,0 +1,52 @@
+using DBADashService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace DBADash.Test
+{
+    [TestClass]
+    public class CollectionSchedulesSerializationTests
+    {
+        [TestMethod]
+        public void Drivers_CustomSchedule_RoundTrips()
+        {
+            var schedules = new CollectionSchedules
+            {
+                [CollectionType.Drivers] = new CollectionSchedule { Schedule = "0 0 22 * * ?", RunOnServiceStart = false }
+            };
+
+            var json = JsonConvert.SerializeObject(schedules);
+            // Persisted using the current member name, not the collection method.
+            StringAssert.Contains(json, "\"Drivers\"");
+
+            var restored = JsonConvert.DeserializeObject<CollectionSchedules>(json)!;
+            Assert.IsTrue(restored.ContainsKey(CollectionType.Drivers));
+            Assert.AreEqual("0 0 22 * * ?", restored[CollectionType.Drivers].Schedule);
+            Assert.IsFalse(restored[CollectionType.Drivers].RunOnServiceStart);
+        }
+
+        [TestMethod]
+        public void LegacyDriversWMI_Key_MapsToDrivers()
+        {
+            // A config saved before the DriversWMI -> Drivers rename.
+            const string legacyJson = "{\"DriversWMI\":{\"Schedule\":\"0 0 22 * * ?\",\"RunOnServiceStart\":false}}";
+
+            var restored = JsonConvert.DeserializeObject<CollectionSchedules>(legacyJson)!;
+
+            Assert.IsTrue(restored.ContainsKey(CollectionType.Drivers), "Legacy DriversWMI schedule should map to Drivers");
+            Assert.AreEqual("0 0 22 * * ?", restored[CollectionType.Drivers].Schedule);
+        }
+
+        [TestMethod]
+        public void UnknownCollectionType_IsSkipped_NotThrown()
+        {
+            // A removed/renamed collection type must not fail the whole config load.
+            const string json = "{\"SomeRemovedType\":{\"Schedule\":\"0 0 22 * * ?\"},\"CPU\":{\"Schedule\":\"0 0/1 * * * ?\"}}";
+
+            var restored = JsonConvert.DeserializeObject<CollectionSchedules>(json)!;
+
+            Assert.AreEqual(1, restored.Count);
+            Assert.IsTrue(restored.ContainsKey(CollectionType.CPU));
+        }
+    }
+}

--- a/DBADash.Test/CommandTimeoutLegacyNameTests.cs
+++ b/DBADash.Test/CommandTimeoutLegacyNameTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace DBADash.Test
+{
+    [TestClass]
+    public class CommandTimeoutLegacyNameTests
+    {
+        [TestMethod]
+        public void LegacyDriversWMI_Timeout_IsPreserved()
+        {
+            // A commandTimeouts.json saved before the DriversWMI -> Drivers rename.
+            const string legacyJson = "{\"CollectionCommandTimeouts\":{\"DriversWMI\":300}}";
+
+            var remapped = CollectionCommandTimeout.RemapLegacyNames(legacyJson);
+            var settings = JsonConvert.DeserializeObject<CollectionCommandTimeout.CommandTimeoutSettingsBase>(remapped)!;
+
+            Assert.IsTrue(settings.CollectionCommandTimeouts.TryGetValue(CollectionType.Drivers, out var timeout),
+                "Legacy DriversWMI timeout should be preserved under Drivers");
+            Assert.AreEqual(300, timeout);
+        }
+
+        [TestMethod]
+        public void CurrentDriversTimeout_StillLoads()
+        {
+            const string json = "{\"CollectionCommandTimeouts\":{\"Drivers\":300}}";
+
+            var remapped = CollectionCommandTimeout.RemapLegacyNames(json);
+            var settings = JsonConvert.DeserializeObject<CollectionCommandTimeout.CommandTimeoutSettingsBase>(remapped)!;
+
+            Assert.AreEqual(300, settings.CollectionCommandTimeouts[CollectionType.Drivers]);
+        }
+
+        [TestMethod]
+        public void TryParse_HandlesLegacyAndCurrentNames()
+        {
+            Assert.IsTrue(CollectionTypeLegacyNames.TryParse("DriversWMI", out var legacy));
+            Assert.AreEqual(CollectionType.Drivers, legacy);
+
+            Assert.IsTrue(CollectionTypeLegacyNames.TryParse("Drivers", out var current));
+            Assert.AreEqual(CollectionType.Drivers, current);
+
+            Assert.IsFalse(CollectionTypeLegacyNames.TryParse("NotACollectionType", out _));
+        }
+    }
+}

--- a/DBADash/CollectionCommandTimeout.cs
+++ b/DBADash/CollectionCommandTimeout.cs
@@ -4,6 +4,7 @@ using System;
 using System.Data;
 using Serilog;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DBADash
 {
@@ -44,7 +45,7 @@ namespace DBADash
 
             try
             {
-                var json = File.ReadAllText(FilePath);
+                var json = RemapLegacyNames(File.ReadAllText(FilePath));
 
                 Settings = JsonConvert.DeserializeObject<CommandTimeoutSettings>(json, serializationOpts);
 
@@ -64,8 +65,34 @@ namespace DBADash
             {
                 return new CommandTimeoutSettingsBase();
             }
-            var json = File.ReadAllText(FilePath);
+            var json = RemapLegacyNames(File.ReadAllText(FilePath));
             return JsonConvert.DeserializeObject<CommandTimeoutSettingsBase>(json, serializationOpts);
+        }
+
+        /// <summary>
+        /// Rewrite any renamed CollectionType keys (e.g. the legacy "DriversWMI" -> Drivers) in the
+        /// CollectionCommandTimeouts object so a timeout customized before the rename is preserved rather
+        /// than dropped as an unknown collection type.  Returns the original text if it can't be parsed;
+        /// callers handle malformed JSON as before.
+        /// </summary>
+        internal static string RemapLegacyNames(string json)
+        {
+            JObject root;
+            try
+            {
+                root = JObject.Parse(json);
+            }
+            catch (JsonException ex)
+            {
+                // Leave malformed JSON untouched so callers handle (and log) the error as before.
+                Log.Debug(ex, "Skipping legacy collection type remap - {FilePath} is not valid JSON", FilePath);
+                return json;
+            }
+            if (root["CollectionCommandTimeouts"] is JObject timeouts)
+            {
+                CollectionTypeLegacyNames.RemapLegacyKeys(timeouts);
+            }
+            return root.ToString();
         }
 
         private static string FilePath => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "commandTimeouts.json");
@@ -113,7 +140,7 @@ namespace DBADash
                 { CollectionType.ServerRoleMembers, 300 },
                 { CollectionType.ServerPermissions, 300 },
                 { CollectionType.VLF, 300 },
-                { CollectionType.DriversWMI, 300 },
+                { CollectionType.Drivers, 300 },
                 { CollectionType.OSLoadedModules, 300 },
                 { CollectionType.ResourceGovernorConfiguration, 300 },
                 { CollectionType.DatabaseQueryStoreOptions, 300 },

--- a/DBADash/CollectionSchedule.cs
+++ b/DBADash/CollectionSchedule.cs
@@ -1,9 +1,14 @@
 ﻿using DBADash;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace DBADashService
 {
+    [JsonConverter(typeof(CollectionSchedulesJsonConverter))]
     public class CollectionSchedules : Dictionary<CollectionType, CollectionSchedule>
     {
         private const string every1min = "0 0/1 * * * ?";
@@ -61,7 +66,7 @@ namespace DBADashService
                             {CollectionType.DatabaseRoleMembers, new CollectionSchedule(){ Schedule = midnight } },
                             {CollectionType.DatabasePermissions, new CollectionSchedule(){ Schedule = midnight } },
                             {CollectionType.VLF, new CollectionSchedule(){ Schedule = midnight } },
-                            {CollectionType.DriversWMI, new CollectionSchedule(){ Schedule = midnight } },
+                            {CollectionType.Drivers, new CollectionSchedule(){ Schedule = midnight } },
                             {CollectionType.OSLoadedModules, new CollectionSchedule(){ Schedule = midnight } },
                             {CollectionType.ResourceGovernorConfiguration, new CollectionSchedule(){ Schedule = midnight } },
                             {CollectionType.DatabaseQueryStoreOptions, new CollectionSchedule(){ Schedule = midnight } },
@@ -145,5 +150,44 @@ namespace DBADashService
 
         private static readonly CollectionSchedule importSchedule = new() { Schedule = "10" };
         public static readonly CollectionSchedule DefaultImportSchedule = importSchedule;
+    }
+
+    /// <summary>
+    /// Serializes <see cref="CollectionSchedules"/> as a { "CollectionType": schedule } object, writing the
+    /// current enum name for each key.  On read it maps legacy names to their current member (e.g. the
+    /// renamed "DriversWMI" -> <see cref="CollectionType.Drivers"/>) so custom schedules saved before the
+    /// rename still load, and quietly skips keys for collection types that no longer exist rather than
+    /// failing the whole config load.
+    /// </summary>
+    public class CollectionSchedulesJsonConverter : JsonConverter<CollectionSchedules>
+    {
+        public override void WriteJson(JsonWriter writer, CollectionSchedules value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            foreach (var kvp in value)
+            {
+                writer.WritePropertyName(kvp.Key.ToString());
+                serializer.Serialize(writer, kvp.Value);
+            }
+            writer.WriteEndObject();
+        }
+
+        public override CollectionSchedules ReadJson(JsonReader reader, Type objectType, CollectionSchedules existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null) return null;
+
+            var result = existingValue ?? new CollectionSchedules();
+            var jObject = JObject.Load(reader);
+            foreach (var property in jObject.Properties())
+            {
+                if (!CollectionTypeLegacyNames.TryParse(property.Name, out var type))
+                {
+                    Log.Warning("Ignoring unknown collection type '{type}' in custom schedule", property.Name);
+                    continue;
+                }
+                result[type] = property.Value.ToObject<CollectionSchedule>(serializer);
+            }
+            return result;
+        }
     }
 }

--- a/DBADash/CollectionTypeLegacyNames.cs
+++ b/DBADash/CollectionTypeLegacyNames.cs
@@ -1,0 +1,52 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace DBADash
+{
+    /// <summary>
+    /// Maps <see cref="CollectionType"/> member names that have been renamed to their current member, so
+    /// configuration saved before a rename (custom schedules, command timeouts) still loads and keeps any
+    /// customization instead of silently reverting to defaults.
+    /// </summary>
+    public static class CollectionTypeLegacyNames
+    {
+        private static readonly Dictionary<string, CollectionType> Map = new(StringComparer.OrdinalIgnoreCase)
+        {
+            // "DriversWMI" was renamed to Drivers - the name now reflects the data collected rather than the
+            // collection method (WMI), so it survives a future change of method.
+            { "DriversWMI", CollectionType.Drivers }
+        };
+
+        /// <summary>
+        /// Parse a CollectionType name, honoring legacy renames.  Returns false for names that match neither
+        /// a current member nor a known legacy name.
+        /// </summary>
+        public static bool TryParse(string name, out CollectionType type)
+        {
+            return Map.TryGetValue(name, out type) || Enum.TryParse(name, ignoreCase: true, out type);
+        }
+
+        /// <summary>
+        /// Rewrite any legacy CollectionType names used as property keys in <paramref name="obj"/> to their
+        /// current names so it can be deserialized after a member rename.  If a property already exists under
+        /// the current name it wins and the legacy one is dropped.
+        /// </summary>
+        public static void RemapLegacyKeys(JObject obj)
+        {
+            if (obj == null) return;
+            foreach (var (legacyName, currentType) in Map)
+            {
+                var legacyProperty = obj.Property(legacyName, StringComparison.OrdinalIgnoreCase);
+                if (legacyProperty == null) continue;
+
+                var currentName = currentType.ToString();
+                if (obj.Property(currentName, StringComparison.OrdinalIgnoreCase) == null)
+                {
+                    obj.Add(currentName, legacyProperty.Value);
+                }
+                legacyProperty.Remove();
+            }
+        }
+    }
+}

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -35,7 +35,7 @@ namespace DBADash
         Corruption,
         OSInfo,
         TraceFlags,
-        DriversWMI,
+        Drivers,
         CPU,
         BlockingSnapshot,
         IOStats,
@@ -1027,7 +1027,7 @@ OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid
             {
                 await CollectServerExtraPropertiesAsync();
             }
-            else if (collectionType == CollectionType.DriversWMI)
+            else if (collectionType == CollectionType.Drivers)
             {
                 CollectDriversWMI();
             }

--- a/DBADash/Messaging/CollectionMessage.cs
+++ b/DBADash/Messaging/CollectionMessage.cs
@@ -186,11 +186,7 @@ namespace DBADash.Messaging
                     throw new ArgumentException("Collection type cannot be null");
                 }
                 var customCollectionName = type.StartsWith("UserData.", StringComparison.OrdinalIgnoreCase) ? type["UserData.".Length..] : type;
-                if (string.Equals(type, "Drivers", StringComparison.OrdinalIgnoreCase))
-                {
-                    standardCollections.Add(CollectionType.DriversWMI);
-                }
-                else if (string.Equals(type, "QueryPlans", StringComparison.OrdinalIgnoreCase) || string.Equals(type, "QueryText", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(type, "QueryPlans", StringComparison.OrdinalIgnoreCase) || string.Equals(type, "QueryText", StringComparison.OrdinalIgnoreCase))
                 {
                     throw new ArgumentException("QueryPlan and QueryText are collected as part of the RunningQueries collection");
                 }
@@ -202,8 +198,9 @@ namespace DBADash.Messaging
                 {
                     throw new ArgumentException("InternalPerformanceCounters collection can't be triggered manually");
                 }
-                else if (Enum.TryParse<CollectionType>(type, out var collectionType))
+                else if (CollectionTypeLegacyNames.TryParse(type, out var collectionType))
                 {
+                    // Honors legacy renames (e.g. "DriversWMI" -> Drivers) via the central map.
                     standardCollections.Add(collectionType);
                 }
                 else if (src.CustomCollections.TryGetValue(customCollectionName, out var customCollection))

--- a/DBADash/commandTimeouts.json.example
+++ b/DBADash/commandTimeouts.json.example
@@ -30,7 +30,7 @@
     "ServerRoleMembers": 300,
     "ServerPermissions": 300,
     "VLF": 300,
-    "DriversWMI": 300,
+    "Drivers": 300,
     "OSLoadedModules": 300,
     "ResourceGovernorConfiguration": 300,
     "DatabaseQueryStoreOptions": 300,


### PR DESCRIPTION
The Drivers collection logged its collection date as 'Drivers' but its enum value was DriversWMI, so the reported schedule reference didn't match and the schedule info was missing from the  collectionDates tab. Drivers is the better name — it reflects the data collected rather than the method (WMI) — so rename the enum. Keep backward compatibility so custom schedules saved as 'DriversWMI' still load.