### PR TITLE
Job History - option to show job steps

### DIFF
--- a/DBADashDB/dbo/Stored Procedures/JobHistory_Get.sql
+++ b/DBADashDB/dbo/Stored Procedures/JobHistory_Get.sql
@@ -1,4 +1,4 @@
-﻿CREATE PROC dbo.JobHistory_Get(
+CREATE PROC dbo.JobHistory_Get(
 	@InstanceID INT,
 	@JobID UNIQUEIDENTIFIER,
 	@StepID INT=0,
@@ -11,9 +11,9 @@ DECLARE @SQL NVARCHAR(MAX)
 DECLARE @instance_id_from INT
 IF @instance_id IS NOT NULL
 BEGIN
-	SELECT TOP(1) @instance_id_from = instance_id 
+	SELECT TOP(1) @instance_id_from = instance_id
 	FROM dbo.JobHistory
-	WHERE InstanceID = @InstanceID 
+	WHERE InstanceID = @InstanceID
 	AND job_id = @JobID
 	AND step_id=0
 	AND instance_id<@instance_id
@@ -23,31 +23,73 @@ BEGIN
 END
 
 SET @SQL = N'
-SELECT TOP(@Top) 
-	JH.InstanceID,
-	J.name,
-	JH.job_id,
-	JH.RunDateTime,
-	JH.instance_id,
-	JH.step_id,
-	JH.step_name,
-	JH.sql_message_id,
-	JH.sql_severity,
-	JH.message,
-	JH.run_status,
-	CASE WHEN JH.run_status=0 THEN ''Failed'' WHEN JH.run_status=1 THEN ''Succeeded'' WHEN JH.run_status=2 THEN ''Retry'' WHEN JH.run_status=3 THEN ''Cancelled'' WHEN JH.run_status=4 THEN ''In Progress'' ELSE FORMAT(JH.run_status,''N0'') END as run_status_description,
-	JH.RunDurationSec,
-	HD.HumanDuration as RunDuration,
-	JH.retries_attempted,
-	DATEADD(ss,JH.RunDurationSec,JH.RunDateTime) as RunEndDateTime
-FROM dbo.JobHistory JH
-JOIN dbo.Jobs J ON JH.job_id = J.job_id AND J.InstanceID = JH.InstanceID
-CROSS APPLY dbo.SecondsToHumanDuration(JH.RunDurationSec) AS HD
-WHERE JH.InstanceID = @InstanceID
-AND JH.job_id = @JobID
-' + CASE WHEN @StepID IS NULL THEN '' ELSE 'AND JH.step_id = @StepID' END + ' 
-' + CASE WHEN @instance_id IS NULL THEN '' ELSE 'AND JH.instance_id>@instance_id_from AND JH.instance_id <= @instance_id' END + ' 
-' + CASE WHEN @FailedOnly=1 THEN 'AND JH.run_status<> 1' ELSE '' END + '
-ORDER BY JH.instance_id DESC'
+SELECT TOP(@Top) *
+FROM (
+	SELECT
+		JH.InstanceID,
+		J.name,
+		JH.job_id,
+		JH.RunDateTime,
+		JH.instance_id,
+		JH.step_id,
+		JH.step_name,
+		JH.sql_message_id,
+		JH.sql_severity,
+		JH.message,
+		JH.run_status,
+		CASE WHEN JH.run_status=0 THEN ''Failed'' WHEN JH.run_status=1 THEN ''Succeeded'' WHEN JH.run_status=2 THEN ''Retry'' WHEN JH.run_status=3 THEN ''Cancelled'' WHEN JH.run_status=4 THEN ''In Progress'' ELSE FORMAT(JH.run_status,''N0'') END as run_status_description,
+		JH.RunDurationSec,
+		HD.HumanDuration as RunDuration,
+		JH.retries_attempted,
+		DATEADD(ss,JH.RunDurationSec,JH.RunDateTime) as RunEndDateTime
+	FROM dbo.JobHistory JH
+	JOIN dbo.Jobs J ON JH.job_id = J.job_id AND J.InstanceID = JH.InstanceID
+	CROSS APPLY dbo.SecondsToHumanDuration(JH.RunDurationSec) AS HD
+	WHERE JH.InstanceID = @InstanceID
+	AND JH.job_id = @JobID
+	' + CASE WHEN @StepID IS NULL THEN '' ELSE 'AND JH.step_id = @StepID' END + '
+	' + CASE WHEN @instance_id IS NULL THEN '' ELSE 'AND JH.instance_id>@instance_id_from AND JH.instance_id <= @instance_id' END + '
+	' + CASE WHEN @FailedOnly=1 THEN 'AND JH.run_status<> 1' ELSE '' END + '
+	' +
+	/* On the default outcome view, synthesize a placeholder outcome row for a job that is currently executing.
+	   SQL Server Agent does not write the step_id=0 outcome record until the whole job finishes, so a running
+	   execution would otherwise be invisible in this view.  The synthetic row uses instance_id = 2147483647 so it
+	   sorts to the top and so the View Steps drill-down captures the already completed steps of the running run. */
+	CASE WHEN @StepID = 0 AND @instance_id IS NULL AND @FailedOnly = 0 THEN N'
+	UNION ALL
+	SELECT
+		RJ.InstanceID,
+		J.name,
+		RJ.job_id,
+		CAST(RJ.start_execution_date_utc AS DATETIME2(2)),
+		2147483647,
+		0,
+		N''(Job in progress)'',
+		CAST(NULL AS INT),
+		CAST(NULL AS INT),
+		CONCAT(N''Job is currently executing.'', CASE WHEN RJ.current_execution_step_id IS NOT NULL THEN CONCAT(N'' Current step: ('', RJ.current_execution_step_id, N'') '', RJ.current_execution_step_name) ELSE N'''' END),
+		4,
+		N''In Progress'',
+		DATEDIFF(s, RJ.start_execution_date_utc, GETUTCDATE()),
+		HDR.HumanDuration,
+		RJ.current_retry_attempt,
+		CAST(NULL AS DATETIME2(2))
+	FROM dbo.RunningJobs RJ
+	JOIN dbo.Jobs J ON RJ.job_id = J.job_id AND J.InstanceID = RJ.InstanceID
+	CROSS APPLY dbo.SecondsToHumanDuration(DATEDIFF(s, RJ.start_execution_date_utc, GETUTCDATE())) AS HDR
+	WHERE RJ.InstanceID = @InstanceID
+	AND RJ.job_id = @JobID
+	AND RJ.start_execution_date_utc IS NOT NULL /* guard: RunDateTime/duration derive from this */
+	AND ISNULL(RJ.current_execution_status,1) <> 4 /* not idle */
+	AND NOT EXISTS (
+		SELECT 1
+		FROM dbo.JobHistory JH2
+		WHERE JH2.InstanceID = RJ.InstanceID
+		AND JH2.job_id = RJ.job_id
+		AND JH2.step_id = 0
+		AND JH2.RunDateTime >= CAST(RJ.start_execution_date_utc AS DATETIME2(2))
+	)' ELSE N'' END + '
+) q
+ORDER BY q.instance_id DESC'
 
 EXEC sp_executesql @SQL,N'@InstanceID INT,@JobID UNIQUEIDENTIFIER,@StepID INT,@instance_id INT,@instance_id_from INT,@Top INT',@InstanceID,@JobID,@StepID,@instance_id,@instance_id_from,@Top

--- a/DBADashGUI/AgentJobs/JobHistoryReport.cs
+++ b/DBADashGUI/AgentJobs/JobHistoryReport.cs
@@ -156,6 +156,33 @@ namespace DBADashGUI.AgentJobs
                 }
             },
             Params = ReportParams,
+            Pickers = ToolbarPickers,
+        };
+
+        /// <summary>
+        /// Toolbar pickers for the Job History report.  "Steps" toggles @StepID between the job outcome record only
+        /// (the default - one row per execution) and NULL (every step record).  Passing NULL makes the already
+        /// completed steps of a job that is still running visible, since SQL Server Agent doesn't write the outcome
+        /// record until the whole job finishes (issue #2003).  "Failed Only" toggles @FailedOnly, which excludes
+        /// succeeded runs (run_status <> 1), so it surfaces failures along with retries and cancellations.
+        /// </summary>
+        private static List<Picker> ToolbarPickers => new()
+        {
+            new()
+            {
+                ParameterName = "@StepID",
+                Name = "Steps",
+                DefaultValue = 0,
+                DataType = typeof(int),
+                PickerItems = new Dictionary<object, string>
+                {
+                    { 0, "Outcome Only" },
+                    { DBNull.Value, "All Steps" },
+                },
+                MenuBar = true,
+                Image = Properties.Resources.List_NumberedHS
+            },
+            Picker.CreateBooleanPicker("@FailedOnly", "Failed Only", defaultValue: false, trueString: "Yes", falseString: "No", menuBar: true, image: Properties.Resources.Filter_16x)
         };
 
         private static SystemReport StepsInstance => new()

--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -2730,6 +2730,11 @@ namespace DBADashGUI.CustomReports
                     if (picker.MenuBar)
                     {
                         var lbl = new ToolStripLabel(picker.Name + ":") { Tag = pickerTag };
+                        if (picker.Image != null)
+                        {
+                            lbl.Image = picker.Image;
+                            lbl.DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
+                        }
                         toolStrip1.Items.Insert(baseIdx + 1, lbl);
                         toolStrip1.Items.Insert(baseIdx + 2, txtItem);
                     }
@@ -2743,6 +2748,11 @@ namespace DBADashGUI.CustomReports
                 else if (picker.MultiSelect)
                 {
                     var pickerMenu = new ToolStripDropDownButton(picker.Name) { Tag = pickerTag, DisplayStyle = ToolStripItemDisplayStyle.Text };
+                    if (picker.Image != null)
+                    {
+                        pickerMenu.Image = picker.Image;
+                        pickerMenu.DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
+                    }
                     var selectedValues = param.UseDefaultValue
                         ? null
                         : param.Param.Value?.ToString()?.Split(',').Select(s => s.Trim()).ToHashSet(StringComparer.OrdinalIgnoreCase);
@@ -2775,6 +2785,11 @@ namespace DBADashGUI.CustomReports
                 else
                 {
                     var pickerMenu = new ToolStripMenuItem(picker.Name) { Tag = pickerTag };
+                    if (picker.Image != null)
+                    {
+                        pickerMenu.Image = picker.Image;
+                        pickerMenu.DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
+                    }
                     var isNonDefault = !param.UseDefaultValue && picker.DefaultValue != null
                         && param.Param.Value?.ToString() != picker.DefaultValue.ToString();
                     if (isNonDefault)

--- a/DBADashGUI/CustomReports/Picker.cs
+++ b/DBADashGUI/CustomReports/Picker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Drawing;
 using Microsoft.Data.SqlClient;
 using Newtonsoft.Json;
 
@@ -11,6 +12,13 @@ namespace DBADashGUI.CustomReports
         public string ParameterName { get; set; }
 
         public string Name { get; set; }
+
+        /// <summary>
+        /// Optional icon shown next to the picker on the toolbar (when <see cref="MenuBar"/> is set).  Not persisted -
+        /// intended for code-defined pickers on system reports.
+        /// </summary>
+        [JsonIgnore]
+        public Image Image { get; set; }
 
         public virtual Dictionary<object, string> PickerItems { get; set; }
 
@@ -61,7 +69,7 @@ namespace DBADashGUI.CustomReports
             };
         }
 
-        public static Picker CreateBooleanPicker(string paramName, string name, bool defaultValue = true, string trueString = "Yes", string falseString = "No", bool menuBar=false)
+        public static Picker CreateBooleanPicker(string paramName, string name, bool defaultValue = true, string trueString = "Yes", string falseString = "No", bool menuBar=false, Image image = null)
         {
             return new Picker()
             {
@@ -74,7 +82,8 @@ namespace DBADashGUI.CustomReports
                         {true, trueString},
                         {false, falseString}
                     },
-                MenuBar = menuBar
+                MenuBar = menuBar,
+                Image = image
             };
         }
     }


### PR DESCRIPTION
Add toolbar options to show job steps and filter for failed only.  These options were previously available before the system report conversion.  #2003 
Also show a placeholder outcome row for jobs that are currently executing.  This provides a quick way to see the progress of the current execution.