### PR TITLE
Query Store Top Queries fix for older instances

### DIFF
--- a/DBADash/SQL/SQLQueryStoreTopQueries.sql
+++ b/DBADash/SQL/SQLQueryStoreTopQueries.sql
@@ -66,6 +66,7 @@ BEGIN
 	RAISERROR('Invalid sort',11,1)
 	RETURN
 END
+DECLARE @HasPlanForcingTypeDesc BIT
 DECLARE @SupportsTuningRecommendations BIT
 /* 
 	Requires 130 compatibility level or later for OPENJSON
@@ -83,7 +84,17 @@ SELECT @SupportsTuningRecommendations = CASE	WHEN EXISTS(SELECT 1
 													OR SERVERPROPERTY('EngineEdition') <> 3
 													)		
 												THEN CAST(1 AS BIT)
-												ELSE CAST(0 AS BIT) END
+												ELSE CAST(0 AS BIT) END,
+	@HasPlanForcingTypeDesc = CASE WHEN COLUMNPROPERTY(OBJECT_ID('sys.query_store_plan'), 'plan_forcing_type_desc', 'ColumnId') IS NULL THEN CAST(0 AS BIT) ELSE CAST(1 AS BIT) END
+
+/*
+	plan_forcing_type_desc doesn't exist on older instances.  Derive it from is_forced_plan (available on all
+	Query Store versions) so forced plans aren't mislabelled as "NONE" (unforced) in the UI.  is_forced_plan only
+	tells us the plan is forced - not whether it was forced manually or automatically - so we report 'MANUAL'.
+*/
+DECLARE @PlanForcingSelect NVARCHAR(MAX) = CASE WHEN @HasPlanForcingTypeDesc = 1 THEN 'P.plan_forcing_type_desc'
+	ELSE 'CASE WHEN P.is_forced_plan = 1 THEN ''MANUAL'' ELSE ''NONE'' END AS plan_forcing_type_desc' END
+DECLARE @PlanForcingGroupBy NVARCHAR(MAX) = CASE WHEN @HasPlanForcingTypeDesc = 1 THEN 'P.plan_forcing_type_desc' ELSE 'P.is_forced_plan' END
 
 IF @SupportsTuningRecommendations=1
 BEGIN
@@ -160,8 +171,8 @@ SELECT TOP (@Top)
 		WHEN @GroupBy = 'query_plan_hash' THEN 'P.query_plan_hash,'
 		WHEN @GroupBy = 'object_id' THEN 'Q.object_id,
 		ISNULL(OBJECT_NAME(Q.object_id),'''') object_name,'
-		WHEN @GroupBy = 'date_bucket' THEN 'RS.plan_id,P.plan_forcing_type_desc,'
-		ELSE NULL END, 
+		WHEN @GroupBy = 'date_bucket' THEN 'RS.plan_id,' + @PlanForcingSelect + ','
+		ELSE NULL END,
 		CASE WHEN @IncludeWaits = 1 THEN 'STUFF(
 				(SELECT TOP(3) '', '' + CONCAT(W.wait_category_desc, '' = '',SUM(W.total_query_wait_time_ms),''ms'')
 						FROM sys.query_store_wait_stats W
@@ -198,7 +209,7 @@ SELECT TOP (@Top)
 		', CASE WHEN COLUMNPROPERTY(OBJECT_ID('sys.query_store_runtime_stats'),'max_tempdb_space_used','ColumnId') IS NULL THEN '' ELSE 'MAX(RS.max_tempdb_space_used)*8 AS max_tempdb_space_used_kb,' END + '
 		MAX(RS.max_dop) AS max_dop,
 		', CASE WHEN @GroupBy IN('query_id','plan_id') THEN 'Q.query_parameterization_type_desc,' ELSE 'COUNT(DISTINCT Q.query_id) AS num_queries,' END, '
-		', CASE WHEN @GroupBy = 'plan_id' THEN 'P.plan_forcing_type_desc,P.force_failure_count,P.last_force_failure_reason_desc,P.is_parallel_plan,' ELSE 'COUNT(DISTINCT P.plan_id) num_plans,' END, '
+		', CASE WHEN @GroupBy = 'plan_id' THEN @PlanForcingSelect + ',P.force_failure_count,P.last_force_failure_reason_desc,P.is_parallel_plan,' ELSE 'COUNT(DISTINCT P.plan_id) num_plans,' END, '
 		' + CASE WHEN @GroupBy = 'date_bucket' THEN
 		CONCAT(@BucketStart,' AS bucket_start,',@BucketEnd,' AS bucket_end')
 		ELSE 'MIN(MIN(RS.first_execution_time)) OVER() interval_start,
@@ -229,8 +240,10 @@ GROUP BY ',CASE WHEN @GroupBy = 'query_id' THEN 'P.query_id, QT.query_sql_text, 
 			WHEN @GroupBy = 'query_plan_hash' THEN 'P.query_plan_hash'
 			WHEN @GroupBy = 'query_hash' THEN 'Q.query_hash'
 			WHEN @GroupBy = 'object_id' THEN 'Q.object_id'
-			WHEN @GroupBy = 'plan_id' THEN 'P.query_id, QT.query_sql_text, Q.object_id,Q.query_hash,Q.query_parameterization_type_desc,RS.plan_id,P.query_plan_hash,P.plan_forcing_type_desc,P.force_failure_count,P.last_force_failure_reason_desc,P.is_parallel_plan,Rec.recommended_plan_id,Reg.regressed_plan_id' 
-			WHEN @GroupBy = 'date_bucket' THEN CONCAT(@BucketStart,',',@BucketEnd,',RS.plan_id,P.plan_forcing_type_desc')
+			WHEN @GroupBy = 'plan_id' THEN 'P.query_id, QT.query_sql_text, Q.object_id,Q.query_hash,Q.query_parameterization_type_desc,RS.plan_id,P.query_plan_hash,P.force_failure_count,P.last_force_failure_reason_desc,P.is_parallel_plan'
+													+ ',' + @PlanForcingGroupBy
+													+ CASE WHEN @SupportsTuningRecommendations = 1 THEN ',Rec.recommended_plan_id,Reg.regressed_plan_id' ELSE '' END
+			WHEN @GroupBy = 'date_bucket' THEN CONCAT(@BucketStart,',',@BucketEnd,',RS.plan_id,' + @PlanForcingGroupBy)
 			ELSE NULL END, '
 ', CASE WHEN @MinimumPlanCount >1 THEN 'HAVING COUNT(DISTINCT RS.plan_id)>=@MinimumPlanCount' ELSE '' END,'
 ORDER BY ',@SortSQL,' DESC
@@ -238,4 +251,3 @@ OPTION(HASH JOIN, LOOP JOIN)')
 
 EXEC sp_executesql @SQL,N'@Top INT,@FromDate DATETIMEOFFSET(7),@ToDate DATETIMEOFFSET(7), @ObjectName NVARCHAR(128),@ObjectID INT,@QueryID BIGINT,@PlanID BIGINT,@QueryHash BINARY(8),@QueryPlanHash BINARY(8),@MinimumPlanCount INT',
 					@Top,@FromDate,@ToDate,@ObjectName,@ObjectID,@QueryID,@PlanID,@QueryHash,@QueryPlanHash,@MinimumPlanCount
-

--- a/DBADashGUI/CustomReports/ColumnMetadata.cs
+++ b/DBADashGUI/CustomReports/ColumnMetadata.cs
@@ -53,6 +53,15 @@ namespace DBADashGUI.CustomReports
 
         public LinkColumnInfo Link { get; set; }
 
+        /// <summary>
+        /// When true, this link column is only rendered when a matching column is present in the result set.
+        /// Use for data-backed link columns that are only conditionally present (e.g. columns that appear
+        /// for certain group by options) so they aren't rendered as empty link buttons showing the header
+        /// text when absent. Synthetic "action" link columns that are never backed by data (e.g. Configure /
+        /// History / Files) should leave this false so they are always added.
+        /// </summary>
+        public bool RequiresDataColumn { get; set; }
+
         public CellHighlightingRuleSet Highlighting { get; set; }
     }
 }

--- a/DBADashGUI/ExtensionMethods.cs
+++ b/DBADashGUI/ExtensionMethods.cs
@@ -694,7 +694,7 @@ namespace DBADashGUI
 
             foreach (var (colName, colInfo) in customReportResult.Columns)
             {
-                if (colInfo?.Link == null || dataColumnNames.Contains(colName)) continue;
+                if (colInfo?.Link == null || dataColumnNames.Contains(colName) || colInfo.RequiresDataColumn) continue;
                 var column = new DataGridViewLinkColumn
                 {
                     Name = colName,

--- a/DBADashGUI/Performance/QueryStoreTopQueries.cs
+++ b/DBADashGUI/Performance/QueryStoreTopQueries.cs
@@ -238,6 +238,7 @@ namespace DBADashGUI.Performance
                         Alias = "Query ID",
                         Width = 80,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new DrillDownLinkColumnInfo()
                     }
                 },
@@ -248,6 +249,7 @@ namespace DBADashGUI.Performance
                         Alias = "Plan ID",
                         Width = 70,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new PlanIdLinkColumnInfo
                         {
                             DatabaseNameColumn = "DB",
@@ -260,6 +262,7 @@ namespace DBADashGUI.Performance
                         Alias = "Query Hash",
                         Width = 160,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new QueryStoreLinkColumnInfo()
                         {
                             TargetColumn = "query_hash",
@@ -273,6 +276,7 @@ namespace DBADashGUI.Performance
                         Alias = "Plan Hash",
                         Width = 160,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new QueryStoreLinkColumnInfo()
                         {
                             TargetColumn = "query_plan_hash",
@@ -286,6 +290,7 @@ namespace DBADashGUI.Performance
                         Alias = "Object Name",
                         Width = 180,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new QueryStoreLinkColumnInfo()
                         {
                             TargetColumn = "object_name",
@@ -299,6 +304,7 @@ namespace DBADashGUI.Performance
                         Alias = "Text",
                         Width = 250,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new TextLinkColumnInfo()
                         {
                             TargetColumn = "query_sql_text",
@@ -363,6 +369,7 @@ namespace DBADashGUI.Performance
                         Alias = "Plan Forcing",
                         Width = 100,
                         Visible = true,
+                        RequiresDataColumn = true,
                         Link = new DrillDownLinkColumnInfo(),
                         Highlighting = new CellHighlightingRuleSet("plan_forcing_type_desc")
                         {


### PR DESCRIPTION
### Query Store Top Queries fix for older instances

Ensure Rec.recommended_plan_id & Reg.regressed_plan_id are only added to the group by when `@SupportsTuningRecommendations = 1`.

### Query Store Top Queries - unbound column fix
Certain columns are not always present in the resultset.  Add RequiresDataColumn property so they don't get rendered as empty link buttons showing only the header text.

