### PR TITLE
Add day/hour/minute duration editor for alert threshold properties

### DIFF
--- a/DBADashGUI/DBADashAlerts/Rules/AlertRuleBase.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/AlertRuleBase.cs
@@ -1,10 +1,12 @@
 ﻿using CommandLine;
 using DBADash.Alert;
+using DBADashGUI.Pickers;
 using Microsoft.Data.SqlClient;
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
 using System.Data;
+using System.Drawing.Design;
 using System.Linq;
 
 namespace DBADashGUI.DBADashAlerts.Rules
@@ -131,8 +133,10 @@ namespace DBADashGUI.DBADashAlerts.Rules
         public virtual decimal? Threshold { get; set; }
 
         [JsonIgnore]
-        [Description("Evaluation period to apply the threshold over in minutes")]
-        [DisplayName("Evaluation Period (Mins)")]
+        [Description("Evaluation period to apply the threshold over. Enter days / hours / minutes.")]
+        [DisplayName("Evaluation Period")]
+        [TypeConverter(typeof(MinuteDurationConverter))]
+        [Editor(typeof(MinuteDurationEditor), typeof(UITypeEditor))]
         public virtual int? EvaluationPeriodMins { get; set; } = 5;
 
         [Description("Set to false to disable this rule")]

--- a/DBADashGUI/DBADashAlerts/Rules/BackupAlertRule.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/BackupAlertRule.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using System;
+using System.Drawing.Design;
 using System.Linq;
+using DBADashGUI.Pickers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -99,8 +101,10 @@ namespace DBADashGUI.DBADashAlerts.Rules
             set;
         }
 
-        [DisplayName("Age Threshold (Mins)")]
-        [Description("When Alert Mode is AgeSinceLastBackup, alert when the selected backup is older than this threshold in minutes.")]
+        [DisplayName("Age Threshold")]
+        [Description("When Alert Mode is AgeSinceLastBackup, alert when the selected backup is older than this threshold. Enter days / hours / minutes.")]
+        [TypeConverter(typeof(MinuteDurationConverter))]
+        [Editor(typeof(MinuteDurationEditor), typeof(UITypeEditor))]
         public override decimal? Threshold
         {
             get => AlertMode == AlertModes.AgeSinceLastBackup ? field ?? DefaultThreshold : null;
@@ -118,7 +122,7 @@ namespace DBADashGUI.DBADashAlerts.Rules
             {
                 if (Threshold is not (>= 0M))
                 {
-                    return (false, "Age Threshold (Mins) must be >= 0");
+                    return (false, "Age Threshold must be >= 0");
                 }
             }
 

--- a/DBADashGUI/DBADashAlerts/Rules/CollectionDatesRule.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/CollectionDatesRule.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Drawing.Design;
+using DBADashGUI.Pickers;
 
 namespace DBADashGUI.DBADashAlerts.Rules
 {
@@ -15,7 +17,9 @@ namespace DBADashGUI.DBADashAlerts.Rules
 
         public override string AlertKey => "COLLECTION DATES";
 
-        [Description("Set a threshold in minutes or leave blank to rely on critical status only")]
+        [Description("Alert when the collection is older than this. Enter days / hours / minutes, or leave blank to rely on critical status only.")]
+        [TypeConverter(typeof(MinuteDurationConverter))]
+        [Editor(typeof(NullableMinuteDurationEditor), typeof(UITypeEditor))]
         public override decimal? Threshold { get; set; }
 
         [Description("Use the critical threshold already configured. This can be used instead of specifying an alert threshold or in combination with an additional threshold.")]

--- a/DBADashGUI/DBADashAlerts/Rules/FailedLoginsRule.cs
+++ b/DBADashGUI/DBADashAlerts/Rules/FailedLoginsRule.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Drawing.Design;
+using DBADashGUI.Pickers;
 
 namespace DBADashGUI.DBADashAlerts.Rules
 {
@@ -8,8 +10,10 @@ namespace DBADashGUI.DBADashAlerts.Rules
 
         public override string AlertKey => "FailedLogins";
 
-        [Description("Evaluation period to apply the threshold over in minutes")]
-        [DisplayName("Evaluation Period (Mins)")]
+        [Description("Evaluation period to apply the threshold over. Enter days / hours / minutes.")]
+        [DisplayName("Evaluation Period")]
+        [TypeConverter(typeof(MinuteDurationConverter))]
+        [Editor(typeof(MinuteDurationEditor), typeof(UITypeEditor))]
         public override int? EvaluationPeriodMins { get; set; } = 60;
 
         public override (bool isValid, string message) Validate()

--- a/DBADashGUI/Pickers/DurationDropDown.cs
+++ b/DBADashGUI/Pickers/DurationDropDown.cs
@@ -1,0 +1,132 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+using DBADashGUI.Theme;
+
+namespace DBADashGUI.Pickers
+{
+    /// <summary>
+    /// Drop-down editing control used by <see cref="MinuteDurationEditor"/>.
+    /// Presents separate day / hour / minute entry boxes for a duration that is
+    /// stored as a number of minutes, e.g. [7] days [4] hrs [1] min.
+    /// When <paramref name="allowNull"/> is set, a "Not set" checkbox is shown so the
+    /// user can explicitly clear the value (null) rather than entering a duration.
+    /// </summary>
+    internal sealed class DurationDropDown : UserControl
+    {
+        private readonly NumericUpDown numDays = new() { Minimum = 0, Maximum = 1000000, Width = 60 };
+        private readonly NumericUpDown numHours = new() { Minimum = 0, Maximum = 23, Width = 48 };
+        private readonly NumericUpDown numMinutes = new() { Minimum = 0, Maximum = 59, Width = 48 };
+        private readonly CheckBox chkNotSet;
+        private readonly bool allowNull;
+        private readonly IWindowsFormsEditorServiceCloser closer;
+
+        /// <summary>Small abstraction so the control can close the drop-down when Enter is pressed.</summary>
+        internal interface IWindowsFormsEditorServiceCloser
+        {
+            void CloseDropDown();
+        }
+
+        public DurationDropDown(IWindowsFormsEditorServiceCloser closer = null, bool allowNull = false)
+        {
+            this.closer = closer;
+            this.allowNull = allowNull;
+
+            var boxesTop = 8;
+            if (allowNull)
+            {
+                chkNotSet = new CheckBox
+                {
+                    Text = "Not set",
+                    AutoSize = true,
+                    Location = new Point(8, 6)
+                };
+                chkNotSet.CheckedChanged += ChkNotSet_CheckedChanged;
+                Controls.Add(chkNotSet);
+                boxesTop = 34;
+            }
+
+            numDays.Location = new Point(8, boxesTop);
+            numHours.Location = new Point(110, boxesTop);
+            numMinutes.Location = new Point(196, boxesTop);
+
+            Controls.Add(numDays);
+            Controls.Add(NewLabel("days", 70, boxesTop + 4));
+            Controls.Add(numHours);
+            Controls.Add(NewLabel("hrs", 160, boxesTop + 4));
+            Controls.Add(numMinutes);
+            Controls.Add(NewLabel("mins", 246, boxesTop + 4));
+
+            Size = new Size(290, boxesTop + 35);
+
+            foreach (var num in new[] { numDays, numHours, numMinutes })
+            {
+                num.KeyDown += Num_KeyDown;
+            }
+
+            this.ApplyTheme();
+        }
+
+        private static Label NewLabel(string text, int x, int y) => new()
+        {
+            Text = text,
+            AutoSize = true,
+            Location = new Point(x, y)
+        };
+
+        private void ChkNotSet_CheckedChanged(object sender, EventArgs e)
+        {
+            var enabled = !chkNotSet.Checked;
+            numDays.Enabled = enabled;
+            numHours.Enabled = enabled;
+            numMinutes.Enabled = enabled;
+        }
+
+        private void Num_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                closer?.CloseDropDown();
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>The edited duration in minutes, or null when "Not set" is enabled and checked.</summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public decimal? Value
+        {
+            get => allowNull && chkNotSet.Checked ? null : TotalMinutes;
+            set
+            {
+                if (value == null)
+                {
+                    if (allowNull) { chkNotSet.Checked = true; }
+                    TotalMinutes = 0;
+                }
+                else
+                {
+                    if (allowNull) { chkNotSet.Checked = false; }
+                    TotalMinutes = value.Value;
+                }
+            }
+        }
+
+        private decimal TotalMinutes
+        {
+            get => (numDays.Value * 1440m) + (numHours.Value * 60m) + numMinutes.Value;
+            set
+            {
+                var total = value < 0 ? 0 : decimal.Truncate(value);
+                var days = Math.Floor(total / 1440m);
+                var remainder = total - (days * 1440m);
+                var hours = Math.Floor(remainder / 60m);
+                var minutes = remainder - (hours * 60m);
+
+                numDays.Value = Math.Min(days, numDays.Maximum);
+                numHours.Value = Math.Min(hours, numHours.Maximum);
+                numMinutes.Value = Math.Min(minutes, numMinutes.Maximum);
+            }
+        }
+    }
+}

--- a/DBADashGUI/Pickers/MinuteDurationConverter.cs
+++ b/DBADashGUI/Pickers/MinuteDurationConverter.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace DBADashGUI.Pickers
+{
+    /// <summary>
+    /// Renders and parses a duration stored as a number of minutes.  Used alongside
+    /// <see cref="MinuteDurationEditor"/> so a PropertyGrid row shows "7 days 4 hrs 1 min"
+    /// instead of a raw minute count, and still accepts typed input such as "7d 4h 1m",
+    /// "90m" or a bare number of minutes.
+    /// </summary>
+    public class MinuteDurationConverter : TypeConverter
+    {
+        private static readonly Regex TokenRegex = new(
+            @"(?<value>\d+(\.\d+)?)\s*(?<unit>days?|d|hours?|hrs?|h|minutes?|mins?|m)",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            => destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(string))
+            {
+                return value == null ? string.Empty : FormatMinutes(Convert.ToDecimal(value, culture));
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string s)
+            {
+                var propertyType = context?.PropertyDescriptor?.PropertyType;
+                var isNullable = propertyType != null && Nullable.GetUnderlyingType(propertyType) != null;
+                var underlyingType = propertyType == null ? null : Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+                // A blank value clears a nullable property (e.g. "rely on critical status only").
+                if (string.IsNullOrWhiteSpace(s))
+                {
+                    if (isNullable) { return null; }
+                    return underlyingType == typeof(int) ? 0 : (object)0m;
+                }
+
+                var minutes = ParseMinutes(s, culture);
+                return underlyingType == typeof(int) ? (int)Math.Round(minutes, MidpointRounding.AwayFromZero) : (object)minutes;
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        private static string FormatMinutes(decimal totalMinutes)
+        {
+            var total = (long)Math.Max(0, Math.Round(totalMinutes));
+            var days = total / 1440;
+            var hours = (total % 1440) / 60;
+            var minutes = total % 60;
+
+            var parts = new List<string>();
+            if (days > 0) { parts.Add($"{days} {(days == 1 ? "day" : "days")}"); }
+            if (hours > 0) { parts.Add($"{hours} {(hours == 1 ? "hr" : "hrs")}"); }
+            if (minutes > 0 || parts.Count == 0) { parts.Add($"{minutes} {(minutes == 1 ? "min" : "mins")}"); }
+
+            return string.Join(" ", parts);
+        }
+
+        private static decimal ParseMinutes(string text, CultureInfo culture)
+        {
+            var trimmed = text?.Trim() ?? string.Empty;
+            if (trimmed.Length == 0)
+            {
+                return 0;
+            }
+
+            // A bare number is treated as minutes.
+            if (decimal.TryParse(trimmed, NumberStyles.Number, culture, out var bareMinutes) ||
+                decimal.TryParse(trimmed, NumberStyles.Number, CultureInfo.InvariantCulture, out bareMinutes))
+            {
+                return bareMinutes;
+            }
+
+            decimal total = 0;
+            foreach (Match match in TokenRegex.Matches(trimmed))
+            {
+                var number = decimal.Parse(match.Groups["value"].Value, CultureInfo.InvariantCulture);
+                var unit = match.Groups["unit"].Value.ToLowerInvariant();
+                total += unit[0] switch
+                {
+                    'd' => number * 1440m,
+                    'h' => number * 60m,
+                    _ => number
+                };
+            }
+
+            // Reject input that isn't fully consumed by valid tokens (e.g. "1h abc"),
+            // so typos surface as an error rather than being silently ignored.
+            var leftover = TokenRegex.Replace(trimmed, string.Empty);
+            if (!string.IsNullOrWhiteSpace(leftover))
+            {
+                throw new FormatException($"'{text}' is not a valid duration. Use e.g. '7d 4h 1m' or a number of minutes.");
+            }
+
+            return total;
+        }
+    }
+}

--- a/DBADashGUI/Pickers/MinuteDurationEditor.cs
+++ b/DBADashGUI/Pickers/MinuteDurationEditor.cs
@@ -1,0 +1,74 @@
+using System;
+using System.ComponentModel;
+using System.Drawing.Design;
+using System.Windows.Forms.Design;
+
+namespace DBADashGUI.Pickers
+{
+    /// <summary>
+    /// A PropertyGrid drop-down editor for a duration that is stored as a number of minutes.
+    /// It presents separate day / hour / minute entry boxes (e.g. [7] days [4] hrs [1] min).
+    /// Reusable on any <c>decimal?</c> / <c>int?</c> property whose value represents minutes.
+    /// Use <see cref="NullableMinuteDurationEditor"/> for properties where an unset (null) value
+    /// is a meaningful state that the user should be able to choose.
+    /// </summary>
+    public class MinuteDurationEditor : UITypeEditor
+    {
+        private sealed class DropDownCloser : DurationDropDown.IWindowsFormsEditorServiceCloser
+        {
+            private readonly IWindowsFormsEditorService service;
+
+            public DropDownCloser(IWindowsFormsEditorService service) => this.service = service;
+
+            public void CloseDropDown() => service.CloseDropDown();
+        }
+
+        /// <summary>When true, the drop-down offers a "Not set" checkbox so the user can clear the value.</summary>
+        protected virtual bool AllowNull => false;
+
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+            => UITypeEditorEditStyle.DropDown;
+
+        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        {
+            if (provider?.GetService(typeof(IWindowsFormsEditorService)) is not IWindowsFormsEditorService editorService)
+            {
+                return value;
+            }
+
+            using var control = new DurationDropDown(new DropDownCloser(editorService), AllowNull)
+            {
+                Value = value == null ? null : Convert.ToDecimal(value)
+            };
+
+            editorService.DropDownControl(control);
+
+            return FromValue(control.Value, context);
+        }
+
+        /// <summary>Converts the edited minutes back to the property's underlying type (int or decimal), or null.</summary>
+        private static object FromValue(decimal? minutes, ITypeDescriptorContext context)
+        {
+            if (minutes == null)
+            {
+                return null;
+            }
+
+            var propertyType = context?.PropertyDescriptor?.PropertyType;
+            var underlyingType = propertyType == null ? null : Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+
+            return underlyingType == typeof(int)
+                ? (int)Math.Round(minutes.Value, MidpointRounding.AwayFromZero)
+                : (object)minutes.Value;
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="MinuteDurationEditor"/> variant that lets the user explicitly clear the value
+    /// (via a "Not set" checkbox), for properties where null is a meaningful state.
+    /// </summary>
+    public sealed class NullableMinuteDurationEditor : MinuteDurationEditor
+    {
+        protected override bool AllowNull => true;
+    }
+}


### PR DESCRIPTION
Introduce a reusable PropertyGrid drop-down editor that lets users enter minute-based durations as separate day / hour / minute boxes (e.g. 7d 4h 1m) instead of a raw minute count.

Applied to the minute-duration alert rule properties:
- BackupAlertRule.Threshold (backup age)
- CollectionDatesRule.Threshold (collection staleness)
- EvaluationPeriodMins (AlertRuleBase + FailedLoginsRule), renamed to "Evaluation Period"

#2031