### PR TITLE
SQL Patching - exclude Azure DB

### DIFF
--- a/DBADashGUI/Changes/SQLPatchingView.cs
+++ b/DBADashGUI/Changes/SQLPatchingView.cs
@@ -393,6 +393,8 @@ namespace DBADashGUI.Changes
             ProcedureName = "SQLPatchingReport_Get",
             QualifiedProcedureName = "dbo.SQLPatchingReport_Get",
             CanEditReport = false,
+            AppliesTo = CustomReport.InstanceApplicability.RegularOnly, // SQL Patching is not relevant to Azure SQL DB
+
             TriggerCollectionTypes = new List<string>
             {
                 CollectionType.ServerProperties.ToString()

--- a/DBADashGUI/CustomReports/CustomReport.cs
+++ b/DBADashGUI/CustomReports/CustomReport.cs
@@ -23,6 +23,29 @@ namespace DBADashGUI.CustomReports
             Right
         }
 
+        /// <summary>
+        /// Indicates which instances (by engine edition) a report is relevant to.  Used to filter the list of
+        /// context instance IDs passed to the report's @InstanceIDs parameter.  For example SQL Patching is not
+        /// relevant to Azure SQL DB and uses <see cref="InstanceApplicability.RegularOnly"/>.
+        /// </summary>
+        public enum InstanceApplicability
+        {
+            /// <summary>Report applies to all instances (default).</summary>
+            All,
+
+            /// <summary>Report applies to regular (non-Azure SQL DB) instances only.</summary>
+            RegularOnly,
+
+            /// <summary>Report applies to Azure SQL DB instances only.</summary>
+            AzureOnly
+        }
+
+        /// <summary>
+        /// Controls which subset of the current context's instances is passed to the report's @InstanceIDs
+        /// parameter.  Defaults to <see cref="InstanceApplicability.All"/>.
+        /// </summary>
+        public InstanceApplicability AppliesTo { get; set; } = InstanceApplicability.All;
+
         public ChartLocations ChartLocation { get; set; } = ChartLocations.Top;
 
         public double ChartSplitPercentage { get; set; } = 0.6;

--- a/DBADashGUI/CustomReports/CustomReportView.cs
+++ b/DBADashGUI/CustomReports/CustomReportView.cs
@@ -2231,7 +2231,16 @@ namespace DBADashGUI.CustomReports
             var pInstanceIDs = customParams.FirstOrDefault(p => p.Param.ParameterName.Equals("@InstanceIDs", StringComparison.InvariantCultureIgnoreCase) && p.UseDefaultValue);
             if (pInstanceIDs != null)
             {
-                pInstanceIDs.Param.Value = context.InstanceIDs.AsDataTable();
+                var reportInstanceIDs = context.GetInstanceIDs(Report.AppliesTo);
+                // When a report is scoped to a subset of engine editions (e.g. SQL Patching excludes Azure SQL DB)
+                // and none of the current context's instances apply, pass a non-existent InstanceID so the proc
+                // returns no rows.  An empty @InstanceIDs table is treated as "all active instances" by the procs,
+                // which would incorrectly widen the scope beyond the current context.
+                if (reportInstanceIDs.Count == 0 && Report.AppliesTo != CustomReport.InstanceApplicability.All)
+                {
+                    reportInstanceIDs = new HashSet<int> { 0 };
+                }
+                pInstanceIDs.Param.Value = reportInstanceIDs.AsDataTable();
             }
             var pInstanceID = customParams.FirstOrDefault(p => p.Param.ParameterName.Equals("@InstanceID", StringComparison.InvariantCultureIgnoreCase) && p.UseDefaultValue);
             if (pInstanceID != null)

--- a/DBADashGUI/DBADashContext.cs
+++ b/DBADashGUI/DBADashContext.cs
@@ -13,6 +13,17 @@ namespace DBADashGUI
     public class DBADashContext : ICloneable
     {
         public HashSet<int> InstanceIDs => new HashSet<int>(RegularInstanceIDs.Union(AzureInstanceIDs));
+
+        /// <summary>
+        /// Returns the subset of context instance IDs relevant to a report based on its
+        /// <see cref="CustomReport.AppliesTo"/> setting (e.g. exclude Azure SQL DB for SQL Patching).
+        /// </summary>
+        public HashSet<int> GetInstanceIDs(CustomReport.InstanceApplicability applicability) => applicability switch
+        {
+            CustomReport.InstanceApplicability.RegularOnly => RegularInstanceIDs,
+            CustomReport.InstanceApplicability.AzureOnly => AzureInstanceIDs,
+            _ => InstanceIDs
+        };
         public HashSet<int> AzureInstanceIDs => ShowHiddenInstances ? AzureInstanceIDsWithHidden : new HashSet<int>(AzureInstanceIDsWithHidden.Except(HiddenInstanceIDs));
         public HashSet<int> RegularInstanceIDs => ShowHiddenInstances ? RegularInstanceIDsWithHidden : new HashSet<int>(RegularInstanceIDsWithHidden.Except(HiddenInstanceIDs));
 


### PR DESCRIPTION
SQL Patching report should exclude AzureDB instances.  Add InstanceApplicability option to custom reports so we can pass a filtered list of InstanceIDs - excluding AzureDB instances.