### PR TITLE
Add OS-level (Perfmon) counter collection via WMI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
           "Configure"
           ./dbadashconfig -c "Data Source=localhost;UID=sa;pwd=dbatools.I0;Initial Catalog=DBADashDB_GitHubAction;Encrypt=True;TrustServerCertificate=True;" -a SetDestination
           ./dbadashconfig -c "Data Source=localhost;UID=sa;pwd=dbatools.I0;Encrypt=True;TrustServerCertificate=True;" -a Add --PlanCollectionEnabled --SlowQueryThresholdMs 1000 --SchemaSnapshotDBs "*"
+          "Enable OS-level (perfmon) counter collection"
+          ./dbadashconfig -a SetPerfmonCounters --PerfmonDefaults
           "Install Service"
           ./DBADashService install --localsystem
           "Start Service"
@@ -143,7 +145,9 @@ jobs:
             Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -MinimumVersion 5.0.0
           }
           Import-Module Pester -MinimumVersion 5.0.0
-          Invoke-Pester -Output Detailed Scripts\CI_Workflow.Tests.ps1
+          # Perfmon = $true: this leg enables the default perfmon counters, so assert they were collected.
+          $container = New-PesterContainer -Path 'Scripts\CI_Workflow.Tests.ps1' -Data @{ Perfmon = $true }
+          Invoke-Pester -Container $container -Output Detailed
 
       - name: Output Table Counts Following Delete
         shell: powershell

--- a/DBADash.Test/DBADashConfig.cs
+++ b/DBADash.Test/DBADashConfig.cs
@@ -151,6 +151,87 @@ namespace DBADashConfig.Test
         }
 
         [TestMethod]
+        public void SetPerfmonCountersGlobalTest()
+        {
+            var defaultCount = PerfmonCounter.DefaultCounters().Count;
+
+            // Enable defaults
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig", "-a SetPerfmonCounters --PerfmonDefaults"));
+            var cfg = BasicConfig.Load<CollectionConfig>();
+            Assert.AreEqual(defaultCount, cfg.PerfmonCounters.Count, "Defaults should populate the global list");
+
+            // Add a specific counter on top of the defaults
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig",
+                "-a SetPerfmonCounters --PerfmonDefaults --PerfmonCounters \"Win32_PerfRawData_PerfProc_Process:HandleCount:_Total\""));
+            cfg = BasicConfig.Load<CollectionConfig>();
+            Assert.AreEqual(defaultCount + 1, cfg.PerfmonCounters.Count, "Specific counter should be added on top of defaults");
+            var added = cfg.PerfmonCounters.Single(c => c.WmiProperty == "HandleCount");
+            Assert.AreEqual("Win32_PerfRawData_PerfProc_Process", added.WmiClass);
+            Assert.AreEqual("_Total", added.InstanceName);
+            Assert.AreEqual(0, added.CounterType, "Counter type is resolved by the collector, not stored by the CLI");
+
+            // Clear
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig", "-a SetPerfmonCounters --PerfmonClear"));
+            cfg = BasicConfig.Load<CollectionConfig>();
+            Assert.AreEqual(0, cfg.PerfmonCounters.Count, "Clear should empty the global list");
+        }
+
+        [TestMethod]
+        public void SetPerfmonCountersInvalidSpecFailsTest()
+        {
+            // A non-raw class must be rejected: the CLI logs the error and exits with a non-zero code.
+            var psi = new ProcessStartInfo("DBADashConfig",
+                "-a SetPerfmonCounters --PerfmonCounters \"Win32_PerfFormattedData_PerfOS_Processor:PercentProcessorTime\"")
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            using var p = Process.Start(psi) ?? throw new Exception("Process is NULL");
+            p.WaitForExit();
+            Assert.AreEqual(1, p.ExitCode, "Invalid (non-raw) counter class should fail with a non-zero exit code");
+        }
+
+        [TestMethod]
+        [DataRow("PerfmonConn1", "Data Source=PerfmonConn1;Integrated Security=SSPI")]
+        public void SetPerfmonCountersPerConnectionTest(string connectionID, string connectionString)
+        {
+            var defaultCount = PerfmonCounter.DefaultCounters().Count;
+
+            // Arrange: add a source connection to attach the override to.
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig",
+                $"-a Add -c \"{connectionString}\" --SkipValidation true --ConnectionID {connectionID}"));
+
+            // A fresh connection inherits the global list (null override).
+            var conn = BasicConfig.Load<CollectionConfig>().SourceConnections.Single(c => c.ConnectionID == connectionID);
+            Assert.IsNull(conn.PerfmonCounters, "New connection should inherit (null) by default");
+
+            // Custom override: defaults for this connection only.
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig",
+                $"-a SetPerfmonCounters -c \"{connectionString}\" --PerfmonDefaults"));
+            conn = BasicConfig.Load<CollectionConfig>().SourceConnections.Single(c => c.ConnectionID == connectionID);
+            Assert.IsNotNull(conn.PerfmonCounters);
+            Assert.AreEqual(defaultCount, conn.PerfmonCounters.Count, "Per-connection defaults");
+
+            // Disabled for this instance (empty, not null).
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig",
+                $"-a SetPerfmonCounters -c \"{connectionString}\" --PerfmonClear"));
+            conn = BasicConfig.Load<CollectionConfig>().SourceConnections.Single(c => c.ConnectionID == connectionID);
+            Assert.IsNotNull(conn.PerfmonCounters, "Clear should be empty, not null (disabled != inherit)");
+            Assert.AreEqual(0, conn.PerfmonCounters.Count);
+
+            // Back to inherit (null).
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig",
+                $"-a SetPerfmonCounters -c \"{connectionString}\" --PerfmonInherit"));
+            conn = BasicConfig.Load<CollectionConfig>().SourceConnections.Single(c => c.ConnectionID == connectionID);
+            Assert.IsNull(conn.PerfmonCounters, "Inherit should reset the override to null");
+
+            // Cleanup
+            Helper.RunProcess(new ProcessStartInfo("DBADashConfig", $"-a Remove --ConnectionID {connectionID}"));
+        }
+
+        [TestMethod]
         [DataRow("DBADashUnitTest")]
         public void ServiceNameTest(string serviceName)
         {

--- a/DBADash.Test/PerfmonCounterTests.cs
+++ b/DBADash.Test/PerfmonCounterTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using DBADash;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DBADash.Test
+{
+    [TestClass]
+    public class PerfmonCounterTests
+    {
+        [TestMethod]
+        public void ParseSpec_ClassAndProperty_DefaultsInstanceToStar()
+        {
+            var c = PerfmonCounter.ParseSpec("Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime");
+
+            Assert.AreEqual("Win32_PerfRawData_PerfOS_Processor", c.WmiClass);
+            Assert.AreEqual("PercentProcessorTime", c.WmiProperty);
+            Assert.AreEqual("*", c.InstanceName);
+            // Object name is derived from the class so the stored name is friendly.
+            Assert.AreEqual("Processor", c.EffectiveObjectName);
+            // Counter type is resolved by the collector at collection time, not at config time.
+            Assert.AreEqual(0, c.CounterType);
+            Assert.IsNull(c.BaseWmiProperty);
+        }
+
+        [TestMethod]
+        public void ParseSpec_ExplicitInstance_IsUsed()
+        {
+            var c = PerfmonCounter.ParseSpec("Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime:_Total");
+            Assert.AreEqual("_Total", c.InstanceName);
+        }
+
+        [TestMethod]
+        public void ParseSpec_InstanceContainingColon_IsPreserved()
+        {
+            // A drive instance name legitimately contains a colon - only the first two colons delimit.
+            var c = PerfmonCounter.ParseSpec("Win32_PerfRawData_PerfDisk_LogicalDisk:AvgDisksecPerRead:C:");
+            Assert.AreEqual("AvgDisksecPerRead", c.WmiProperty);
+            Assert.AreEqual("C:", c.InstanceName);
+        }
+
+        [TestMethod]
+        public void ParseSpec_WhitespaceIsTrimmed()
+        {
+            var c = PerfmonCounter.ParseSpec("  Win32_PerfRawData_PerfOS_System : ProcessorQueueLength ");
+            Assert.AreEqual("Win32_PerfRawData_PerfOS_System", c.WmiClass);
+            Assert.AreEqual("ProcessorQueueLength", c.WmiProperty);
+        }
+
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("   ")]
+        [DataRow("Win32_PerfRawData_PerfOS_Processor")]              // missing property
+        [DataRow("Win32_PerfRawData_PerfOS_Processor:")]             // empty property
+        [DataRow(":PercentProcessorTime")]                          // empty class
+        [DataRow("Win32_PerfFormattedData_PerfOS_Processor:PercentProcessorTime")] // not a raw class
+        public void ParseSpec_InvalidInput_Throws(string spec)
+        {
+            Assert.ThrowsExactly<ArgumentException>(() => PerfmonCounter.ParseSpec(spec));
+        }
+
+        [TestMethod]
+        public void ParseSpecList_ParsesMultiple_AndSkipsBlankEntries()
+        {
+            var list = PerfmonCounter.ParseSpecList(
+                "Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime:_Total, ,Win32_PerfRawData_PerfOS_Memory:PagesPersec");
+
+            Assert.AreEqual(2, list.Count);
+            Assert.AreEqual("Processor", list[0].EffectiveObjectName);
+            Assert.AreEqual("Memory", list[1].EffectiveObjectName);
+        }
+
+        [TestMethod]
+        public void ParseSpecList_Empty_ReturnsEmptyList()
+        {
+            Assert.AreEqual(0, PerfmonCounter.ParseSpecList("").Count);
+            Assert.AreEqual(0, PerfmonCounter.ParseSpecList(null).Count);
+        }
+
+        [TestMethod]
+        public void BuildList_DefaultsOnly_ReturnsAllDefaults()
+        {
+            var list = PerfmonCounter.BuildList(includeDefaults: true, specs: null);
+            Assert.AreEqual(PerfmonCounter.DefaultCounters().Count, list.Count);
+        }
+
+        [TestMethod]
+        public void BuildList_SpecsOnly_ReturnsParsedSpecs()
+        {
+            var list = PerfmonCounter.BuildList(includeDefaults: false,
+                specs: "Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime:_Total,Win32_PerfRawData_PerfOS_Memory:PagesPersec");
+            Assert.AreEqual(2, list.Count);
+        }
+
+        [TestMethod]
+        public void BuildList_DefaultsPlusOverlappingSpec_DeDuplicatesByWmiIdentity()
+        {
+            // Re-specify a default counter by its WMI identity (class / property / instance).  Even though the
+            // spec would store a different display name, it is the same counter, so it is de-duplicated.
+            var list = PerfmonCounter.BuildList(includeDefaults: true,
+                specs: "Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime:_Total");
+
+            Assert.AreEqual(PerfmonCounter.DefaultCounters().Count, list.Count);
+        }
+
+        [TestMethod]
+        public void ResolveStorageNames_KnownCounter_UsesCanonicalName()
+        {
+            // A well-known counter added by its raw WMI property name still stores under the curated display name.
+            var (objectName, counterName) =
+                PerfmonCounter.ResolveStorageNames("Win32_PerfRawData_PerfOS_Processor", "PercentProcessorTime");
+            Assert.AreEqual("Processor", objectName);
+            Assert.AreEqual("% Processor Time", counterName);
+        }
+
+        [TestMethod]
+        public void ResolveStorageNames_UnknownCounter_DerivesFromWmiIdentity()
+        {
+            var (objectName, counterName) =
+                PerfmonCounter.ResolveStorageNames("Win32_PerfRawData_PerfProc_Process", "HandleCount");
+            Assert.AreEqual("Process", objectName);   // derived from the class name
+            Assert.AreEqual("HandleCount", counterName); // falls back to the WMI property
+        }
+
+        [TestMethod]
+        public void ResolveStorageNames_IsDeterministic_RegardlessOfConfigNames()
+        {
+            // The same WMI identity always resolves to the same stored name, so it can't fragment.
+            var viaProperty = PerfmonCounter.ResolveStorageNames("Win32_PerfRawData_PerfOS_Memory", "PagesPersec");
+            var defMemory = PerfmonCounter.DefaultCounters()
+                .Single(c => c.WmiClass == "Win32_PerfRawData_PerfOS_Memory" && c.WmiProperty == "PagesPersec");
+            Assert.AreEqual(defMemory.EffectiveObjectName, viaProperty.ObjectName);
+            Assert.AreEqual(defMemory.EffectiveCounterName, viaProperty.CounterName);
+        }
+
+        [TestMethod]
+        public void BuildList_InvalidSpec_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentException>(
+                () => PerfmonCounter.BuildList(includeDefaults: true, specs: "not_a_raw_class:Foo"));
+        }
+
+        [TestMethod]
+        public void DefaultCounters_AllUseRawClasses_AndAreUnique()
+        {
+            var defaults = PerfmonCounter.DefaultCounters();
+            Assert.IsTrue(defaults.Count > 0);
+
+            // Every default must be a raw perf class (the cooking in PerfmonCounters_Upd assumes raw values).
+            Assert.IsTrue(defaults.All(c => c.WmiClass.StartsWith(PerfmonCounter.RawClassPrefix, StringComparison.OrdinalIgnoreCase)),
+                "All default counters must use the raw Win32_PerfRawData_* classes.");
+
+            // No duplicate (object, counter, instance) - that key is unique in dbo.Counters.
+            var distinct = defaults
+                .Select(c => (c.EffectiveObjectName, c.EffectiveCounterName, c.InstanceName))
+                .Distinct()
+                .Count();
+            Assert.AreEqual(defaults.Count, distinct, "Default counters contain a duplicate (object, counter, instance).");
+        }
+    }
+}

--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -37,6 +37,14 @@ namespace DBADash
         public CollectionSchedules CollectionSchedules;
         public Dictionary<string, CustomCollection> CustomCollections { get; set; } = new();
 
+        /// <summary>
+        /// OS-level (perfmon) performance counters collected from the host via WMI.  Separate from
+        /// the DMV performance counters (sys.dm_os_performance_counters).  Empty = collect nothing
+        /// (no auto-defaults at runtime; the curated <see cref="PerfmonCounter.DefaultCounters"/> are
+        /// only offered as a starting point via the "Defaults" button in the config UI).
+        /// </summary>
+        public List<PerfmonCounter> PerfmonCounters { get; set; } = new();
+
         public string SummaryRefreshCron { get; set; }
 
         public string UpgradeCheckCron { get; set; }

--- a/DBADash/CollectionSchedule.cs
+++ b/DBADash/CollectionSchedule.cs
@@ -48,6 +48,7 @@ namespace DBADashService
                             {CollectionType.AzureDBElasticPoolResourceStats, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false  } },
                             {CollectionType.SlowQueries, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false  } },
                             {CollectionType.PerformanceCounters, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false } },
+                            {CollectionType.PerfmonCounters, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false } },
                             {CollectionType.JobHistory, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false  } },
                             {CollectionType.RunningQueries, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false  } },
                             {CollectionType.DatabasesHADR, new CollectionSchedule(){ Schedule = every1min,RunOnServiceStart=false  } },

--- a/DBADash/DBADashSource.cs
+++ b/DBADash/DBADashSource.cs
@@ -149,6 +149,24 @@ namespace DBADash
             set => noWMI = value;
         }
 
+        /// <summary>
+        /// Per-instance perfmon counters, a tri-state override of the global list
+        /// (<see cref="CollectionConfig.PerfmonCounters"/>):
+        /// <list type="bullet">
+        /// <item><c>null</c> - inherit the global list.</item>
+        /// <item>empty list - disabled (collect no perfmon counters for this instance).</item>
+        /// <item>populated - collect exactly these counters.</item>
+        /// </list>
+        /// Only applies to SQL sources and requires WMI (no effect when <see cref="NoWMI"/> is set).
+        /// </summary>
+        public List<PerfmonCounter> PerfmonCounters
+        {
+            get => SourceConnection is { Type: ConnectionType.SQL } ? perfmonCounters : null;
+            set => perfmonCounters = value;
+        }
+
+        private List<PerfmonCounter> perfmonCounters;
+
         public int SlowQuerySessionMaxMemoryKB
         {
             get => SourceConnection is { Type: ConnectionType.SQL } ? slowQuerySessionMaxMemoryKB : 0;

--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -8,7 +8,9 @@ using Newtonsoft.Json.Converters;
 using Polly;
 using Polly.Retry;
 using Serilog;
+using Serilog.Events;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
@@ -84,7 +86,8 @@ namespace DBADash
         FailedLogins,
         ResourceGovernorWorkloadGroups,
         ResourceGovernorResourcePools,
-        ScheduleInfo
+        ScheduleInfo,
+        PerfmonCounters
     }
 
     public enum HostPlatform
@@ -101,6 +104,14 @@ namespace DBADash
         public bool LogInternalPerformanceCounters = false;
         private DataTable dtInternalPerfCounters;
         public int PerformanceCollectionPeriodMins = 60;
+        public List<PerfmonCounter> PerfmonCounters { get; set; }
+
+        // Perfmon counter schema (PERF type + base property) is immutable per class, so resolve it at most
+        // once per (host, class) for the life of the process rather than on every collection.  Only used as
+        // a fallback for counters whose type isn't persisted in config (see PerfmonCounter.CounterType).
+        private static readonly ConcurrentDictionary<string, Dictionary<string, PerfmonCounterDiscovery.DiscoveredCounter>> PerfmonMetadataCache
+            = new(StringComparer.OrdinalIgnoreCase);
+
         private string computerName;
         private readonly CollectionType[] azureCollectionTypes = new[] { CollectionType.SlowQueries, CollectionType.AzureDBElasticPoolResourceStats, CollectionType.AzureDBServiceObjectives, CollectionType.AzureDBResourceStats, CollectionType.CPU, CollectionType.DBFiles, CollectionType.Databases, CollectionType.DBConfig, CollectionType.TraceFlags, CollectionType.ObjectExecutionStats, CollectionType.BlockingSnapshot, CollectionType.IOStats, CollectionType.Waits, CollectionType.ServerProperties, CollectionType.DBTuningOptions, CollectionType.SysConfig, CollectionType.DatabasePrincipals, CollectionType.DatabaseRoleMembers, CollectionType.DatabasePermissions, CollectionType.OSInfo, CollectionType.CustomChecks, CollectionType.PerformanceCounters, CollectionType.VLF, CollectionType.DatabaseQueryStoreOptions, CollectionType.AzureDBResourceGovernance, CollectionType.RunningQueries, CollectionType.IdentityColumns, CollectionType.TableSize, CollectionType.AvailableProcs, CollectionType.DatabaseExtendedProperties };
         private readonly CollectionType[] azureOnlyCollectionTypes = new[] { CollectionType.AzureDBElasticPoolResourceStats, CollectionType.AzureDBResourceStats, CollectionType.AzureDBServiceObjectives, CollectionType.AzureDBResourceGovernance };
@@ -1106,6 +1117,10 @@ OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid
             {
                 CollectDriversWMI();
             }
+            else if (collectionType == CollectionType.PerfmonCounters)
+            {
+                await CollectPerfmonCountersWMIAsync();
+            }
             else if (collectionType == CollectionType.SlowQueries)
             {
                 try
@@ -1815,6 +1830,307 @@ OPTION(RECOMPILE)"); // Plan caching is not beneficial.  RECOMPILE hint to avoid
             {
                 LogError(ex, "Drivers", "Collect:WMI");
             }
+        }
+
+        // Perfmon (PERF_*) counter types we normalise to.  The raw WMI CounterType is mapped to one of
+        // these; dbo.PerfmonCounters_Upd cooks each one (see that proc for the formulas).
+        private const int PerfLargeRawCount = 65792;   // value as-is
+        private const int PerfBulkCount = 272696576;   // rate: Δvalue/Δseconds
+        private const int PerfLargeRawFraction = 537003264; // value*100/base
+        private const int Perf100NsTimer = 542180608;  // 0x20510500 - % over interval
+        private const int Perf100NsTimerInv = 558957824; // 0x21510500 - inverse % over interval
+        private const int PerfAverageTimer = 805438464; // (Δvalue/1e7)/Δbase - value pre-scaled to 100ns
+        private const int PerfLargeRawBase = 1073939712; // base row marker
+        private const int PerfMultiCounter = 0x02000000; // flag: value is summed across instances (_Total)
+
+        // Per-class WMI query timeout.  A wedged perf provider must not hang the collection (and its
+        // Task.WhenAll) indefinitely - the collection runs on a 1-minute schedule, so this is a generous
+        // backstop that still frees the worker well within the next collection.
+        private static readonly TimeSpan PerfmonQueryTimeout = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Collect OS-level (perfmon) performance counters from the host via WMI - the RAW
+        /// (Win32_PerfRawData_*) classes.  Emits raw accumulators (plus a "&lt;counter&gt; Base" row and,
+        /// for timer counters, a 100ns-scaled value) into a "PerfmonCounters" table which
+        /// dbo.PerfmonCounters_Upd cooks over the collection interval.  Uses the same WSMan/DCom
+        /// session as the other WMI collections.  Distinct from the DMV PerformanceCounters collection.
+        /// </summary>
+        private async Task CollectPerfmonCountersWMIAsync()
+        {
+            if (noWMI || !OperatingSystem.IsWindows()) return;
+            var counters = PerfmonCounters;
+            if (counters == null || counters.Count == 0) return; // no counters configured => nothing to collect
+            if (Data.Tables.Contains("PerfmonCounters")) return; // already collected this batch
+
+            try
+            {
+                var dt = new DataTable("PerfmonCounters");
+                dt.Columns.Add("SnapshotDate", typeof(DateTime));
+                dt.Columns.Add("object_name", typeof(string));
+                dt.Columns.Add("counter_name", typeof(string));
+                dt.Columns.Add("instance_name", typeof(string));
+                dt.Columns.Add("cntr_value", typeof(decimal));
+                dt.Columns.Add("cntr_type", typeof(int));
+                dt.Columns.Add("timebase", typeof(decimal)); // Timestamp_Sys100NS for 100ns timers, else 0
+                // Stable WMI identity (persisted on dbo.Counters).  Appended last to keep the TVP ordinals stable.
+                dt.Columns.Add("WmiClass", typeof(string));
+                dt.Columns.Add("WmiProperty", typeof(string));
+
+                var snapshotDate = DateTime.UtcNow;
+
+                var debug = Log.IsEnabled(LogEventLevel.Debug);
+                var swSession = debug ? Stopwatch.StartNew() : null;
+                using CimSession session = CimSession.Create(computerName, WMISessionOptions);
+                if (debug) Log.Debug("Perfmon {computer}: CimSession created in {ms}ms", computerName, swSession.ElapsedMilliseconds);
+
+                // Build a query plan per class (metadata resolve + projection) - cheap and synchronous.
+                var plans = counters
+                    .Where(c => !string.IsNullOrEmpty(c.WmiClass) && !string.IsNullOrEmpty(c.WmiProperty))
+                    .GroupBy(c => c.WmiClass, StringComparer.OrdinalIgnoreCase)
+                    .Select(g => BuildPerfmonClassPlan(session, g))
+                    .Where(p => p != null)
+                    .ToList();
+                if (plans.Count == 0) return;
+
+                // Each class query is an independent WSMan round-trip, and cost is dominated by that
+                // round-trip (not row count), so run them concurrently via native async I/O.  Awaiting
+                // (rather than blocking) releases the collection worker thread for the duration of the
+                // WMI wait instead of parking it.
+                var perClassRows = await Task.WhenAll(plans.Select(p => CollectPerfmonClassAsync(session, p, snapshotDate)))
+                    .ConfigureAwait(false);
+
+                foreach (var rows in perClassRows)
+                    foreach (var row in rows)
+                        dt.Rows.Add(row);
+
+                if (dt.Rows.Count > 0) Data.Tables.Add(dt);
+            }
+            catch (Exception ex)
+            {
+                LogError(ex, "PerfmonCounters", "Collect:WMI");
+            }
+        }
+
+        /// <summary>A resolved plan to collect one WMI perf class: the narrowed WQL query and, per configured
+        /// counter, the metadata (PERF type + base property) needed to cook it.</summary>
+        private sealed class PerfmonClassPlan
+        {
+            public string WmiClass;
+            public string Query;
+            public List<(PerfmonCounter Ctr, PerfmonCounterDiscovery.DiscoveredCounter Meta)> Resolved;
+        }
+
+        private PerfmonClassPlan BuildPerfmonClassPlan(CimSession session, IGrouping<string, PerfmonCounter> classGroup)
+        {
+            // Resolve each counter's PERF type + base property.  Prefer the values persisted in config
+            // (no WMI round-trip); only fall back to the class schema (process-cached) for counters that
+            // lack a persisted type - e.g. a hand-edited config.
+            Dictionary<string, PerfmonCounterDiscovery.DiscoveredCounter> schema = null;
+            var resolved = new List<(PerfmonCounter Ctr, PerfmonCounterDiscovery.DiscoveredCounter Meta)>();
+            foreach (var ctr in classGroup)
+            {
+                PerfmonCounterDiscovery.DiscoveredCounter cm;
+                if (ctr.CounterType != 0)
+                {
+                    cm = new PerfmonCounterDiscovery.DiscoveredCounter
+                    {
+                        WmiProperty = ctr.WmiProperty,
+                        CounterType = ctr.CounterType,
+                        BaseWmiProperty = ctr.BaseWmiProperty
+                    };
+                }
+                else
+                {
+                    schema ??= GetCachedPerfmonMetadata(session, classGroup.Key);
+                    if (!schema.TryGetValue(ctr.WmiProperty, out cm)) continue;
+                }
+                resolved.Add((ctr, cm));
+            }
+            if (resolved.Count == 0) return null;
+
+            // Only project the columns we actually read (plus the always-present timing columns), rather
+            // than SELECT * which marshals every counter the class exposes.
+            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                { "Name", "Frequency_PerfTime", "Timestamp_Sys100NS" };
+            foreach (var (_, cm) in resolved)
+            {
+                columns.Add(cm.WmiProperty);
+                if (!string.IsNullOrEmpty(cm.BaseWmiProperty)) columns.Add(cm.BaseWmiProperty);
+            }
+            return new PerfmonClassPlan
+            {
+                WmiClass = classGroup.Key,
+                Query = "SELECT " + string.Join(", ", columns) + " FROM " + classGroup.Key,
+                Resolved = resolved
+            };
+        }
+
+        /// <summary>Query one perf class asynchronously and cook its rows.  Never throws - a class absent on
+        /// this OS (or any other per-class failure) is logged and yields no rows, so it can't fail the batch
+        /// (or the Task.WhenAll).</summary>
+        private async Task<List<object[]>> CollectPerfmonClassAsync(CimSession session, PerfmonClassPlan plan, DateTime snapshotDate)
+        {
+            var rows = new List<object[]>();
+            // dbo.Counters key is (object_name, counter_name, instance_name); dedupe overlapping config
+            // within the class (cross-class collisions can't happen - object_name is class-derived).
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            List<CimInstance> instances = null;
+            // Per-class timing: which WMI class dominates varies by host, so log it to pinpoint slow classes
+            // (some perf providers are far slower to enumerate on certain machines).  Gated so the Stopwatch
+            // and the 4-arg log (which allocates + boxes) cost nothing when Debug isn't enabled.
+            var debug = Log.IsEnabled(LogEventLevel.Debug);
+            var swClass = debug ? Stopwatch.StartNew() : null;
+            try
+            {
+                instances = await QueryInstancesAsync(session, plan.Query).ConfigureAwait(false);
+                if (debug) Log.Debug("Perfmon {computer}: {class} queried {instances} instance(s) in {ms}ms",
+                    computerName, plan.WmiClass, instances.Count, swClass.ElapsedMilliseconds);
+
+                foreach (var itm in instances)
+                {
+                    // Single-instance classes (e.g. Memory, System) return a null Name.
+                    // The raw _Total for timer counters is already the per-core average (not a sum),
+                    // so no instance-count division is needed.
+                    var wmiName = Convert.ToString(itm.CimInstanceProperties["Name"]?.Value) ?? string.Empty;
+                    var freqPerfTime = ToDecimalOrZero(itm.CimInstanceProperties["Frequency_PerfTime"]?.Value);
+                    // The counter's own 100ns timestamp, sampled atomically with the values - used as the
+                    // exact time base for 100ns-timer counters instead of wall-clock time.
+                    var timestampSys100Ns = ToDecimalOrZero(itm.CimInstanceProperties["Timestamp_Sys100NS"]?.Value);
+
+                    foreach (var (ctr, cm) in plan.Resolved)
+                    {
+                        // "*" => every instance; otherwise match the WMI Name property.
+                        if (ctr.InstanceName != "*" &&
+                            !string.Equals(ctr.InstanceName ?? string.Empty, wmiName, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                        var rawValue = itm.CimInstanceProperties[ctr.WmiProperty]?.Value;
+                        if (rawValue == null) continue;
+
+                        // Resolve the display names deterministically from the WMI identity (not from the
+                        // per-config names) so the same WMI counter always stores under one identity.  The
+                        // stable key (WmiClass / WmiProperty) is persisted alongside for the app to key off.
+                        var (resolvedObject, counterName) = PerfmonCounter.ResolveStorageNames(ctr.WmiClass, ctr.WmiProperty);
+                        // Namespace the stored object_name so perfmon counters can never collide with DMV
+                        // counters in dbo.Counters (see ObjectNamePrefix).
+                        var objectName = PerfmonCounter.ObjectNamePrefix + resolvedObject;
+                        if (!seen.Add(objectName + "|" + counterName + "|" + wmiName)) continue;
+
+                        var value = ToDecimalOrZero(rawValue);
+                        decimal? baseValue = null;
+                        int emitType;
+                        // Some timers carry the MULTI flag (0x02000000); clear it to reduce to the base
+                        // type we cook (harmless for non-multi types).
+                        switch (cm.CounterType & ~PerfMultiCounter)
+                        {
+                            case 65536: case 65792: // RAWCOUNT / LARGE_RAWCOUNT
+                                emitType = PerfLargeRawCount; break;
+                            case 272696320: case 272696576: // COUNTER / BULK_COUNT (rate)
+                                emitType = PerfBulkCount; break;
+                            case 537003008: case 537003264: // RAW_FRACTION / LARGE_RAW_FRACTION
+                                // Fraction counters can't be cooked without their base (value*100/base).
+                                // A base-less config (e.g. stale Win32_PerfFormattedData_* data) is skipped.
+                                if (string.IsNullOrEmpty(cm.BaseWmiProperty)) continue;
+                                emitType = PerfLargeRawFraction;
+                                baseValue = ToDecimalOrZero(itm.CimInstanceProperties[cm.BaseWmiProperty]?.Value);
+                                break;
+                            case 542180608: emitType = Perf100NsTimer; break;    // 100NSEC_TIMER (+ MULTI)
+                            case 558957824: emitType = Perf100NsTimerInv; break; // 100NSEC_TIMER_INV (+ MULTI)
+                            case 805438464: // AVERAGE_TIMER (e.g. disk latency)
+                                // Average-timer counters need their base too (Δvalue/Δbase); skip if absent.
+                                if (string.IsNullOrEmpty(cm.BaseWmiProperty)) continue;
+                                emitType = PerfAverageTimer;
+                                baseValue = ToDecimalOrZero(itm.CimInstanceProperties[cm.BaseWmiProperty]?.Value);
+                                if (freqPerfTime > 0) value = value * 10000000m / freqPerfTime; // ticks -> 100ns units
+                                break;
+                            default: // unhandled type: collect raw as-is, but flag it so it's not silently wrong
+                                Log.Warning("Perfmon counter {object}\\{counter} has unhandled CounterType {type} - collected as a raw value",
+                                    objectName, counterName, cm.CounterType);
+                                emitType = PerfLargeRawCount; break;
+                        }
+
+                        var timebase = emitType is Perf100NsTimer or Perf100NsTimerInv ? timestampSys100Ns : 0m;
+                        // Column order must match the DataTable schema built in CollectPerfmonCountersWMIAsync.
+                        rows.Add(new object[] { snapshotDate, objectName, counterName, wmiName, value, emitType, timebase, ctr.WmiClass, ctr.WmiProperty });
+                        if (baseValue.HasValue)
+                        {
+                            // Base rows aren't registered as counters (excluded by cntr_type), so their WMI
+                            // identity carries the base property for traceability only.
+                            rows.Add(new object[] { snapshotDate, objectName, counterName.TrimEnd() + " Base", wmiName, baseValue.Value, PerfLargeRawBase, 0m, ctr.WmiClass, cm.BaseWmiProperty });
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // A class absent on this OS shouldn't fail the whole collection.
+                LogError(ex, "PerfmonCounters", $"Collect:WMI {plan.WmiClass}");
+            }
+            finally
+            {
+                if (instances != null) foreach (var itm in instances) itm.Dispose();
+            }
+            return rows;
+        }
+
+        /// <summary>
+        /// Bridge the MI async query (an IObservable&lt;CimInstance&gt;) to a Task that completes with all
+        /// instances.  Lets several class queries overlap their WSMan round-trips without a thread each.
+        /// A server-side operation timeout (<see cref="PerfmonQueryTimeout"/>) bounds a wedged provider so
+        /// it can't hang the collection forever, and the subscription is disposed once the operation ends.
+        /// </summary>
+        private static Task<List<CimInstance>> QueryInstancesAsync(CimSession session, string query)
+        {
+            var tcs = new TaskCompletionSource<List<CimInstance>>(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Not a 'using': keep the options alive for the whole operation, not just until this method
+            // returns, in case MI reads them past Subscribe.  Disposed in the completion continuation below.
+            var options = new CimOperationOptions { Timeout = PerfmonQueryTimeout };
+            IObservable<CimInstance> op = session.QueryInstancesAsync(@"root\cimv2", "WQL", query, options);
+            IDisposable subscription = op.Subscribe(new CimInstanceObserver(tcs));
+            // Release the subscription and options once the operation finishes (completed, faulted, or timed out).
+            _ = tcs.Task.ContinueWith(_ =>
+            {
+                subscription.Dispose();
+                options.Dispose();
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        private sealed class CimInstanceObserver : IObserver<CimInstance>
+        {
+            private readonly List<CimInstance> results = new();
+            private readonly TaskCompletionSource<List<CimInstance>> tcs;
+            public CimInstanceObserver(TaskCompletionSource<List<CimInstance>> tcs) => this.tcs = tcs;
+            public void OnNext(CimInstance value) => results.Add(value); // delivered sequentially per operation
+
+            public void OnError(Exception error)
+            {
+                // On the error path the buffered instances are never handed to the consumer (it awaits the
+                // faulted task), so nothing else can dispose them - do it here.  Only when we win the race to
+                // complete the task, otherwise OnCompleted already handed ownership to the consumer.
+                if (tcs.TrySetException(error))
+                    foreach (var itm in results) itm.Dispose();
+            }
+
+            public void OnCompleted() => tcs.TrySetResult(results);
+        }
+
+        private static decimal ToDecimalOrZero(object value)
+        {
+            try { return value == null ? 0m : Convert.ToDecimal(value); }
+            catch { return 0m; }
+        }
+
+        /// <summary>
+        /// Resolve a perf class's counter metadata, cached for the life of the process (schema never
+        /// changes).  A transient empty result is not cached, so a failed lookup is retried next time.
+        /// </summary>
+        private Dictionary<string, PerfmonCounterDiscovery.DiscoveredCounter> GetCachedPerfmonMetadata(CimSession session, string wmiClass)
+        {
+            var key = (computerName ?? string.Empty) + "|" + wmiClass;
+            if (PerfmonMetadataCache.TryGetValue(key, out var cached)) return cached;
+            var meta = PerfmonCounterDiscovery.GetCounterMetadata(session, computerName, wmiClass);
+            if (meta.Count > 0) PerfmonMetadataCache[key] = meta;
+            return meta;
         }
 
         private void AddPVDriverVersion(ref DataTable dtDrivers)

--- a/DBADash/DBImporter.cs
+++ b/DBADash/DBImporter.cs
@@ -367,7 +367,7 @@ namespace DBADash
             "AzureDBServiceObjectives", "AzureDBElasticPoolResourceStats", "SlowQueries",
             "SlowQueriesStats", "LastGoodCheckDB", "Alerts", "ObjectExecutionStats", "ServerPrincipals",
             "ServerRoleMembers", "ServerPermissions", "DatabasePrincipals", "DatabaseRoleMembers",
-            "DatabasePermissions", "CustomChecks", "PerformanceCounters", "VLF", "DatabaseMirroring",
+            "DatabasePermissions", "CustomChecks", "PerformanceCounters", "PerfmonCounters", "VLF", "DatabaseMirroring",
             "Jobs", "JobHistory", "AvailabilityReplicas", "AvailabilityGroups", "JobSteps",
             "DatabaseQueryStoreOptions", "ResourceGovernorConfiguration", "AzureDBResourceGovernance",
             "RunningQueries", "QueryText", "QueryPlans", "InternalPerformanceCounters", "MemoryUsage",

--- a/DBADash/PerfmonCounter.cs
+++ b/DBADash/PerfmonCounter.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DBADash
+{
+    /// <summary>
+    /// Defines an OS-level performance counter collected from the host via WMI
+    /// (the raw <c>Win32_PerfRawData_*</c> classes, cooked over the collection interval) rather than
+    /// from <c>sys.dm_os_performance_counters</c>.
+    ///
+    /// Collection identifiers (<see cref="WmiClass"/> / <see cref="WmiProperty"/>) are what we
+    /// actually query. Storage identifiers (<see cref="ObjectName"/> / <see cref="CounterName"/> /
+    /// <see cref="InstanceName"/>) are the perfmon-style triad written to the existing
+    /// PerformanceCounters table so the whole GUI / alerting stack works unchanged.
+    ///
+    /// There is no clean bidirectional map between perfmon names ("% Processor Time") and WMI
+    /// property names ("PercentProcessorTime"), so we carry both. Display names fall back to the
+    /// WMI names when not supplied.
+    /// </summary>
+    public class PerfmonCounter
+    {
+        /// <summary>
+        /// Prefix applied to the stored object_name so perfmon counters can never clash with the DMV
+        /// performance counters in dbo.Counters.  The DMV collection strips everything up to the first
+        /// colon (STUFF(...CHARINDEX(':')...)), so every DMV-stored object_name is colon-free - a colon
+        /// in this prefix therefore guarantees perfmon names are disjoint from DMV names by construction.
+        /// Also makes the source identifiable: object_name LIKE 'PerfMon:%'.
+        /// </summary>
+        public const string ObjectNamePrefix = "PerfMon:";
+
+        /// <summary>Prefix of the raw WMI perf classes we collect from (e.g. Win32_PerfRawData_PerfOS_Processor).</summary>
+        public const string RawClassPrefix = "Win32_PerfRawData_";
+
+        /// <summary>WMI class to query, e.g. "Win32_PerfRawData_PerfOS_Processor".</summary>
+        public string WmiClass { get; set; }
+
+        /// <summary>WMI property holding the cooked value, e.g. "PercentProcessorTime".</summary>
+        public string WmiProperty { get; set; }
+
+        /// <summary>
+        /// Perfmon object name stored in the DB, e.g. "Processor". Falls back to <see cref="WmiClass"/>.
+        /// </summary>
+        public string ObjectName { get; set; }
+
+        /// <summary>
+        /// Perfmon counter name stored in the DB, e.g. "% Processor Time". Falls back to <see cref="WmiProperty"/>.
+        /// </summary>
+        public string CounterName { get; set; }
+
+        /// <summary>
+        /// Instance to collect. "*" collects every instance the class returns (matched on the WMI
+        /// <c>Name</c> property). For single-instance classes (e.g. Memory) use "" or "*".
+        /// </summary>
+        public string InstanceName { get; set; } = "*";
+
+        /// <summary>
+        /// The PERF_* counter type (the WMI <c>CounterType</c> qualifier) that drives how the raw value is
+        /// cooked.  Persisted at discovery time so collection needs no per-sample WMI schema lookup.
+        /// 0 = unknown (e.g. a hand-edited config): the collector resolves it from the class schema
+        /// (process-cached) at collection time instead.
+        /// </summary>
+        public int CounterType { get; set; }
+
+        /// <summary>
+        /// Companion base WMI property (e.g. <c>&lt;WmiProperty&gt;_Base</c>) needed to cook fraction /
+        /// average-timer counters, else null.  Persisted alongside <see cref="CounterType"/>.
+        /// </summary>
+        public string BaseWmiProperty { get; set; }
+
+        public string EffectiveObjectName => string.IsNullOrEmpty(ObjectName) ? WmiClass : ObjectName;
+
+        public string EffectiveCounterName => string.IsNullOrEmpty(CounterName) ? WmiProperty : CounterName;
+
+        /// <summary>
+        /// Curated default counters, focused on OS-level signals that COMPLEMENT DBA Dash's existing
+        /// SQL telemetry rather than duplicate it.  Collected from the raw (Win32_PerfRawData_*) classes
+        /// and cooked over the collection interval, so rates are true interval averages and fractional
+        /// values (disk latency) keep full precision.  Deliberately excluded:
+        ///   - machine CPU % breakdown        -> covered by the CPU collection (dm_os_ring_buffers)
+        ///   - available / committed memory    -> covered by the DMV counters (dm_os_sys_memory / Memory Manager)
+        ///   - scheduler / runnable / pending IO -> covered by the DMV counters (dm_os_schedulers)
+        /// Disk latency (Avg. Disk sec/Read/Write) is included now that raw cooking preserves precision.
+        /// The _Total Processor % counters cook correctly because the raw _Total instance is already the
+        /// per-core average (not a sum across cores), so no instance-count division is needed.
+        /// </summary>
+        /// CounterType / BaseWmiProperty are the values WMI reports for these well-known counters, hardcoded
+        /// so the default set needs no schema lookup at all (the collector still resolves the type from the
+        /// class schema for any counter that lacks it - see <see cref="CounterType"/>).
+        public static List<PerfmonCounter> DefaultCounters() => new()
+        {
+            new() { WmiClass = "Win32_PerfRawData_PerfOS_Processor",   WmiProperty = "PercentProcessorTime",   ObjectName = "Processor",         CounterName = "% Processor Time",           InstanceName = "_Total", CounterType = 558957824 /* PERF_100NSEC_TIMER_INV */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfOS_Processor",   WmiProperty = "PercentPrivilegedTime",  ObjectName = "Processor",         CounterName = "% Privileged Time",          InstanceName = "_Total", CounterType = 542180608 /* PERF_100NSEC_TIMER */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfOS_System",      WmiProperty = "ProcessorQueueLength",   ObjectName = "System",            CounterName = "Processor Queue Length",     InstanceName = "",       CounterType = 65536 /* PERF_COUNTER_RAWCOUNT */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfOS_Memory",      WmiProperty = "PagesPersec",            ObjectName = "Memory",            CounterName = "Pages/sec",                  InstanceName = "",       CounterType = 272696320 /* PERF_COUNTER_COUNTER */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfDisk_PhysicalDisk", WmiProperty = "DiskReadsPersec",     ObjectName = "PhysicalDisk",      CounterName = "Disk Reads/sec",             InstanceName = "_Total", CounterType = 272696320 /* PERF_COUNTER_COUNTER */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfDisk_PhysicalDisk", WmiProperty = "DiskWritesPersec",    ObjectName = "PhysicalDisk",      CounterName = "Disk Writes/sec",            InstanceName = "_Total", CounterType = 272696320 /* PERF_COUNTER_COUNTER */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfDisk_PhysicalDisk", WmiProperty = "DiskBytesPersec",     ObjectName = "PhysicalDisk",      CounterName = "Disk Bytes/sec",             InstanceName = "_Total", CounterType = 272696576 /* PERF_COUNTER_BULK_COUNT */ },
+            new() { WmiClass = "Win32_PerfRawData_PerfDisk_PhysicalDisk", WmiProperty = "AvgDisksecPerRead",   ObjectName = "PhysicalDisk",      CounterName = "Avg. Disk sec/Read",         InstanceName = "_Total", CounterType = 805438464 /* PERF_AVERAGE_TIMER */, BaseWmiProperty = "AvgDisksecPerRead_Base" },
+            new() { WmiClass = "Win32_PerfRawData_PerfDisk_PhysicalDisk", WmiProperty = "AvgDisksecPerWrite",  ObjectName = "PhysicalDisk",      CounterName = "Avg. Disk sec/Write",        InstanceName = "_Total", CounterType = 805438464 /* PERF_AVERAGE_TIMER */, BaseWmiProperty = "AvgDisksecPerWrite_Base" },
+            new() { WmiClass = "Win32_PerfRawData_Tcpip_NetworkInterface", WmiProperty = "BytesTotalPersec",   ObjectName = "Network Interface", CounterName = "Bytes Total/sec",            InstanceName = "*",      CounterType = 272696576 /* PERF_COUNTER_BULK_COUNT */ },
+        };
+
+        /// <summary>
+        /// Parse a compact counter spec of the form "WmiClass:WmiProperty" or "WmiClass:WmiProperty:Instance"
+        /// (e.g. "Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime:_Total").  Instance defaults to "*".
+        /// <para>
+        /// <see cref="CounterType"/> / <see cref="BaseWmiProperty"/> are deliberately left unset (0 / null):
+        /// the collector resolves them from the class schema at collection time (see <see cref="CounterType"/>),
+        /// so a spec never needs the raw PERF_* type or base property.
+        /// </para>
+        /// Throws <see cref="ArgumentException"/> for a malformed spec or a class that isn't a raw perf class.
+        /// </summary>
+        public static PerfmonCounter ParseSpec(string spec)
+        {
+            if (string.IsNullOrWhiteSpace(spec))
+                throw new ArgumentException("Counter spec is empty.");
+
+            // Class and property are WMI identifiers (no colons); an instance name can contain a colon
+            // (e.g. a drive "C:"), so split off only the first two segments and keep the rest as the instance.
+            var parts = spec.Split(':', 3);
+            var wmiClass = parts[0].Trim();
+            var wmiProperty = parts.Length > 1 ? parts[1].Trim() : string.Empty;
+            var instance = parts.Length > 2 ? parts[2].Trim() : "*";
+            if (instance.Length == 0) instance = "*";
+
+            if (wmiClass.Length == 0 || wmiProperty.Length == 0)
+                throw new ArgumentException($"Invalid counter spec '{spec}'. Expected WmiClass:WmiProperty[:Instance].");
+            if (!wmiClass.StartsWith(RawClassPrefix, StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException($"Invalid counter class '{wmiClass}'. Perfmon collection uses the raw '{RawClassPrefix}*' classes.");
+
+            return new PerfmonCounter
+            {
+                WmiClass = wmiClass,
+                WmiProperty = wmiProperty,
+                ObjectName = PerfmonCounterDiscovery.DeriveObjectName(wmiClass),
+                InstanceName = instance
+                // CounterType left 0 / BaseWmiProperty null - resolved by the collector from the class schema.
+            };
+        }
+
+        /// <summary>
+        /// Parse a comma-separated list of counter specs (see <see cref="ParseSpec"/>).  An empty / whitespace
+        /// input yields an empty list.  Throws <see cref="ArgumentException"/> on the first malformed spec.
+        /// </summary>
+        public static List<PerfmonCounter> ParseSpecList(string specs)
+        {
+            var list = new List<PerfmonCounter>();
+            if (string.IsNullOrWhiteSpace(specs)) return list;
+            foreach (var raw in specs.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                list.Add(ParseSpec(raw));
+            }
+            return list;
+        }
+
+        /// <summary>
+        /// Build a counter list from the curated defaults and/or a comma-separated spec list, de-duplicating
+        /// on the (object, counter, instance) key that is unique in dbo.Counters.  Throws
+        /// <see cref="ArgumentException"/> on a malformed spec.
+        /// </summary>
+        public static List<PerfmonCounter> BuildList(bool includeDefaults, string specs)
+        {
+            var list = new List<PerfmonCounter>();
+            if (includeDefaults) list.AddRange(DefaultCounters());
+            foreach (var c in ParseSpecList(specs))
+            {
+                if (!list.Any(existing => SameCounter(existing, c))) list.Add(c);
+            }
+            return list;
+        }
+
+        /// <summary>
+        /// True if two counters are the same counter, compared by their stable WMI identity
+        /// (class / property / instance) rather than the display names, which can vary by config.
+        /// </summary>
+        public static bool SameCounter(PerfmonCounter a, PerfmonCounter b) =>
+            string.Equals(a.WmiClass, b.WmiClass, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(a.WmiProperty, b.WmiProperty, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(a.InstanceName ?? "*", b.InstanceName ?? "*", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Canonical display names for the well-known counters, keyed by WMI identity.  This is the single
+        /// source of the friendly (object_name, counter_name) so the same WMI counter always stores under one
+        /// deterministic name regardless of how it was configured (defaults vs discovery vs hand-edited CLI).
+        /// </summary>
+        private static readonly Dictionary<string, (string ObjectName, string CounterName)> CanonicalNames =
+            DefaultCounters().ToDictionary(
+                c => c.WmiClass + "|" + c.WmiProperty,
+                c => (c.EffectiveObjectName, c.EffectiveCounterName),
+                StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Resolve the display (object_name, counter_name) to store for a given WMI identity: the curated
+        /// name for a well-known counter, else derived (<see cref="PerfmonCounterDiscovery.DeriveObjectName"/>
+        /// / the WMI property).  Deterministic, so a given WMI counter never fragments across two names.
+        /// </summary>
+        public static (string ObjectName, string CounterName) ResolveStorageNames(string wmiClass, string wmiProperty) =>
+            CanonicalNames.TryGetValue(wmiClass + "|" + wmiProperty, out var names)
+                ? names
+                : (PerfmonCounterDiscovery.DeriveObjectName(wmiClass), wmiProperty);
+    }
+}

--- a/DBADash/PerfmonCounterDiscovery.cs
+++ b/DBADash/PerfmonCounterDiscovery.cs
@@ -1,0 +1,226 @@
+using Microsoft.Management.Infrastructure;
+using Microsoft.Management.Infrastructure.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+
+namespace DBADash
+{
+    /// <summary>
+    /// Enumerates the OS-level (perfmon) counters available on a host via WMI - the
+    /// <c>Win32_PerfRawData_*</c> (raw) classes.  We collect raw counters (accumulators + base +
+    /// timebase) and cook them ourselves across the collection interval, which is both more accurate
+    /// than the cooked <c>Win32_PerfFormattedData_*</c> classes (true interval average vs an aliased
+    /// point sample) and preserves fractional values (e.g. disk latency) that the formatted classes
+    /// truncate to integer.  Uses the same WSMan-then-DCom fallback as the collector.
+    /// </summary>
+    public static class PerfmonCounterDiscovery
+    {
+        private const string PerfClassPrefix = "Win32_PerfRawData_";
+        private const string PerfBaseClass = "Win32_PerfRawData";
+
+        /// <summary>Standard properties present on every perf class that are not real counters.</summary>
+        private static readonly HashSet<string> NonCounterProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Caption", "Description", "Name",
+            "Frequency_Object", "Frequency_PerfTime", "Frequency_Sys100NS",
+            "Timestamp_Object", "Timestamp_PerfTime", "Timestamp_Sys100NS"
+        };
+
+        /// <summary>Bound every WMI operation so a slow/unreachable host can't hang the UI indefinitely.</summary>
+        private static CimOperationOptions OperationOptions => new() { Timeout = TimeSpan.FromSeconds(30) };
+
+        /// <summary>A single collectable counter within a perf class.</summary>
+        public class DiscoveredCounter
+        {
+            public string WmiProperty { get; set; }
+            /// <summary>The PERF_* counter type (from the CounterType qualifier) - drives how it's cooked.</summary>
+            public int CounterType { get; set; }
+            /// <summary>Companion base property (e.g. for fraction/average/timer counters), else null.</summary>
+            public string BaseWmiProperty { get; set; }
+        }
+
+        public class DiscoveredCounterClass
+        {
+            public string WmiClass { get; set; }
+            public string ObjectName { get; set; }
+            public List<DiscoveredCounter> Counters { get; set; } = new();
+        }
+
+        /// <summary>
+        /// Derive a friendly perfmon object name from a WMI perf class name,
+        /// e.g. "Win32_PerfRawData_PerfOS_Processor" -> "Processor".
+        /// </summary>
+        public static string DeriveObjectName(string wmiClass)
+        {
+            if (string.IsNullOrEmpty(wmiClass) ||
+                !wmiClass.StartsWith(PerfClassPrefix, StringComparison.OrdinalIgnoreCase))
+                return wmiClass;
+            var remainder = wmiClass.Substring(PerfClassPrefix.Length); // e.g. PerfOS_Processor
+            var idx = remainder.IndexOf('_');
+            return idx >= 0 && idx < remainder.Length - 1 ? remainder[(idx + 1)..] : remainder;
+        }
+
+        private static CimSession CreateSession(string computerName)
+        {
+            // Mirror the collector: try WSMan first, fall back to DCom.
+            try
+            {
+                var session = CimSession.Create(computerName, new WSManSessionOptions());
+                using (session.GetClass(@"root\cimv2", "Win32_ComputerSystem", OperationOptions)) { }
+                return session;
+            }
+            catch
+            {
+                return CimSession.Create(computerName, new DComSessionOptions());
+            }
+        }
+
+        /// <summary>
+        /// Read the collectable counters (with their PERF type and base counter) from a raw perf class.
+        /// Base properties (named &lt;Counter&gt;_Base) are attached to their primary and not listed
+        /// separately.  Used by both discovery (for the picker) and the collector (to cook values).
+        /// </summary>
+        public static List<DiscoveredCounter> GetCounters(CimClass cimClass)
+        {
+            var propertyNames = new HashSet<string>(
+                cimClass.CimClassProperties.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+
+            var counters = new List<DiscoveredCounter>();
+            foreach (var p in cimClass.CimClassProperties)
+            {
+                if (NonCounterProperties.Contains(p.Name)) continue;
+                if (p.Name.EndsWith("_Base", StringComparison.OrdinalIgnoreCase)) continue; // attached to its primary
+
+                var baseProperty = p.Name + "_Base";
+                counters.Add(new DiscoveredCounter
+                {
+                    WmiProperty = p.Name,
+                    CounterType = GetCounterType(p),
+                    BaseWmiProperty = propertyNames.Contains(baseProperty) ? baseProperty : null
+                });
+            }
+            return counters;
+        }
+
+        private static int GetCounterType(CimPropertyDeclaration property)
+        {
+            try
+            {
+                return Convert.ToInt32(property.Qualifiers["CounterType"]?.Value ?? 0);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Resolve each counter's PERF type + base property for a class, keyed by WMI property.  Used by
+        /// the collector to know how to cook each value.  Tries MI first (works over WSMan or DCom); if MI
+        /// doesn't surface the CounterType qualifiers (they aren't always populated), falls back to
+        /// System.Management which reads them reliably (DCom).
+        /// </summary>
+        public static Dictionary<string, DiscoveredCounter> GetCounterMetadata(CimSession session, string computerName, string wmiClass)
+        {
+            var result = new Dictionary<string, DiscoveredCounter>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                using var cimClass = session.GetClass(@"root\cimv2", wmiClass, OperationOptions);
+                foreach (var c in GetCounters(cimClass)) result[c.WmiProperty] = c;
+            }
+            catch
+            {
+                // fall through to System.Management below
+            }
+
+            // If no counter types came back, the qualifiers weren't populated - use System.Management.
+            if (result.Count == 0 || result.Values.All(c => c.CounterType == 0))
+            {
+                result = GetCounterMetadataViaManagement(computerName, wmiClass);
+            }
+            return result;
+        }
+
+        private static Dictionary<string, DiscoveredCounter> GetCounterMetadataViaManagement(string computerName, string wmiClass)
+        {
+            var result = new Dictionary<string, DiscoveredCounter>(StringComparer.OrdinalIgnoreCase);
+            if (!OperatingSystem.IsWindows()) return result; // System.Management is Windows-only
+            var host = string.IsNullOrEmpty(computerName) ? "." : computerName;
+            var scope = new ManagementScope($@"\\{host}\root\cimv2");
+            scope.Connect();
+            using var mc = new ManagementClass(scope, new ManagementPath(wmiClass), null);
+
+            var propertyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (PropertyData p in mc.Properties) propertyNames.Add(p.Name);
+
+            foreach (PropertyData p in mc.Properties)
+            {
+                if (NonCounterProperties.Contains(p.Name)) continue;
+                if (p.Name.EndsWith("_Base", StringComparison.OrdinalIgnoreCase)) continue;
+
+                var counterType = 0;
+                try { counterType = Convert.ToInt32(p.Qualifiers["CounterType"].Value); } catch { /* not a counter */ }
+
+                var baseProperty = p.Name + "_Base";
+                result[p.Name] = new DiscoveredCounter
+                {
+                    WmiProperty = p.Name,
+                    CounterType = counterType,
+                    BaseWmiProperty = propertyNames.Contains(baseProperty) ? baseProperty : null
+                };
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Enumerate the perf counter classes (and their counters) available on the host.
+        /// Instances are resolved lazily via <see cref="DiscoverInstances"/> when a class is selected.
+        /// </summary>
+        public static List<DiscoveredCounterClass> DiscoverClasses(string computerName)
+        {
+            using var session = CreateSession(computerName);
+            var result = new List<DiscoveredCounterClass>();
+            foreach (var cimClass in session.EnumerateClasses(@"root\cimv2", PerfBaseClass, OperationOptions))
+            {
+                using (cimClass)
+                {
+                    var className = cimClass.CimSystemProperties.ClassName;
+                    if (string.IsNullOrEmpty(className) ||
+                        !className.StartsWith(PerfClassPrefix, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var counters = GetCounters(cimClass);
+                    if (counters.Count == 0) continue;
+
+                    result.Add(new DiscoveredCounterClass
+                    {
+                        WmiClass = className,
+                        ObjectName = DeriveObjectName(className),
+                        Counters = counters.OrderBy(c => c.WmiProperty, StringComparer.OrdinalIgnoreCase).ToList()
+                    });
+                }
+            }
+            return result.OrderBy(c => c.ObjectName, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        /// <summary>
+        /// Resolve the instance names (the WMI Name property) for a given perf class.
+        /// Returns a single empty string for single-instance classes (e.g. Memory).
+        /// </summary>
+        public static List<string> DiscoverInstances(string computerName, string wmiClass)
+        {
+            using var session = CreateSession(computerName);
+            var instances = new List<string>();
+            foreach (var itm in session.QueryInstances(@"root\cimv2", "WQL", "SELECT Name FROM " + wmiClass, OperationOptions))
+            {
+                using (itm)
+                {
+                    instances.Add(Convert.ToString(itm.CimInstanceProperties["Name"]?.Value) ?? string.Empty);
+                }
+            }
+            return instances.Distinct().OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+    }
+}

--- a/DBADashConfig/Helper.cs
+++ b/DBADashConfig/Helper.cs
@@ -356,6 +356,88 @@ namespace DBADashConfig
             }
         }
 
+        public static async Task SetPerfmonCounters(CollectionConfig config, Options o)
+        {
+            // A connection target (-c or --ConnectionID) switches to a per-connection override; otherwise
+            // we edit the global list.  --PerfmonInherit only makes sense per-connection.
+            var perConnection = !string.IsNullOrEmpty(o.ConnectionString) || !string.IsNullOrEmpty(o.ConnectionID);
+
+            if (o.PerfmonInherit && !perConnection)
+            {
+                Log.Error("--PerfmonInherit requires a connection (-c or --ConnectionID).  The global list has nothing to inherit from.");
+                Environment.Exit(1);
+                return;
+            }
+
+            // Resolve the requested action into a tri-state result:
+            //   null  = inherit the global list (per-connection only)
+            //   empty = collect nothing (disabled)
+            //   list  = these counters
+            List<PerfmonCounter>? result;
+            if (o.PerfmonInherit)
+            {
+                if (o.PerfmonDefaults || o.PerfmonClear || !string.IsNullOrWhiteSpace(o.PerfmonCounters))
+                {
+                    Log.Error("--PerfmonInherit cannot be combined with --PerfmonDefaults, --PerfmonCounters or --PerfmonClear.");
+                    Environment.Exit(1);
+                    return;
+                }
+                result = null;
+            }
+            else if (o.PerfmonClear)
+            {
+                if (o.PerfmonDefaults || !string.IsNullOrWhiteSpace(o.PerfmonCounters))
+                {
+                    Log.Error("--PerfmonClear cannot be combined with --PerfmonDefaults or --PerfmonCounters.");
+                    Environment.Exit(1);
+                    return;
+                }
+                result = new List<PerfmonCounter>();
+            }
+            else if (o.PerfmonDefaults || !string.IsNullOrWhiteSpace(o.PerfmonCounters))
+            {
+                try
+                {
+                    result = PerfmonCounter.BuildList(o.PerfmonDefaults, o.PerfmonCounters);
+                }
+                catch (ArgumentException ex)
+                {
+                    Log.Error("Invalid --PerfmonCounters value: {Message}", ex.Message);
+                    Environment.Exit(1);
+                    return;
+                }
+            }
+            else
+            {
+                Log.Error("Nothing to do.  Specify --PerfmonDefaults and/or --PerfmonCounters, --PerfmonClear to disable{0}.",
+                    perConnection ? ", or --PerfmonInherit to use the global list" : string.Empty);
+                Environment.Exit(1);
+                return;
+            }
+
+            if (perConnection)
+            {
+                var source = await GetSourceConnectionAsync(o, config);
+                if (source == null)
+                {
+                    Log.Error("Source connection not found.");
+                    Environment.Exit(1);
+                    return;
+                }
+                source.PerfmonCounters = result;
+                Log.Information("Perfmon counters for {Connection} set to {State}", source.SourceConnection.ConnectionForPrint,
+                    result == null ? "inherit global" : result.Count == 0 ? "disabled" : $"{result.Count} counter(s)");
+            }
+            else
+            {
+                config.PerfmonCounters = result!; // never null on the global path (--PerfmonInherit is blocked above)
+                Log.Information("Global perfmon counter list set to {State}",
+                    result!.Count == 0 ? "disabled" : $"{result.Count} counter(s)");
+            }
+
+            SaveConfig(config, o);
+        }
+
         public static void SaveConfig(CollectionConfig config, Options o)
         {
             Log.Information("Saving config");

--- a/DBADashConfig/Options.cs
+++ b/DBADashConfig/Options.cs
@@ -27,7 +27,8 @@ Decrypt - Decrypt the config file. --DecryptionPassword can be used if required.
 SetConfigFileBackupRetention - Specify how long to keep config file backups. --RetentionDays
 PopulateConnectionID - Add ConnectionID to source connections without a ConnectionID
 PopulateConnectionID2 - Add ConnectionID to source connections without a ConnectionID.  If connection fails, set ConnectionID based on Data Source in connection string.
-SetAWS - Set AWS Credentials")]
+SetAWS - Set AWS Credentials
+SetPerfmonCounters - Set OS-level (perfmon) counters.  Sets the global list, or a per-connection override when -c/--ConnectionID is supplied.  Use --PerfmonDefaults, --PerfmonCounters, --PerfmonClear and/or --PerfmonInherit.")]
         public CommandLineActionOption Option { get; set; }
 
         [Option('r', "Replace", Required = false, HelpText = "Option to replace the existing connection if it already exists", Default = false)]
@@ -143,6 +144,18 @@ SetAWS - Set AWS Credentials")]
         [Option("AWSProfile", Required = false, HelpText = "Use with -a SetAWS to set AWS Profile for S3 storage")]
         public string? AWSProfile { get; set; }
 
+        [Option("PerfmonDefaults", Default = false, Required = false, HelpText = "Use with -a SetPerfmonCounters to enable the curated default OS-level (perfmon) counters.  Can be combined with --PerfmonCounters to add extras on top.")]
+        public bool PerfmonDefaults { get; set; }
+
+        [Option("PerfmonCounters", Required = false, HelpText = "Use with -a SetPerfmonCounters to set specific OS-level (perfmon) counters.  Comma-separated list of WmiClass:WmiProperty[:Instance] e.g. \"Win32_PerfRawData_PerfOS_Processor:PercentProcessorTime:_Total\".  Instance defaults to *.  The counter type is resolved automatically at collection time.")]
+        public string? PerfmonCounters { get; set; }
+
+        [Option("PerfmonClear", Default = false, Required = false, HelpText = "Use with -a SetPerfmonCounters to clear the perfmon counter list.  Global: disables OS-level counter collection.  Per-connection (with -c/--ConnectionID): disables collection for that instance only.")]
+        public bool PerfmonClear { get; set; }
+
+        [Option("PerfmonInherit", Default = false, Required = false, HelpText = "Use with -a SetPerfmonCounters and -c/--ConnectionID to make a connection inherit the global perfmon counter list (removes any per-connection override).")]
+        public bool PerfmonInherit { get; set; }
+
         public enum CommandLineActionOption
         {
             Add,
@@ -166,7 +179,8 @@ SetAWS - Set AWS Credentials")]
             Restore,
             PopulateConnectionID,
             PopulateConnectionID2,
-            SetAWS
+            SetAWS,
+            SetPerfmonCounters
         }
     }
 }

--- a/DBADashConfig/Program.cs
+++ b/DBADashConfig/Program.cs
@@ -144,6 +144,10 @@ public class Program
             case CommandLineActionOption.SetAWS:
                 Helper.SetAWS(config, o);
                 break;
+
+            case CommandLineActionOption.SetPerfmonCounters:
+                await Helper.SetPerfmonCounters(config, o);
+                break;
         }
     }
 }

--- a/DBADashDB/DBADashDB.sqlproj
+++ b/DBADashDB/DBADashDB.sqlproj
@@ -488,14 +488,17 @@
     <Build Include="Storage\PS_DBIOStats_60MIN.sql" />
     <Build Include="Storage\PS_CPU_60MIN.sql" />
     <Build Include="Staging\Tables\PerformanceCounters.sql" />
+    <Build Include="Staging\Tables\PerfmonCounters.sql" />
     <Build Include="dbo\Tables\PerformanceCounters.sql" />
     <Build Include="dbo\Tables\InstanceCounters.sql" />
     <Build Include="dbo\Tables\Counters.sql" />
     <Build Include="dbo\Tables\CounterMapping.sql" />
     <Build Include="dbo\Stored Procedures\PerformanceCounterSummary_Get.sql" />
     <Build Include="dbo\Stored Procedures\PerformanceCounters_Upd.sql" />
+    <Build Include="dbo\Stored Procedures\PerfmonCounters_Upd.sql" />
     <Build Include="dbo\Stored Procedures\PerformanceCounter_Get.sql" />
     <Build Include="dbo\User Defined Types\PerformanceCounters.sql" />
+    <Build Include="dbo\User Defined Types\PerfmonCounters.sql" />
     <Build Include="Storage\PF_PerformanceCounters.sql" />
     <Build Include="Storage\PS_PerformanceCounters.sql" />
     <Build Include="Security\App.sql" />

--- a/DBADashDB/Staging/Tables/PerfmonCounters.sql
+++ b/DBADashDB/Staging/Tables/PerfmonCounters.sql
@@ -1,0 +1,16 @@
+/*
+	Holds the previous raw sample of each perfmon counter per instance, so dbo.PerfmonCounters_Upd
+	can cook rate / timer / average values from the delta across collections.  Dedicated to perfmon
+	(separate from Staging.PerformanceCounters) so the two collections never touch each other's rows.
+*/
+CREATE TABLE [Staging].[PerfmonCounters] (
+    [InstanceID]    INT             NOT NULL,
+    [object_name]   NCHAR (128)     NOT NULL,
+    [counter_name]  NCHAR (128)     NOT NULL,
+    [instance_name] NCHAR (128)     NOT NULL,
+    [cntr_value]    DECIMAL (28, 9) NOT NULL,
+    [cntr_type]     INT             NOT NULL,
+    [timebase]      DECIMAL (28, 9) NOT NULL CONSTRAINT [DF_PerfmonCounters_Staging_timebase] DEFAULT (0),
+    [SnapshotDate]  DATETIME2 (7)   NOT NULL,
+    CONSTRAINT [PK_PerfmonCounters_Staging] PRIMARY KEY CLUSTERED ([InstanceID] ASC, [object_name] ASC, [counter_name] ASC, [instance_name] ASC)
+);

--- a/DBADashDB/dbo/Stored Procedures/PerfmonCounters_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/PerfmonCounters_Upd.sql
@@ -1,0 +1,201 @@
+/*
+	Imports OS-level (perfmon) performance counters collected from the host via WMI - the RAW
+	(Win32_PerfRawData_*) classes.  Raw accumulators are cooked here over the collection interval
+	(delta vs the previous sample in Staging.PerfmonCounters), which is more accurate than the cooked
+	Win32_PerfFormattedData classes (true interval average vs an aliased point sample) and preserves
+	fractional values such as disk latency.
+
+	The collector normalises each WMI CounterType to one of the types handled below and, for
+	fraction / average-timer counters, emits an extra "<counter> Base" row (cntr_type 1073939712):
+
+	  65792      PERF_COUNTER_LARGE_RAWCOUNT   -> value as-is (queue lengths etc.)
+	  272696576  PERF_COUNTER_BULK_COUNT       -> (Δvalue)/Δseconds (rates)
+	  537003264  PERF_LARGE_RAW_FRACTION       -> value*100/base (% usage)
+	  542180608  PERF_100NSEC_TIMER            -> 100*Δvalue/Δtimebase (% privileged time)
+	  558957824  PERF_100NSEC_TIMER_INV        -> 100*(1 - Δvalue/Δtimebase) (% processor time)
+	                                              (timebase = the counter's Timestamp_Sys100NS, 100ns units)
+	  805438464  PERF_AVERAGE_TIMER            -> (Δvalue/1e7)/Δbase, value pre-scaled to 100ns units
+	                                              by the collector (disk latency, seconds)
+
+	Values land in the shared dbo.PerformanceCounters / _60MIN tables (unified reporting).  Collection
+	dates are recorded under a distinct reference.
+*/
+CREATE PROC dbo.PerfmonCounters_Upd (
+    @InstanceID INT,
+    @SnapshotDate DATETIME2 (7),
+    @PerfmonCounters dbo.PerfmonCounters READONLY
+)
+AS
+SET XACT_ABORT ON;
+DECLARE @Ref NVARCHAR(128) = N'PerfmonCounters';
+
+/* Metric counter types (i.e. not the base rows) */
+DECLARE @MetricTypes TABLE (cntr_type INT PRIMARY KEY);
+INSERT INTO @MetricTypes VALUES (65792), (272696576), (537003264), (542180608), (558957824), (805438464);
+
+/* --- Register any new counters / instance associations (serialised via app lock; see
+       PerformanceCounters_Upd for the rationale).  Base rows are excluded - they are not metrics. --- */
+/* Including WmiClass / WmiProperty in the EXCEPT means this fires both for a brand new counter and for an
+   existing row whose WMI identity doesn't yet match (e.g. NULL on rows created before the columns existed) -
+   so no separate probe is needed.  Read-only on the hot path; the writes below only run when this is true. */
+IF EXISTS (
+        SELECT RTRIM(object_name), RTRIM(counter_name), RTRIM(instance_name), WmiClass, WmiProperty
+        FROM @PerfmonCounters WHERE cntr_type <> 1073939712
+        EXCEPT
+        SELECT object_name, counter_name, instance_name, WmiClass, WmiProperty FROM dbo.Counters
+    )
+    OR EXISTS (
+        SELECT @InstanceID, C.CounterID
+        FROM @PerfmonCounters pc
+        JOIN dbo.Counters C ON C.counter_name = pc.counter_name AND C.instance_name = pc.instance_name AND C.object_name = pc.object_name
+        WHERE pc.cntr_type <> 1073939712
+        EXCEPT
+        SELECT InstanceID, CounterID FROM dbo.InstanceCounters WHERE InstanceID = @InstanceID
+    )
+BEGIN
+    DECLARE @LockResult INT;
+    BEGIN TRAN;
+        EXEC @LockResult = sp_getapplock @Resource = 'DBADash_CounterRegistration',
+                                         @LockMode = 'Exclusive', @LockOwner = 'Transaction', @LockTimeout = 30000;
+        IF @LockResult >= 0
+        BEGIN
+            /* New counters carry their stable WMI identity immediately (deduped by name only, so a differing
+               WMI value never creates a duplicate-name row). */
+            INSERT INTO dbo.Counters (object_name, counter_name, instance_name, WmiClass, WmiProperty)
+            SELECT DISTINCT RTRIM(pc.object_name), RTRIM(pc.counter_name), RTRIM(pc.instance_name), pc.WmiClass, pc.WmiProperty
+            FROM @PerfmonCounters pc
+            WHERE pc.cntr_type <> 1073939712
+            AND NOT EXISTS (SELECT 1 FROM dbo.Counters C
+                            WHERE C.object_name = RTRIM(pc.object_name)
+                              AND C.counter_name = RTRIM(pc.counter_name)
+                              AND C.instance_name = RTRIM(pc.instance_name));
+
+            INSERT INTO dbo.InstanceCounters (InstanceID, CounterID)
+            SELECT @InstanceID, C.CounterID
+            FROM @PerfmonCounters pc
+            JOIN dbo.Counters C ON C.counter_name = pc.counter_name AND C.instance_name = pc.instance_name AND C.object_name = pc.object_name
+            WHERE pc.cntr_type <> 1073939712
+            EXCEPT
+            SELECT InstanceID, CounterID FROM dbo.InstanceCounters WHERE InstanceID = @InstanceID;
+
+            /* Backfill / repair the WMI identity on rows the INSERT didn't create: those that predate the
+               WmiClass / WmiProperty columns (NULL), or any drift.  Matches what the EXCEPT guard above
+               detects, so once resolved the guard stops firing.  The app keys off this identity rather than
+               the (object_name, counter_name) display names. */
+            UPDATE C
+                SET C.WmiClass = pc.WmiClass, C.WmiProperty = pc.WmiProperty
+            FROM dbo.Counters C
+            JOIN @PerfmonCounters pc ON C.object_name = RTRIM(pc.object_name)
+                                    AND C.counter_name = RTRIM(pc.counter_name)
+                                    AND C.instance_name = RTRIM(pc.instance_name)
+            WHERE pc.cntr_type <> 1073939712 AND pc.WmiClass IS NOT NULL
+            AND (C.WmiClass IS NULL OR C.WmiProperty IS NULL OR C.WmiClass <> pc.WmiClass OR C.WmiProperty <> pc.WmiProperty);
+        END
+    COMMIT;
+END
+
+UPDATE IC
+SET IC.UpdatedDate = @SnapshotDate
+FROM dbo.InstanceCounters IC
+WHERE IC.InstanceID = @InstanceID
+AND EXISTS (SELECT 1 FROM @PerfmonCounters pc
+            JOIN dbo.Counters C ON C.counter_name = pc.counter_name AND C.instance_name = pc.instance_name AND C.object_name = pc.object_name
+            WHERE C.CounterID = IC.CounterID AND pc.cntr_type <> 1073939712);
+
+/* --- Cook the values from the current sample (B) and the previous sample (A = Staging) --- */
+DECLARE @PC TABLE (
+    InstanceID     INT           NOT NULL,
+    CounterID      INT           NOT NULL,
+    SnapshotDate   DATETIME2 (2) NOT NULL,
+    SnapshotDate60 DATETIME2 (2) NOT NULL,
+    Value          DECIMAL (28, 9) NULL,
+    PRIMARY KEY (InstanceID, CounterID, SnapshotDate)
+);
+
+INSERT INTO @PC (InstanceID, CounterID, SnapshotDate, SnapshotDate60, Value)
+SELECT @InstanceID,
+       C.CounterID,
+       B.SnapshotDate,
+       DG.DateGroup,
+       CASE
+           WHEN B.cntr_type = 65792
+               THEN B.cntr_value
+           WHEN B.cntr_type = 272696576 AND B.cntr_value >= A.cntr_value
+               THEN (B.cntr_value - A.cntr_value) / NULLIF(DATEDIFF_BIG(ms, A.SnapshotDate, B.SnapshotDate) / 1000.0, 0)
+           WHEN B.cntr_type = 537003264
+               THEN B.cntr_value * 100.0 / NULLIF(Bbase.cntr_value, 0)
+           WHEN B.cntr_type = 542180608 AND B.cntr_value >= A.cntr_value
+               THEN 100.0 * (B.cntr_value - A.cntr_value) / NULLIF(B.timebase - A.timebase, 0)
+           WHEN B.cntr_type = 558957824 AND B.cntr_value >= A.cntr_value
+               THEN 100.0 * (1 - (B.cntr_value - A.cntr_value) / NULLIF(B.timebase - A.timebase, 0))
+           WHEN B.cntr_type = 805438464 AND B.cntr_value >= A.cntr_value AND Bbase.cntr_value >= Abase.cntr_value
+               THEN ((B.cntr_value - A.cntr_value) / 10000000.0) / NULLIF(Bbase.cntr_value - Abase.cntr_value, 0)
+           ELSE NULL
+       END AS Value
+FROM @PerfmonCounters B
+CROSS APPLY dbo.DateGroupingMins(B.SnapshotDate, 60) DG
+JOIN dbo.Counters C ON C.counter_name = B.counter_name AND C.object_name = B.object_name AND C.instance_name = B.instance_name
+/* previous sample of this counter */
+LEFT JOIN Staging.PerfmonCounters A ON A.InstanceID = @InstanceID
+                                    AND A.object_name = B.object_name AND A.counter_name = B.counter_name AND A.instance_name = B.instance_name
+                                    AND A.cntr_type = B.cntr_type AND A.SnapshotDate < B.SnapshotDate
+/* current base (fraction / average-timer) */
+LEFT JOIN @PerfmonCounters Bbase ON Bbase.object_name = B.object_name AND Bbase.instance_name = B.instance_name
+                                 AND Bbase.counter_name = RTRIM(B.counter_name) + ' Base' AND Bbase.cntr_type = 1073939712
+/* previous base (average-timer) */
+LEFT JOIN Staging.PerfmonCounters Abase ON Abase.InstanceID = @InstanceID
+                                        AND Abase.object_name = B.object_name AND Abase.instance_name = B.instance_name
+                                        AND Abase.counter_name = RTRIM(B.counter_name) + ' Base' AND Abase.cntr_type = 1073939712
+                                        AND Abase.SnapshotDate < B.SnapshotDate
+WHERE B.cntr_type IN (SELECT cntr_type FROM @MetricTypes)
+AND NOT EXISTS (SELECT 1 FROM dbo.PerformanceCounters PC
+                WHERE PC.SnapshotDate = CAST(B.SnapshotDate AS DATETIME2(2)) AND PC.InstanceID = @InstanceID AND PC.CounterID = C.CounterID)
+AND (DATEDIFF(mi, A.SnapshotDate, B.SnapshotDate) < 1440 /* skip if the gap is more than a day */
+     OR A.SnapshotDate IS NULL /* first sample: only produces a value for types that don't need a delta (65792 / fraction) */
+    );
+
+BEGIN TRAN;
+
+INSERT INTO dbo.PerformanceCounters (InstanceID, CounterID, SnapshotDate, Value)
+SELECT InstanceID, CounterID, SnapshotDate, Value FROM @PC WHERE Value IS NOT NULL;
+
+/* 60 minute rollup (mirrors PerformanceCounters_Upd) */
+WITH T AS (
+    SELECT InstanceID, CounterID, SnapshotDate60,
+           SUM(Value) AS Value_Total, MIN(Value) AS Value_Min, MAX(Value) AS Value_Max, COUNT(*) AS SampleCount
+    FROM @PC WHERE Value IS NOT NULL
+    GROUP BY InstanceID, CounterID, SnapshotDate60
+)
+UPDATE PC60
+    SET PC60.Value_Total += T.Value_Total,
+        PC60.Value_Min = CASE WHEN T.Value_Min < PC60.Value_Min THEN T.Value_Min ELSE PC60.Value_Min END,
+        PC60.Value_Max = CASE WHEN T.Value_Max > PC60.Value_Max THEN T.Value_Max ELSE PC60.Value_Max END,
+        PC60.SampleCount += T.SampleCount
+FROM dbo.PerformanceCounters_60MIN PC60
+JOIN T ON T.InstanceID = PC60.InstanceID AND T.CounterID = PC60.CounterID AND T.SnapshotDate60 = PC60.SnapshotDate;
+
+INSERT INTO dbo.PerformanceCounters_60MIN (InstanceID, CounterID, SnapshotDate, Value_Total, Value_Min, Value_Max, SampleCount)
+SELECT InstanceID, CounterID, SnapshotDate60, SUM(Value), MIN(Value), MAX(Value), COUNT(*)
+FROM @PC PC
+WHERE Value IS NOT NULL
+AND NOT EXISTS (SELECT 1 FROM dbo.PerformanceCounters_60MIN PC60
+               WHERE PC60.InstanceID = PC.InstanceID AND PC60.CounterID = PC.CounterID AND PC60.SnapshotDate = PC.SnapshotDate60)
+GROUP BY InstanceID, CounterID, SnapshotDate60;
+
+/* Refresh this instance's previous-sample staging (own table, so a full delete is safe).
+   Only rows a later sample needs as its "previous" are kept: rate / timer metrics and the base rows
+   average-timer cooking reads (Abase).  Skipped as they never need a prior sample:
+     - 65792     RAWCOUNT  - stored as-is
+     - 537003264 fraction  - cooked from the current sample only (value*100/base)
+   Fraction base rows share the base marker (1073939712) with average-timer bases and can't be told
+   apart by type, so all base rows are retained - harmless. */
+DELETE Staging.PerfmonCounters WHERE InstanceID = @InstanceID;
+
+INSERT INTO Staging.PerfmonCounters (InstanceID, SnapshotDate, object_name, counter_name, instance_name, cntr_value, cntr_type, timebase)
+SELECT @InstanceID, SnapshotDate, object_name, counter_name, instance_name, cntr_value, cntr_type, timebase
+FROM @PerfmonCounters
+WHERE cntr_type NOT IN (65792, 537003264);
+
+COMMIT;
+
+EXEC dbo.CollectionDates_Upd @InstanceID = @InstanceID, @Reference = @Ref, @SnapshotDate = @SnapshotDate;

--- a/DBADashDB/dbo/Stored Procedures/PerformanceCounters_Upd.sql
+++ b/DBADashDB/dbo/Stored Procedures/PerformanceCounters_Upd.sql
@@ -8,37 +8,80 @@ AS
 SET XACT_ABORT ON
 DECLARE @Ref NVARCHAR(128)='PerformanceCounters'
 
-/* Insert any new performance counters into dbo.Counters table */
-INSERT INTO dbo.Counters
-(
-    object_name,
-    counter_name,
-    instance_name
-)
-SELECT	RTRIM(object_name),
-		RTRIM(counter_name),
-		RTRIM(instance_name) 
-FROM @PerformanceCounters
-WHERE cntr_type <> 1073939712 /* PERF_LARGE_RAW_BASE.  Excluding this counter as it's just used in calculations for another counter */
-EXCEPT 
-SELECT	object_name,
-		counter_name,
-		instance_name 
-FROM dbo.Counters WITH(UPDLOCK);
+/* Register any new performance counters (dbo.Counters) and instance associations (dbo.InstanceCounters).
 
-/* Associate performance counters collected with this SQL Instance */
-INSERT INTO dbo.InstanceCounters(InstanceID,CounterID)
-SELECT	@InstanceID,
-		C.CounterID
-FROM @PerformanceCounters pc 
-JOIN dbo.Counters C ON C.counter_name = pc.counter_name 
-					AND C.instance_name = pc.instance_name
-					AND C.object_name = pc.object_name
-EXCEPT 
-SELECT	InstanceID,
-		CounterID 
-FROM dbo.InstanceCounters
-WHERE InstanceID =@InstanceID;
+   Concurrency: dbo.Counters is a small shared natural-key table.  Registering a brand-new counter is a
+   check-then-insert, which two concurrent imports can race:
+     - with no guard they both insert -> 2601 duplicate key on IX_Counters_object_name_counter_name_instance_name;
+     - with UPDLOCK/HOLDLOCK range locks they instead deadlock (1205) on overlapping key ranges.
+   So we serialise registration with an application lock (a single named mutex) - concurrent registrants
+   queue instead of racing, and there is no cross-key cycle to deadlock on.
+
+   Fast path: cheap lock-free existence checks first.  Steady-state imports register nothing, so they
+   take neither the app lock nor any range locks.  We only enter the serialised block when there is
+   actually something new to register (first sighting of a counter / first association for an instance). */
+IF EXISTS (
+		SELECT	RTRIM(object_name), RTRIM(counter_name), RTRIM(instance_name)
+		FROM @PerformanceCounters
+		WHERE cntr_type <> 1073939712 /* PERF_LARGE_RAW_BASE */
+		EXCEPT
+		SELECT	object_name, counter_name, instance_name
+		FROM dbo.Counters
+	)
+	OR EXISTS (
+		SELECT	@InstanceID, C.CounterID
+		FROM @PerformanceCounters pc
+		JOIN dbo.Counters C ON C.counter_name = pc.counter_name
+							AND C.instance_name = pc.instance_name
+							AND C.object_name = pc.object_name
+		EXCEPT
+		SELECT	InstanceID, CounterID
+		FROM dbo.InstanceCounters
+		WHERE InstanceID = @InstanceID
+	)
+BEGIN
+	DECLARE @LockResult INT;
+	BEGIN TRAN
+		EXEC @LockResult = sp_getapplock @Resource = 'DBADash_CounterRegistration',
+										 @LockMode = 'Exclusive',
+										 @LockOwner = 'Transaction',
+										 @LockTimeout = 30000; /* ms.  On timeout (<0) skip registration this round - it self-heals next import */
+		IF @LockResult >= 0
+		BEGIN
+			/* Insert any new performance counters into dbo.Counters table */
+			INSERT INTO dbo.Counters
+			(
+			    object_name,
+			    counter_name,
+			    instance_name
+			)
+			SELECT	RTRIM(object_name),
+					RTRIM(counter_name),
+					RTRIM(instance_name)
+			FROM @PerformanceCounters
+			WHERE cntr_type <> 1073939712 /* PERF_LARGE_RAW_BASE.  Excluding this counter as it's just used in calculations for another counter */
+			EXCEPT
+			SELECT	object_name,
+					counter_name,
+					instance_name
+			FROM dbo.Counters;
+
+			/* Associate performance counters collected with this SQL Instance */
+			INSERT INTO dbo.InstanceCounters(InstanceID,CounterID)
+			SELECT	@InstanceID,
+					C.CounterID
+			FROM @PerformanceCounters pc
+			JOIN dbo.Counters C ON C.counter_name = pc.counter_name
+								AND C.instance_name = pc.instance_name
+								AND C.object_name = pc.object_name
+			EXCEPT
+			SELECT	InstanceID,
+					CounterID
+			FROM dbo.InstanceCounters
+			WHERE InstanceID =@InstanceID;
+		END
+	COMMIT
+END
 
 /* Update the date of counter last collection for this SQL Instance */
 UPDATE IC 

--- a/DBADashDB/dbo/Tables/Counters.sql
+++ b/DBADashDB/dbo/Tables/Counters.sql
@@ -16,6 +16,11 @@
 	SystemGoodFrom DECIMAL (28, 9)  NULL,
 	SystemGoodTo DECIMAL (28, 9)  NULL,
 	CounterType TINYINT NOT NULL CONSTRAINT DF_Counters_CounterType DEFAULT(1),
+    /* Stable WMI identity for OS-level (perfmon) counters (Win32_PerfRawData_* class / property).  NULL for
+       DMV performance counters.  The (object_name, counter_name) above is a display name that can vary by
+       config, so app features (e.g. a processor-utilization chart) key off this WMI identity instead. */
+    WmiClass NVARCHAR (128) NULL,
+    WmiProperty NVARCHAR (128) NULL,
     CONSTRAINT [PK_Counters] PRIMARY KEY CLUSTERED (CounterID ASC)
 );
 
@@ -24,4 +29,10 @@ GO
 CREATE UNIQUE NONCLUSTERED INDEX IX_Counters_object_name_counter_name_instance_name
     ON dbo.Counters(object_name ASC, counter_name ASC, instance_name ASC)
 INCLUDE(CounterType);
+
+GO
+/* Lookup by stable WMI identity (perfmon counters only). */
+CREATE NONCLUSTERED INDEX IX_Counters_WmiClass_WmiProperty_instance_name
+    ON dbo.Counters(WmiClass ASC, WmiProperty ASC, instance_name ASC)
+    WHERE WmiClass IS NOT NULL;
 

--- a/DBADashDB/dbo/User Defined Types/PerfmonCounters.sql
+++ b/DBADashDB/dbo/User Defined Types/PerfmonCounters.sql
@@ -1,0 +1,21 @@
+/*
+	TVP used to pass OS-level (perfmon) RAW performance counters collected from the host via WMI into
+	dbo.PerfmonCounters_Upd.  Distinct from the DMV performance counters (dbo.PerformanceCounters).
+
+	timebase carries the counter's own Timestamp_Sys100NS (100ns units) for 100ns-timer counters, so
+	their % is cooked against the exact interval WMI sampled over rather than wall-clock time.  0 for
+	other counter types (which don't need it).
+*/
+CREATE TYPE dbo.PerfmonCounters AS TABLE (
+    [SnapshotDate]  DATETIME2 (7)   NOT NULL,
+    [object_name]   NCHAR (128)     NOT NULL,
+    [counter_name]  NCHAR (128)     NOT NULL,
+    [instance_name] NCHAR (128)     NOT NULL,
+    [cntr_value]    DECIMAL (28, 9) NOT NULL,
+    [cntr_type]     INT             NOT NULL DEFAULT (65792),
+    [timebase]      DECIMAL (28, 9) NOT NULL DEFAULT (0),
+    /* Stable WMI identity - persisted on dbo.Counters so the app can key off it rather than the
+       (object_name, counter_name) display names.  Base rows carry the base property here. */
+    [WmiClass]      NVARCHAR (128)  NULL,
+    [WmiProperty]   NVARCHAR (128)  NULL
+);

--- a/DBADashService/WorkItem.cs
+++ b/DBADashService/WorkItem.cs
@@ -113,6 +113,10 @@ namespace DBADashService
 
                     collector.LogInternalPerformanceCounters = config.LogInternalPerformanceCounters;
 
+                    // Tri-state: a non-null per-instance list wins (empty => disabled for this instance);
+                    // null inherits the global list.  Empty overall => nothing collected (no auto-defaults).
+                    collector.PerfmonCounters = Source.PerfmonCounters ?? config.PerfmonCounters ?? new List<PerfmonCounter>();
+
                     using (var op = SerilogTimings.Operation.Begin("Collect {types} from instance {instance} on schedule {schedule} with priority {priority}. Dequeue latency {latency}ms.",
                                string.Join(", ", types.Select(s => s.ToString())),
                                Source.SourceConnection.ConnectionForPrint,

--- a/DBADashServiceConfig/ManagePerfmonCounters.cs
+++ b/DBADashServiceConfig/ManagePerfmonCounters.cs
@@ -1,0 +1,467 @@
+using DBADash;
+using DBADashGUI.Theme;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DBADashServiceConfig
+{
+    /// <summary>
+    /// Picker for OS-level (perfmon) performance counters collected via WMI.  Used for both the global
+    /// counter list (<see cref="CollectionConfig.PerfmonCounters"/>) and per-instance overrides
+    /// (<see cref="DBADashSource.PerfmonCounters"/>).  Available counters are discovered live from a host
+    /// via <see cref="PerfmonCounterDiscovery"/>.
+    /// </summary>
+    public class ManagePerfmonCounters : Form
+    {
+        /// <summary>The list being edited.  Read back after DialogResult.OK.</summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public List<PerfmonCounter> Counters { get; set; } = new();
+
+        /// <summary>Global list, supplied in per-instance mode to enable the "Load global" button.  Null in global mode.</summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public List<PerfmonCounter> GlobalCounters { get; set; }
+
+        /// <summary>Default host to discover counters from (e.g. the instance's computer name).</summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string ComputerName { get; set; }
+
+        private TextBox txtHost;
+        private TextBox txtSearch;
+        private DataGridView dgvAvailable;
+        private DataGridView dgvSelected;
+        private ComboBox cboInstance;
+        private ComboBox cboObjectFilter;
+        private CheckBox chkAllInstances;
+        private Button bttnAdd;
+        private Button bttnGlobal;
+        private Button bttnDefaults;
+        private Button bttnClear;
+        private Button bttnDiscover;
+        private RadioButton rbInherit;
+        private RadioButton rbCustom;
+        private RadioButton rbDisabled;
+        private FlowLayoutPanel pnlMode;
+
+        private DataTable dtAvailable;
+        private DataTable dtSelected;
+        private string lastInstanceClass;
+
+        private enum PerfMode { Inherit, Custom, Disabled }
+
+        private PerfMode lastMode;
+        private List<PerfmonCounter> customWorking; // preserves custom-mode edits across mode switches
+        private bool suppressModeEvents;
+
+        private const string AllObjects = "(All objects)";
+
+        public ManagePerfmonCounters()
+        {
+            Text = "Perfmon Counters";
+            // AutoScaleMode.None stops the form re-scaling (and growing) on the first real layout pass
+            // after Discover populates the grid, which was pushing the top controls off-screen.
+            AutoScaleMode = AutoScaleMode.None;
+            Width = 1000;
+            Height = 700;
+            MinimumSize = new Size(700, 500);
+            StartPosition = FormStartPosition.CenterParent;
+            BuildLayout();
+            Load += ManagePerfmonCounters_Load;
+        }
+
+        private void BuildLayout()
+        {
+            var tlp = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                RowCount = 6,
+                Padding = new Padding(8)
+            };
+            tlp.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+            tlp.RowStyles.Add(new RowStyle(SizeType.AutoSize));          // 0 mode (per-instance only)
+            tlp.RowStyles.Add(new RowStyle(SizeType.AutoSize));          // 1 discover/search
+            tlp.RowStyles.Add(new RowStyle(SizeType.Percent, 50));       // 2 available grid
+            tlp.RowStyles.Add(new RowStyle(SizeType.AutoSize));          // 3 add controls
+            tlp.RowStyles.Add(new RowStyle(SizeType.Percent, 50));       // 4 selected grid
+            tlp.RowStyles.Add(new RowStyle(SizeType.AutoSize));          // 5 buttons
+
+            // Row 0 - mode selector (only shown in per-instance mode; visibility set at Load)
+            pnlMode = new FlowLayoutPanel { Dock = DockStyle.Fill, AutoSize = true, WrapContents = false, Visible = false };
+            rbInherit = new RadioButton { Text = "Inherit global list", AutoSize = true, Margin = new Padding(3, 5, 15, 3) };
+            rbCustom = new RadioButton { Text = "Custom counters", AutoSize = true, Margin = new Padding(3, 5, 15, 3) };
+            rbDisabled = new RadioButton { Text = "Disabled (collect none)", AutoSize = true, Margin = new Padding(3, 5, 3, 3) };
+            rbInherit.CheckedChanged += ModeChanged;
+            rbCustom.CheckedChanged += ModeChanged;
+            rbDisabled.CheckedChanged += ModeChanged;
+            pnlMode.Controls.Add(rbInherit);
+            pnlMode.Controls.Add(rbCustom);
+            pnlMode.Controls.Add(rbDisabled);
+            tlp.Controls.Add(pnlMode, 0, 0);
+
+            // Row 1 - host + discover + search
+            // WrapContents so the row flows onto a second line rather than pushing controls off-screen.
+            var pnlTop = new FlowLayoutPanel { Dock = DockStyle.Fill, AutoSize = true, WrapContents = true };
+            pnlTop.Controls.Add(new Label { Text = "Host:", AutoSize = true, Anchor = AnchorStyles.Left, Margin = new Padding(3, 8, 3, 3) });
+            txtHost = new TextBox { Width = 200, Margin = new Padding(3, 5, 3, 3) };
+            pnlTop.Controls.Add(txtHost);
+            bttnDiscover = new Button { Text = "Discover", AutoSize = true, Margin = new Padding(3, 3, 15, 3) };
+            bttnDiscover.Click += Discover_Click;
+            pnlTop.Controls.Add(bttnDiscover);
+            pnlTop.Controls.Add(new Label { Text = "Object:", AutoSize = true, Anchor = AnchorStyles.Left, Margin = new Padding(3, 8, 3, 3) });
+            cboObjectFilter = new ComboBox { Width = 170, DropDownStyle = ComboBoxStyle.DropDownList, Margin = new Padding(3, 5, 3, 3) };
+            cboObjectFilter.SelectedIndexChanged += (_, _) => ApplyAvailableFilter();
+            pnlTop.Controls.Add(cboObjectFilter);
+            pnlTop.Controls.Add(new Label { Text = "Search:", AutoSize = true, Anchor = AnchorStyles.Left, Margin = new Padding(3, 8, 3, 3) });
+            txtSearch = new TextBox { Width = 180, Margin = new Padding(3, 5, 3, 3) };
+            txtSearch.TextChanged += (_, _) => ApplyAvailableFilter();
+            pnlTop.Controls.Add(txtSearch);
+            tlp.Controls.Add(pnlTop, 0, 1);
+
+            // Row 2 - available counters grid
+            dgvAvailable = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                AutoGenerateColumns = false,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                ReadOnly = true,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = false,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            dgvAvailable.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Object", DataPropertyName = "ObjectName" });
+            dgvAvailable.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Counter", DataPropertyName = "CounterName" });
+            dgvAvailable.SelectionChanged += Available_SelectionChanged;
+            tlp.Controls.Add(dgvAvailable, 0, 2);
+
+            // Row 3 - add controls
+            var pnlAdd = new FlowLayoutPanel { Dock = DockStyle.Fill, AutoSize = true, WrapContents = false };
+            pnlAdd.Controls.Add(new Label { Text = "Instance:", AutoSize = true, Margin = new Padding(3, 8, 3, 3) });
+            cboInstance = new ComboBox { Width = 200, DropDownStyle = ComboBoxStyle.DropDown, Margin = new Padding(3, 5, 3, 3) };
+            pnlAdd.Controls.Add(cboInstance);
+            chkAllInstances = new CheckBox { Text = "All instances (*)", AutoSize = true, Margin = new Padding(3, 7, 3, 3) };
+            chkAllInstances.CheckedChanged += (_, _) => cboInstance.Enabled = !chkAllInstances.Checked;
+            pnlAdd.Controls.Add(chkAllInstances);
+            bttnAdd = new Button { Text = "Add ↓", AutoSize = true, Margin = new Padding(15, 3, 3, 3) };
+            bttnAdd.Click += Add_Click;
+            pnlAdd.Controls.Add(bttnAdd);
+            tlp.Controls.Add(pnlAdd, 0, 3);
+
+            // Row 4 - selected counters grid
+            dgvSelected = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                AutoGenerateColumns = false,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                ReadOnly = true,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            };
+            dgvSelected.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Object", DataPropertyName = "ObjectName" });
+            dgvSelected.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Counter", DataPropertyName = "CounterName" });
+            dgvSelected.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Instance", DataPropertyName = "InstanceName" });
+            dgvSelected.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "WMI Class", DataPropertyName = "WmiClass", AutoSizeMode = DataGridViewAutoSizeColumnMode.None, Width = 220 });
+            dgvSelected.Columns.Add(new DataGridViewButtonColumn { HeaderText = "", Text = "Remove", UseColumnTextForButtonValue = true, Name = "Remove", AutoSizeMode = DataGridViewAutoSizeColumnMode.None, Width = 80 });
+            dgvSelected.CellContentClick += Selected_CellContentClick;
+            tlp.Controls.Add(dgvSelected, 0, 4);
+
+            // Row 5 - buttons
+            var pnlButtons = new FlowLayoutPanel { Dock = DockStyle.Fill, AutoSize = true, FlowDirection = FlowDirection.RightToLeft };
+            var bttnCancel = new Button { Text = "Cancel", AutoSize = true, Margin = new Padding(3) };
+            bttnCancel.Click += (_, _) => DialogResult = DialogResult.Cancel;
+            pnlButtons.Controls.Add(bttnCancel);
+            var bttnSave = new Button { Text = "Save", AutoSize = true, Margin = new Padding(3) };
+            bttnSave.Click += Save_Click;
+            pnlButtons.Controls.Add(bttnSave);
+            bttnDefaults = new Button { Text = "Load defaults", AutoSize = true, Margin = new Padding(3) };
+            bttnDefaults.Click += (_, _) => AddRange(PerfmonCounter.DefaultCounters());
+            pnlButtons.Controls.Add(bttnDefaults);
+            bttnClear = new Button { Text = "Clear all", AutoSize = true, Margin = new Padding(3) };
+            bttnClear.Click += (_, _) => dtSelected.Clear();
+            pnlButtons.Controls.Add(bttnClear);
+            // Visibility set at Load, since GlobalCounters is assigned by the caller after construction.
+            bttnGlobal = new Button { Text = "Load global", AutoSize = true, Margin = new Padding(3), Visible = false };
+            bttnGlobal.Click += (_, _) => AddRange(GlobalCounters ?? new List<PerfmonCounter>());
+            pnlButtons.Controls.Add(bttnGlobal);
+            tlp.Controls.Add(pnlButtons, 0, 5);
+
+            Controls.Add(tlp);
+            this.ApplyTheme();
+        }
+
+        private void ManagePerfmonCounters_Load(object sender, EventArgs e)
+        {
+            txtHost.Text = ComputerName ?? string.Empty;
+            var perInstance = GlobalCounters != null;
+            pnlMode.Visible = perInstance;
+            bttnGlobal.Visible = perInstance;
+
+            dtSelected = BuildSelectedTable();
+            dgvSelected.DataSource = new DataView(dtSelected);
+
+            // Remember any originally-specified custom counters as the base for Custom mode.
+            customWorking = Counters is { Count: > 0 } ? new List<PerfmonCounter>(Counters) : null;
+
+            if (perInstance)
+            {
+                // null=inherit, empty=disabled, populated=custom.  Set the radio without firing the
+                // transition handler, then seed the grid for the initial mode.
+                lastMode = Counters == null ? PerfMode.Inherit
+                    : Counters.Count == 0 ? PerfMode.Disabled
+                    : PerfMode.Custom;
+                suppressModeEvents = true;
+                (lastMode == PerfMode.Inherit ? rbInherit : lastMode == PerfMode.Disabled ? rbDisabled : rbCustom).Checked = true;
+                suppressModeEvents = false;
+                SeedGridForMode(lastMode);
+            }
+            else
+            {
+                LoadGrid(Counters); // global mode: edit the global list directly
+            }
+            UpdateModeUI();
+        }
+
+        private void ModeChanged(object sender, EventArgs e)
+        {
+            if (suppressModeEvents) return;
+            if (sender is RadioButton { Checked: false }) return; // act only on the newly-selected radio
+            var newMode = CurrentMode();
+            if (newMode == lastMode) return;
+            if (lastMode == PerfMode.Custom) customWorking = ExtractGrid(); // preserve edits before overwriting
+            lastMode = newMode;
+            SeedGridForMode(newMode);
+            UpdateModeUI();
+        }
+
+        private PerfMode CurrentMode() =>
+            rbCustom.Checked ? PerfMode.Custom : rbDisabled.Checked ? PerfMode.Disabled : PerfMode.Inherit;
+
+        private void SeedGridForMode(PerfMode mode)
+        {
+            switch (mode)
+            {
+                case PerfMode.Inherit: LoadGrid(GlobalCounters); break;                    // show the global list
+                case PerfMode.Disabled: LoadGrid(null); break;                             // clear the grid
+                case PerfMode.Custom: LoadGrid(customWorking ?? GlobalCounters); break;    // custom, else global base
+            }
+        }
+
+        private void LoadGrid(List<PerfmonCounter> counters)
+        {
+            dtSelected.Clear();
+            foreach (var c in counters ?? new List<PerfmonCounter>())
+            {
+                AddSelectedRow(c);
+            }
+        }
+
+        private List<PerfmonCounter> ExtractGrid() =>
+            dtSelected.Rows.Cast<DataRow>()
+                .Where(r => r.RowState != DataRowState.Deleted)
+                .Select(r => new PerfmonCounter
+                {
+                    ObjectName = (string)r["ObjectName"],
+                    CounterName = (string)r["CounterName"],
+                    InstanceName = (string)r["InstanceName"],
+                    WmiClass = r["WmiClass"] == DBNull.Value ? null : (string)r["WmiClass"],
+                    WmiProperty = r["WmiProperty"] == DBNull.Value ? null : (string)r["WmiProperty"],
+                    CounterType = r["CounterType"] == DBNull.Value ? 0 : (int)r["CounterType"],
+                    BaseWmiProperty = r["BaseWmiProperty"] == DBNull.Value ? null : (string)r["BaseWmiProperty"]
+                })
+                .ToList();
+
+        /// <summary>Per-instance: only "Custom" is editable; global mode is always editable.</summary>
+        private void UpdateModeUI()
+        {
+            var editable = !pnlMode.Visible || rbCustom.Checked;
+            foreach (var ctl in new Control[]
+                     { txtHost, bttnDiscover, cboObjectFilter, txtSearch, dgvAvailable, cboInstance,
+                       chkAllInstances, bttnAdd, dgvSelected, bttnDefaults, bttnClear, bttnGlobal })
+            {
+                if (ctl != null) ctl.Enabled = editable;
+            }
+        }
+
+        private static DataTable BuildSelectedTable()
+        {
+            var dt = new DataTable("Selected");
+            dt.Columns.Add("ObjectName", typeof(string));
+            dt.Columns.Add("CounterName", typeof(string));
+            dt.Columns.Add("InstanceName", typeof(string));
+            dt.Columns.Add("WmiClass", typeof(string));
+            dt.Columns.Add("WmiProperty", typeof(string));
+            dt.Columns.Add("CounterType", typeof(int));      // persisted so collection needs no schema lookup
+            dt.Columns.Add("BaseWmiProperty", typeof(string));
+            return dt;
+        }
+
+        private void AddSelectedRow(PerfmonCounter c)
+        {
+            // Normalise null -> "*" once, so the existence check and the stored row agree.  A null
+            // InstanceName (e.g. hand-edited config) checked against an already-stored "*" would otherwise
+            // miss and add a duplicate row.
+            var instance = c.InstanceName ?? "*";
+            if (SelectedExists(c.EffectiveObjectName, c.EffectiveCounterName, instance)) return;
+            dtSelected.Rows.Add(c.EffectiveObjectName, c.EffectiveCounterName, instance, c.WmiClass, c.WmiProperty, c.CounterType, c.BaseWmiProperty);
+        }
+
+        private bool SelectedExists(string objectName, string counterName, string instanceName)
+        {
+            return dtSelected.Rows.Cast<DataRow>().Any(r =>
+                string.Equals((string)r["ObjectName"], objectName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals((string)r["CounterName"], counterName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals((string)r["InstanceName"], instanceName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private void AddRange(IEnumerable<PerfmonCounter> counters)
+        {
+            var added = 0;
+            foreach (var c in counters)
+            {
+                if (SelectedExists(c.EffectiveObjectName, c.EffectiveCounterName, c.InstanceName ?? "*")) continue;
+                AddSelectedRow(c);
+                added++;
+            }
+            MessageBox.Show($"{added} counter(s) added", "Perfmon Counters", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private async void Discover_Click(object sender, EventArgs e)
+        {
+            var host = txtHost.Text.Trim();
+            if (string.IsNullOrEmpty(host))
+            {
+                MessageBox.Show("Enter a host name to discover counters from.", "Discover", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            // Disable the button as the busy indicator - deliberately no wait cursor, so a slow/hung
+            // WMI call (bounded to 30s by PerfmonCounterDiscovery) can never leave the form's cursor stuck.
+            bttnDiscover.Enabled = false;
+            var originalText = bttnDiscover.Text;
+            bttnDiscover.Text = "Discovering…";
+            try
+            {
+                var classes = await Task.Run(() => PerfmonCounterDiscovery.DiscoverClasses(host));
+                dtAvailable = new DataTable("Available");
+                dtAvailable.Columns.Add("ObjectName", typeof(string));
+                dtAvailable.Columns.Add("CounterName", typeof(string));
+                dtAvailable.Columns.Add("WmiClass", typeof(string));
+                dtAvailable.Columns.Add("WmiProperty", typeof(string));
+                dtAvailable.Columns.Add("CounterType", typeof(int));
+                dtAvailable.Columns.Add("BaseWmiProperty", typeof(string));
+                foreach (var cls in classes)
+                {
+                    foreach (var counter in cls.Counters)
+                    {
+                        dtAvailable.Rows.Add(cls.ObjectName, counter.WmiProperty, cls.WmiClass, counter.WmiProperty, counter.CounterType, counter.BaseWmiProperty);
+                    }
+                }
+                dgvAvailable.DataSource = new DataView(dtAvailable);
+
+                var objects = classes.Select(c => c.ObjectName).Distinct().OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
+                objects.Insert(0, AllObjects);
+                cboObjectFilter.DataSource = objects;
+            }
+            catch (Exception ex)
+            {
+                CommonShared.ShowExceptionDialog(ex, $"Error discovering counters on '{host}'.  Check the host name and that WMI is accessible.");
+            }
+            finally
+            {
+                bttnDiscover.Text = originalText;
+                bttnDiscover.Enabled = true;
+            }
+        }
+
+        private void ApplyAvailableFilter()
+        {
+            if (dgvAvailable.DataSource is not DataView dv) return;
+            var filters = new List<string>();
+            var search = txtSearch.Text.Replace("'", "''");
+            if (!string.IsNullOrEmpty(search))
+            {
+                filters.Add($"(ObjectName LIKE '*{search}*' OR CounterName LIKE '*{search}*')");
+            }
+            if (cboObjectFilter.SelectedItem is string obj && obj != AllObjects)
+            {
+                filters.Add($"ObjectName = '{obj.Replace("'", "''")}'");
+            }
+            try
+            {
+                dv.RowFilter = string.Join(" AND ", filters);
+            }
+            catch (Exception ex)
+            {
+                CommonShared.ShowExceptionDialog(ex, "Error setting filter");
+            }
+        }
+
+        private async void Available_SelectionChanged(object sender, EventArgs e)
+        {
+            if (dgvAvailable.SelectedRows.Count == 0 || dgvAvailable.SelectedRows[0].DataBoundItem is not DataRowView drv) return;
+            var wmiClass = (string)drv.Row["WmiClass"];
+            if (wmiClass == lastInstanceClass) return; // avoid re-querying WMI on every row within the same class
+            lastInstanceClass = wmiClass;
+            var host = txtHost.Text.Trim();
+            if (string.IsNullOrEmpty(host)) return;
+            // Instance list is a convenience only (the instance can be typed), so this must never drive
+            // the wait cursor or block the UI - if the WMI query is slow/hangs the combo just stays as-is.
+            try
+            {
+                var instances = await Task.Run(() => PerfmonCounterDiscovery.DiscoverInstances(host, wmiClass));
+                if (wmiClass != lastInstanceClass) return; // selection moved on while we were querying - don't clobber the newer list
+                cboInstance.DataSource = instances;
+            }
+            catch
+            {
+                // Non-fatal: leave the combo empty and let the user type the instance (or use All instances).
+                cboInstance.DataSource = null;
+            }
+        }
+
+        private void Add_Click(object sender, EventArgs e)
+        {
+            if (dgvAvailable.SelectedRows.Count == 0 || dgvAvailable.SelectedRows[0].DataBoundItem is not DataRowView drv)
+            {
+                MessageBox.Show("Select a counter to add.", "Add", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            var instance = chkAllInstances.Checked ? "*" : (cboInstance.Text ?? string.Empty);
+            var objectName = (string)drv.Row["ObjectName"];
+            var counterName = (string)drv.Row["CounterName"];
+            if (SelectedExists(objectName, counterName, instance))
+            {
+                MessageBox.Show("The counter already exists in the selection.", "Counter exists", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            dtSelected.Rows.Add(objectName, counterName, instance, (string)drv.Row["WmiClass"], (string)drv.Row["WmiProperty"], drv.Row["CounterType"], drv.Row["BaseWmiProperty"]);
+        }
+
+        private void Selected_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0) return;
+            if (dgvSelected.Columns[e.ColumnIndex].Name == "Remove")
+            {
+                var drv = (DataRowView)dgvSelected.Rows[e.RowIndex].DataBoundItem;
+                drv.Row.Delete();
+            }
+        }
+
+        private void Save_Click(object sender, EventArgs e)
+        {
+            if (pnlMode.Visible) // per-instance tri-state
+            {
+                if (rbInherit.Checked) { Counters = null; DialogResult = DialogResult.OK; return; }        // inherit global
+                if (rbDisabled.Checked) { Counters = new List<PerfmonCounter>(); DialogResult = DialogResult.OK; return; } // collect none
+            }
+            Counters = ExtractGrid();
+            DialogResult = DialogResult.OK;
+        }
+    }
+}

--- a/DBADashServiceConfig/ServiceConfig.cs
+++ b/DBADashServiceConfig/ServiceConfig.cs
@@ -712,6 +712,13 @@ namespace DBADashServiceConfig
             });
             dgvConnections.Columns.Add(new DataGridViewLinkColumn()
             {
+                Name = "PerfmonCounters",
+                HeaderText = "Perfmon Counters",
+                Text = "View/Edit",
+                LinkColor = DashColors.LinkColor
+            });
+            dgvConnections.Columns.Add(new DataGridViewLinkColumn()
+            {
                 Name = "Edit",
                 HeaderText = "Copy Connection",
                 Text = "Copy",
@@ -768,6 +775,7 @@ namespace DBADashServiceConfig
             dgvConnections.ApplyTheme();
             _ = Task.Run(AutoRefreshServiceStatus);
             UpdatePerformanceCountersLabel();
+            AddPerfmonCountersButton();
             CheckWriteAccessToConfig();
         }
 
@@ -1788,7 +1796,7 @@ namespace DBADashServiceConfig
             RefreshEncryption();
         }
 
-        private void DgvConnections_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        private async void DgvConnections_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
             if (e.RowIndex >= 0 && e.ColumnIndex == dgvConnections.Columns["Delete"].Index)
             {
@@ -1864,6 +1872,38 @@ namespace DBADashServiceConfig
                 {
                     MessageBox.Show("Custom collections are only available for SQL connections", "Custom Collections",
                         MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+            else if (e.RowIndex >= 0 && e.ColumnIndex == dgvConnections.Columns["PerfmonCounters"].Index)
+            {
+                var src = (DBADashSource)dgvConnections.Rows[e.RowIndex].DataBoundItem;
+                if (src.SourceConnection.Type != ConnectionType.SQL)
+                {
+                    MessageBox.Show("Perfmon counters are only available for SQL connections", "Perfmon Counters",
+                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+                else if (src.NoWMI)
+                {
+                    MessageBox.Show("Perfmon counter collection requires WMI, which is disabled for this connection (NoWMI).",
+                        "WMI disabled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+                else
+                {
+                    // Resolve the WMI host without blocking the UI thread - GetInstanceHostAsync queries
+                    // the instance (up to 5s) and must not freeze the config window.
+                    var host = await GetInstanceHostAsync(src.SourceConnection);
+                    var frm = new ManagePerfmonCounters()
+                    {
+                        // Preserve tri-state: null=inherit, empty=disabled, populated=custom.
+                        Counters = src.PerfmonCounters == null ? null : new List<PerfmonCounter>(src.PerfmonCounters),
+                        GlobalCounters = collectionConfig.PerfmonCounters ?? new List<PerfmonCounter>(),
+                        ComputerName = host
+                    };
+                    if (frm.ShowDialog() == DialogResult.OK)
+                    {
+                        src.PerfmonCounters = frm.Counters; // null=inherit, empty=disabled, populated=custom
+                        setDgv();
+                    }
                 }
             }
 
@@ -2043,6 +2083,21 @@ namespace DBADashServiceConfig
                         src.CustomCollections == null || src.CustomCollections.Keys.Count == 0
                             ? "Add Collection"
                             : string.Join(", ", src.CustomCollections.Keys.OrderBy(key => key));
+                    var perfmonCell = (DataGridViewLinkCell)dgvConnections.Rows[i].Cells["PerfmonCounters"];
+                    if (src.NoWMI)
+                    {
+                        perfmonCell.Value = "WMI disabled";
+                        perfmonCell.LinkColor = DashColors.NotApplicable;
+                        perfmonCell.ActiveLinkColor = DashColors.NotApplicable;
+                    }
+                    else
+                    {
+                        perfmonCell.Value = src.PerfmonCounters == null ? "Inherit"     // use global list
+                            : src.PerfmonCounters.Count == 0 ? "Disabled"               // collect none
+                            : $"Custom ({src.PerfmonCounters.Count})";
+                        perfmonCell.LinkColor = DashColors.LinkColor;
+                        perfmonCell.ActiveLinkColor = DashColors.LinkColor;
+                    }
                 }
                 var row = dgvConnections.Rows[i];
                 if (hasStatus)
@@ -2736,6 +2791,77 @@ namespace DBADashServiceConfig
             lblPerformanceCounters.Text = isCustom ? "Custom" : "Default";
             lblPerformanceCounters.Font =
                 new Font(lblPerformanceCounters.Font, isCustom ? FontStyle.Bold : FontStyle.Regular);
+        }
+
+        /// <summary>
+        /// Adds the global OS/perfmon counters button to the Performance Counters group box in code
+        /// (the DMV counters button is Designer-defined; this sits alongside it).
+        /// </summary>
+        private void AddPerfmonCountersButton()
+        {
+            if (groupBox5.Controls.ContainsKey("bttnPerfmonCounters")) return;
+            var bttn = new Button
+            {
+                Name = "bttnPerfmonCounters",
+                Text = "Perfmon Counters (OS)",
+                Location = new Point(580, 38),
+                Size = new Size(200, 35),
+                UseVisualStyleBackColor = true
+            };
+            bttn.Click += PerfmonCounters_Click;
+            groupBox5.Controls.Add(bttn);
+            bttn.ApplyTheme();
+        }
+
+        private void PerfmonCounters_Click(object sender, EventArgs e)
+        {
+            var frm = new ManagePerfmonCounters()
+            {
+                Counters = collectionConfig.PerfmonCounters == null
+                    ? new List<PerfmonCounter>()
+                    : new List<PerfmonCounter>(collectionConfig.PerfmonCounters),
+                // The global list isn't tied to any instance - discover counter names from the local machine.
+                ComputerName = "localhost"
+            };
+            if (frm.ShowDialog() != DialogResult.OK) return;
+            collectionConfig.PerfmonCounters = frm.Counters;
+            SetJson();
+        }
+
+        /// <summary>
+        /// Default WMI host for an instance: the physical NetBIOS name the collector targets
+        /// (SERVERPROPERTY('ComputerNamePhysicalNetBIOS')).  Falls back to the data source if the
+        /// instance can't be queried.
+        /// </summary>
+        private static async Task<string> GetInstanceHostAsync(DBADashConnection cn)
+        {
+            if (cn == null) return string.Empty;
+            try
+            {
+                await using var sqlCn = new SqlConnection(cn.ConnectionString);
+                await using var cmd = new SqlCommand("SELECT CAST(SERVERPROPERTY('ComputerNamePhysicalNetBIOS') AS NVARCHAR(128))", sqlCn) { CommandTimeout = 5 };
+                await sqlCn.OpenAsync();
+                if (await cmd.ExecuteScalarAsync() is string netbios && !string.IsNullOrEmpty(netbios)) return netbios;
+            }
+            catch
+            {
+                // Unreachable / permission - fall back to the data source below.
+            }
+            return DerivePerfmonHost(cn);
+        }
+
+        /// <summary>
+        /// Best-effort default host for WMI discovery from a SQL connection's data source
+        /// (strips the named instance / port; maps local aliases to the machine name).
+        /// </summary>
+        private static string DerivePerfmonHost(DBADashConnection cn)
+        {
+            var ds = cn?.DataSource();
+            if (string.IsNullOrEmpty(ds)) return string.Empty;
+            var host = ds.Split('\\')[0].Split(',')[0].Trim();
+            if (host.StartsWith("tcp:", StringComparison.OrdinalIgnoreCase)) host = host[4..];
+            if (host is "." or "(local)" or "localhost") host = Environment.MachineName;
+            return host;
         }
 
         private void CustomCountersHelp_Click(object sender, LinkLabelLinkClickedEventArgs e)

--- a/Scripts/CI_Workflow.Tests.ps1
+++ b/Scripts/CI_Workflow.Tests.ps1
@@ -1,6 +1,8 @@
 param(
     [string]$Database = "DBADashDB_GitHubAction",
-	[string]$Server = "LOCALHOST"
+	[string]$Server = "LOCALHOST",
+	# Only the leg that enables the default perfmon counters asserts they were collected.
+	[bool]$Perfmon = $false
 )
 
 # Get SQL Server version at the script level
@@ -128,11 +130,38 @@ Describe 'CI Workflow checks' {
 	)
 	It 'Check WMI table counts for <TableName>' -TestCases $TableCountGreaterThanZeroTestCasesWMI -Skip:$NoWMI {
 		param($tableName)
-			
+
 			$results= Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database $params.Database -TrustServerCertificate -Query "SELECT COUNT(*) cnt FROM $tableName"
-										
+
 			$results.cnt | Should -BeGreaterThan 0
-					
+
+	}
+
+	# OS-level (perfmon) counters land in the shared dbo.PerformanceCounters table, namespaced with the
+	# 'PerfMon:' object_name prefix.  Skipped unless this leg enabled the default counters (-Perfmon).
+	It 'Perfmon counters collected' -Skip:(-not $Perfmon) {
+		$results = Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database $params.Database -TrustServerCertificate -Query "SELECT COUNT(*) cnt FROM dbo.PerformanceCounters PC JOIN dbo.Counters C ON C.CounterID = PC.CounterID WHERE C.object_name LIKE 'PerfMon:%'"
+		$results.cnt | Should -BeGreaterThan 0
+	}
+	It 'Perfmon Processor % Processor Time collected' -Skip:(-not $Perfmon) {
+		$results = Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database $params.Database -TrustServerCertificate -Query "SELECT COUNT(*) cnt FROM dbo.PerformanceCounters PC JOIN dbo.Counters C ON C.CounterID = PC.CounterID WHERE C.object_name = 'PerfMon:Processor' AND C.counter_name = '% Processor Time'"
+		$results.cnt | Should -BeGreaterThan 0
+	}
+	It 'Perfmon Processor % Processor Time is within 0-100' -Skip:(-not $Perfmon) {
+		# Proves the raw-delta cooking in PerfmonCounters_Upd produced sane values, not just that rows exist.
+		$results = Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database $params.Database -TrustServerCertificate -Query "SELECT COUNT(*) cnt FROM dbo.PerformanceCounters PC JOIN dbo.Counters C ON C.CounterID = PC.CounterID WHERE C.object_name = 'PerfMon:Processor' AND C.counter_name = '% Processor Time' AND (PC.Value < 0 OR PC.Value > 100)"
+		$results.cnt | Should -Be 0
+	}
+	It 'Perfmon counters carry their stable WMI identity' -Skip:(-not $Perfmon) {
+		# WmiClass/WmiProperty must be populated so the app can key off the WMI identity, not the display name.
+		$results = Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database $params.Database -TrustServerCertificate -Query "SELECT COUNT(*) cnt FROM dbo.Counters WHERE object_name LIKE 'PerfMon:%' AND (WmiClass IS NULL OR WmiProperty IS NULL)"
+		$results.cnt | Should -Be 0
+	}
+	It 'Processor utilization counter is findable by WMI identity (exactly one row)' -Skip:(-not $Perfmon) {
+		# The scenario that motivated this: a chart can locate the counter by WMI identity with confidence,
+		# and there is exactly one row for it (no fragmentation across display names).
+		$results = Invoke-Sqlcmd -ServerInstance $params.ServerInstance -Database $params.Database -TrustServerCertificate -Query "SELECT COUNT(*) cnt FROM dbo.Counters WHERE WmiClass = 'Win32_PerfRawData_PerfOS_Processor' AND WmiProperty = 'PercentProcessorTime' AND instance_name = '_Total'"
+		$results.cnt | Should -Be 1
 	}
 
 }


### PR DESCRIPTION
Collect Win32_PerfRawData_* counters from the host alongside the existing DMV performance counters. Raw accumulators are cooked over the collection interval in dbo.PerfmonCounters_Upd (true interval averages, full precision for fractional values like disk latency) and land in the shared dbo.PerformanceCounters tables, so the existing GUI and alerting work unchanged. Object names are namespaced with a "PerfMon:" prefix to keep them disjoint from DMV counters.

Counters are configurable via a curated global default list plus a per-instance tri-state override (inherit / disabled / custom). Adds a WMI discovery + picker UI (ManagePerfmonCounters) wired into the connections grid and the Performance Counters group box. Collection requires WMI.