### PR TITLE
Fix AI Assistant tab failing to load in local mode

### DIFF
--- a/DBADash/RepositoryFingerprint.cs
+++ b/DBADash/RepositoryFingerprint.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using Microsoft.Data.SqlClient;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DBADash
+{
+    /// <summary>
+    /// Produces a stable fingerprint identifying the repository database a component is
+    /// connected to. Used by the AI service and GUI to verify they are pointed at the
+    /// same repository.
+    ///
+    /// The identity is obtained by asking SQL Server for its own canonical server and
+    /// database name (SERVERPROPERTY('ServerName') and DB_NAME()) rather than parsing the
+    /// connection string, so that server-name aliases (localhost vs machine name, FQDN,
+    /// IP, alias, or named port) don't produce false mismatches.
+    /// </summary>
+    public static class RepositoryFingerprint
+    {
+        /// <summary>
+        /// Queries SQL Server for its canonical identity ("server|database", lower-cased)
+        /// using a short timeout. Throws if the repository can't be reached - callers rely
+        /// on the repository being available and should surface the failure rather than
+        /// guessing an identity from the connection string.
+        /// </summary>
+        public static string GetRepositoryIdentity(string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentException("Connection string is required.", nameof(connectionString));
+
+            var builder = new SqlConnectionStringBuilder(connectionString) { ConnectTimeout = 5 };
+            using var conn = new SqlConnection(builder.ConnectionString);
+            conn.Open();
+            using var cmd = new SqlCommand(
+                "SELECT CONVERT(nvarchar(256), SERVERPROPERTY('ServerName')) + N'|' + DB_NAME()", conn)
+            { CommandTimeout = 5 };
+            var result = cmd.ExecuteScalar() as string;
+            if (string.IsNullOrWhiteSpace(result))
+                throw new InvalidOperationException("Could not determine repository identity from SQL Server.");
+            return result.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Computes a SHA-256 fingerprint of the repository identity. Returns null if the
+        /// connection string is blank or the repository can't be queried.
+        /// </summary>
+        public static string? GetFingerprint(string? connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                return null;
+            try
+            {
+                var identity = GetRepositoryIdentity(connectionString);
+                var hash = SHA256.HashData(Encoding.UTF8.GetBytes(identity));
+                return Convert.ToHexString(hash);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/DBADashAI/Program.cs
+++ b/DBADashAI/Program.cs
@@ -263,11 +263,23 @@ RouteHandlerBuilder ApplyAuthAndRateLimit(RouteHandlerBuilder builder) =>
 // Unauthenticated health check endpoint - safe for monitoring/load balancers
 // Returns basic status plus a repository fingerprint (SHA-256 of server|database)
 // so GUI clients can verify the AI service is pointed at the same repository.
-// The fingerprint is computed once at startup (it queries the DB for its canonical
-// identity) and cached so the health endpoint stays cheap under frequent probing.
-var cachedRepositoryFingerprint = DBADash.RepositoryFingerprint.GetFingerprint(app.Configuration.GetConnectionString("Repository"));
+// The fingerprint is computed once (it queries the DB for its canonical identity)
+// and cached so the health endpoint stays cheap under frequent probing. If the
+// repository is unavailable when first computed the value is null, so it is retried
+// lazily on subsequent health calls - a transient startup outage must not disable
+// mismatch detection until the service is restarted.
+var repositoryConnectionString = app.Configuration.GetConnectionString("Repository");
+var cachedRepositoryFingerprint = DBADash.RepositoryFingerprint.GetFingerprint(repositoryConnectionString);
+var fingerprintLock = new object();
 app.MapGet("/api/ai/health", () =>
 {
+    if (cachedRepositoryFingerprint == null)
+    {
+        lock (fingerprintLock)
+        {
+            cachedRepositoryFingerprint ??= DBADash.RepositoryFingerprint.GetFingerprint(repositoryConnectionString);
+        }
+    }
     return Results.Ok(new
     {
         status = "healthy",

--- a/DBADashAI/Program.cs
+++ b/DBADashAI/Program.cs
@@ -263,16 +263,18 @@ RouteHandlerBuilder ApplyAuthAndRateLimit(RouteHandlerBuilder builder) =>
 // Unauthenticated health check endpoint - safe for monitoring/load balancers
 // Returns basic status plus a repository fingerprint (SHA-256 of server|database)
 // so GUI clients can verify the AI service is pointed at the same repository.
-app.MapGet("/api/ai/health", (IConfiguration config) =>
+// The fingerprint is computed once at startup (it queries the DB for its canonical
+// identity) and cached so the health endpoint stays cheap under frequent probing.
+var cachedRepositoryFingerprint = DBADash.RepositoryFingerprint.GetFingerprint(app.Configuration.GetConnectionString("Repository"));
+app.MapGet("/api/ai/health", () =>
 {
-    var fingerprint = GetRepositoryFingerprint(config.GetConnectionString("Repository"));
     return Results.Ok(new
     {
         status = "healthy",
         service = "DBADashAI",
         version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown",
         timestamp = DateTime.UtcNow,
-        repositoryFingerprint = fingerprint
+        repositoryFingerprint = cachedRepositoryFingerprint
     });
 }).AllowAnonymous();
 
@@ -668,23 +670,6 @@ ApplyAuthAndRateLimit(app.MapPost("/api/ai/proactive-digest", async (
 }));
 
 app.Run();
-
-static string? GetRepositoryFingerprint(string? connectionString)
-{
-    if (string.IsNullOrWhiteSpace(connectionString))
-        return null;
-    try
-    {
-        var b = new Microsoft.Data.SqlClient.SqlConnectionStringBuilder(connectionString);
-        var key = $"{b.DataSource.ToLowerInvariant()}|{b.InitialCatalog.ToLowerInvariant()}";
-        var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(key));
-        return Convert.ToHexString(hash);
-    }
-    catch
-    {
-        return null;
-    }
-}
 
 static void LoadSettingsFromServiceConfig(ConfigurationManager config)
 {

--- a/DBADashGUI/AI/AIAssistantControl.cs
+++ b/DBADashGUI/AI/AIAssistantControl.cs
@@ -232,24 +232,22 @@ namespace DBADashGUI.AI
             // Only seed if we actually have a key - seeding null would cause the cache to serve null
             // and suppress the fallback DB lookup in GetApiKeyAsync.
             if (serviceInfo.ApiKey != null)
-                AIApiKeyProvider.SeedFromServiceInfo(serviceInfo);
-            else
             {
-                // No key yet - the service may still be in its startup registration delay.
-                // Show the tab so it's visible, but schedule a retry to pick up the key
-                // once the service has written it to the DB.
+                AIApiKeyProvider.SeedFromServiceInfo(serviceInfo);
+            }
+            else if (serviceInfo.Source != AIServiceDiscovery.ServiceSource.Local)
+            {
+                // Repository mode expects a key. A null key here means the service hasn't
+                // finished writing its registration to the DB yet - show the tab so it's
+                // visible, but schedule a retry to pick up the key once it's registered.
                 IsServiceAvailable = true;
                 ShowServiceStartingMessage();
                 _initRetryTimer.Start();
                 return;
             }
-
-            if (serviceInfo.RepositoryMismatch)
-            {
-                ShowRepositoryMismatchWarning();
-                IsServiceAvailable = false;
-                return;
-            }
+            // Local mode is unauthenticated by design (the loopback binding is the security
+            // boundary, so the service never registers a key in the DB). A null key is the
+            // expected, permanent state - fall through and use the service directly.
 
             if (!serviceInfo.IsActive)
             {
@@ -271,6 +269,18 @@ namespace DBADashGUI.AI
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"InitializeAsync: examples/models load failed: {ex}");
+            }
+
+            // The repository fingerprint is derived from SQL Server's own canonical
+            // identity (SERVERPROPERTY('ServerName') + DB_NAME()), so server-name aliases
+            // (localhost vs machine name, FQDN, IP, named port) do NOT cause false
+            // mismatches - a mismatch means the service really is pointed at a different
+            // server/database. It is surfaced as a non-blocking warning rather than hiding
+            // the tab, so the user is informed but can still use the service (issue #2000).
+            if (serviceInfo.RepositoryMismatch)
+            {
+                ShowStatusWarning("⚠ The local AI service may be connected to a different repository than the one you are viewing. " +
+                                  "If AI answers don't match this repository, check the AI service's repository connection.");
             }
         }
         catch (Exception ex)
@@ -394,18 +404,6 @@ namespace DBADashGUI.AI
         cboCategory.Items.Add("(AI service access restricted)");
         cboCategory.SelectedIndex = 0;
         lblStatus.Text = "⚠ You do not have permission to use the AI service. Ask your DBA to grant you the AIUser role in the repository database.";
-        lblStatus.Visible = true;
-        lblStatus.ForeColor = System.Drawing.Color.OrangeRed;
-        btnAsk.Enabled = false;
-    }
-
-    private void ShowRepositoryMismatchWarning()
-    {
-        cboCategory.Items.Clear();
-        cboCategory.Items.Add("(AI service is connected to a different repository)");
-        cboCategory.SelectedIndex = 0;
-        lblStatus.Text = "⚠ The local AI service is pointed at a different repository than the one you are connected to. " +
-                         "Reconfigure the AI service or switch your repository connection.";
         lblStatus.Visible = true;
         lblStatus.ForeColor = System.Drawing.Color.OrangeRed;
         btnAsk.Enabled = false;
@@ -593,13 +591,10 @@ namespace DBADashGUI.AI
 
         try
         {
+            // In local unauthenticated mode there is no API key (by design) - send the
+            // request anyway. AddApiKeyHeader omits the header when the key is empty, and
+            // the 401 path below handles the authenticated case by fetching/retrying a key.
             var apiKey = await AIApiKeyProvider.GetApiKeyAsync();
-
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                ShowStatusWarning("⚠ No API key available — cannot load examples.");
-                return;
-            }
 
             var url = BuildUrl("/api/ai/examples");
 

--- a/DBADashGUI/AI/AIAssistantControl.cs
+++ b/DBADashGUI/AI/AIAssistantControl.cs
@@ -302,7 +302,7 @@ namespace DBADashGUI.AI
     {
         try
         {
-            var apiKey = await AIApiKeyProvider.GetApiKeyAsync();
+            var apiKey = await GetRequestApiKeyAsync();
 
             using var request = new HttpRequestMessage(HttpMethod.Get, BuildUrl("/api/ai/diagnostics"));
             AddApiKeyHeader(request, apiKey);
@@ -594,7 +594,7 @@ namespace DBADashGUI.AI
             // In local unauthenticated mode there is no API key (by design) - send the
             // request anyway. AddApiKeyHeader omits the header when the key is empty, and
             // the 401 path below handles the authenticated case by fetching/retrying a key.
-            var apiKey = await AIApiKeyProvider.GetApiKeyAsync();
+            var apiKey = await GetRequestApiKeyAsync();
 
             var url = BuildUrl("/api/ai/examples");
 
@@ -696,7 +696,7 @@ namespace DBADashGUI.AI
 
         try
         {
-            var apiKey = await AIApiKeyProvider.GetApiKeyAsync();
+            var apiKey = await GetRequestApiKeyAsync();
 
             using var request = new HttpRequestMessage(HttpMethod.Get, BuildUrl("/api/ai/models"));
             AddApiKeyHeader(request, apiKey);
@@ -836,7 +836,7 @@ namespace DBADashGUI.AI
             _lastQuestionExcerpt = null;
 
             // Get API key from repository database
-            var apiKey = await AIApiKeyProvider.GetApiKeyAsync();
+            var apiKey = await GetRequestApiKeyAsync();
 
             var selectedModel = (cboModel.SelectedItem as ModelItem)?.ModelName;
             var payload = new
@@ -955,7 +955,7 @@ namespace DBADashGUI.AI
 
         try
         {
-            var apiKey = await AIApiKeyProvider.GetApiKeyAsync();
+            var apiKey = await GetRequestApiKeyAsync();
             var payload = new
             {
                 requestId = _lastRequestId,
@@ -1092,6 +1092,20 @@ namespace DBADashGUI.AI
         if (safe != null)
             request.Headers.Add("X-API-Key", safe);
     }
+
+    /// <summary>
+    /// Resolves the API key for an outgoing request. In local (unauthenticated) mode no
+    /// key exists and none will ever be registered, so this returns null immediately
+    /// rather than paying for the service-discovery + repository-DB fallback that
+    /// <see cref="AIApiKeyProvider.GetApiKeyAsync"/> performs on every call. That keeps
+    /// local-mode requests independent of the repository DB's availability. If a local
+    /// service unexpectedly has auth enabled, the caller's 401 retry path still fetches a
+    /// real key via <see cref="AIApiKeyProvider.GetApiKeyAsync"/>.
+    /// </summary>
+    private Task<string?> GetRequestApiKeyAsync() =>
+        _serviceSource == AIServiceDiscovery.ServiceSource.Local
+            ? Task.FromResult<string?>(null)
+            : AIApiKeyProvider.GetApiKeyAsync();
 }
 
 }

--- a/DBADashGUI/AI/AIServiceDiscovery.cs
+++ b/DBADashGUI/AI/AIServiceDiscovery.cs
@@ -85,7 +85,7 @@ namespace DBADashGUI.AI
         }
 
         /// <summary>
-        /// Probes the user-configured local AI service URL.
+        /// Probes the local AI service at the given URL and reads the repository
         /// fingerprint from the health response to detect mismatches. Local mode is
         /// unauthenticated — the loopback binding is the security boundary.
         /// </summary>

--- a/DBADashGUI/AI/AIServiceDiscovery.cs
+++ b/DBADashGUI/AI/AIServiceDiscovery.cs
@@ -3,8 +3,6 @@ using Microsoft.Data.SqlClient;
 using System;
 using System.IO;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -50,26 +48,36 @@ namespace DBADashGUI.AI
         private static readonly HttpClient _probeClient = new() { Timeout = TimeSpan.FromSeconds(3) };
 
         /// <summary>
+        /// Default loopback URL probed when no local service URL is configured in user
+        /// settings. Matches the AI service's default listening port (Registration:Port).
+        /// </summary>
+        private const string DefaultLocalServiceUrl = "http://localhost:5055";
+
+        /// <summary>
         /// Resolves the AI service using the priority chain: local → repository DB.
         /// Returns null if no service is available.
         /// </summary>
         public static async Task<ServiceInfo?> GetServiceInfoAsync()
         {
-            // Priority 1: explicitly configured local service URL
+            // Priority 1: local service on localhost. Use the URL from user settings if
+            // configured, otherwise fall back to the default loopback URL. In local mode
+            // the service is not registered in the DB, so this probe is the only way to
+            // discover it - skipping it when the (user-scoped, empty-by-default) setting
+            // is blank is what hid the AI tab for local-mode installs (issue #2000).
             var localUrl = Properties.Settings.Default.LocalAIServiceUrl?.Trim();
-            if (!string.IsNullOrWhiteSpace(localUrl))
-            {
-                var localInfo = await TryGetLocalServiceAsync(localUrl);
-                if (localInfo != null)
-                {
-                    // If the local service has no API key yet, try to pull it from the
-                    // repository DB. This handles the case where the service runs on the
-                    // same machine but still requires authentication (ApiKey scheme).
-                    if (localInfo.ApiKey == null)
-                        localInfo = await MergeRepositoryKeyAsync(localInfo);
+            if (string.IsNullOrWhiteSpace(localUrl))
+                localUrl = DefaultLocalServiceUrl;
 
-                    return localInfo;
-                }
+            var localInfo = await TryGetLocalServiceAsync(localUrl);
+            if (localInfo != null)
+            {
+                // If the local service has no API key yet, try to pull it from the
+                // repository DB. This handles the case where the service runs on the
+                // same machine but still requires authentication (ApiKey scheme).
+                if (localInfo.ApiKey == null)
+                    localInfo = await MergeRepositoryKeyAsync(localInfo);
+
+                return localInfo;
             }
 
             // Priority 2: shared service registered in the repository database
@@ -77,28 +85,7 @@ namespace DBADashGUI.AI
         }
 
         /// <summary>
-        /// Computes a SHA-256 fingerprint of the repository connection (server|database),
-        /// matching what the AI service returns from its health endpoint.
-        /// </summary>
-        public static string? GetLocalFingerprint(string? connectionString)
-        {
-            if (string.IsNullOrWhiteSpace(connectionString))
-                return null;
-            try
-            {
-                var b = new SqlConnectionStringBuilder(connectionString);
-                var key = $"{b.DataSource.ToLowerInvariant()}|{b.InitialCatalog.ToLowerInvariant()}";
-                var hash = SHA256.HashData(Encoding.UTF8.GetBytes(key));
-                return Convert.ToHexString(hash);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Probes the user-configured local AI service URL. Checks the repository
+        /// Probes the user-configured local AI service URL.
         /// fingerprint from the health response to detect mismatches. Local mode is
         /// unauthenticated — the loopback binding is the security boundary.
         /// </summary>
@@ -123,7 +110,9 @@ namespace DBADashGUI.AI
                 }
                 catch { }
 
-                var guiFingerprint = GetLocalFingerprint(Common.ConnectionString);
+                // Fingerprint of the repository the GUI is connected to, for comparison
+                // against the fingerprint the service reports from its health endpoint.
+                var guiFingerprint = DBADash.RepositoryFingerprint.GetFingerprint(Common.ConnectionString);
 
                 // Mismatch: both sides have a fingerprint but they differ
                 var mismatch = serviceFingerprint != null
@@ -166,9 +155,8 @@ namespace DBADashGUI.AI
 
                     // Successfully retrieved the key from the current repository DB, which
                     // proves this local service IS registered against the same repository
-                    // the GUI is connected to.  Any fingerprint mismatch is therefore just
-                    // a server-name alias difference (e.g. "localhost" vs "lab2022") and
-                    // should not block the tab.
+                    // the GUI is connected to. That is stronger positive proof than the
+                    // fingerprint comparison, so clear any reported mismatch.
                     localInfo.RepositoryMismatch = false;
                 }
                 else


### PR DESCRIPTION
Local mode has no API key by design (loopback binding is the security boundary), but the GUI treated a null key and any repository-fingerprint mismatch as fatal, hiding the AI Assistant tab.

- Treat a null API key in local mode as expected; load examples and send requests without a key (AddApiKeyHeader already omits an empty header).
- Downgrade repository-fingerprint mismatch from a blocking error to a non-blocking warning so the tab stays usable.
- Derive the repository fingerprint from SQL Server's canonical identity (SERVERPROPERTY('ServerName') + DB_NAME()) instead of the connection string, so server-name aliases no longer cause false mismatches.
- Consolidate three duplicate fingerprint implementations into a shared DBADash.RepositoryFingerprint helper; cache the value once at startup in the AI service health endpoint.