### PR TITLE
DateGroupingMins - divide by zero fix

### DIFF
--- a/DBADashDB/dbo/Functions/DateGroupingMins.sql
+++ b/DBADashDB/dbo/Functions/DateGroupingMins.sql
@@ -2,4 +2,4 @@
 RETURNS TABLE
 AS
 RETURN
-SELECT DATEADD(MINUTE, (DATEDIFF(MINUTE, 0, @DateTime) / @Mins) * @Mins, 0) AS DateGroup
+SELECT CASE WHEN @Mins = 0 THEN @DateTime ELSE DATEADD(MINUTE, (DATEDIFF(MINUTE, 0, @DateTime) / @Mins) * @Mins, 0) END AS DateGroup


### PR DESCRIPTION
Fix divide by zero error that can occur when setting date grouping to 0 (DBSpace).  Some other procs handle this with some dynamic SQL to skip using the function.  Applying the fix in the function means the issue is fixed centrally & allows code to be simplified. #2020