### PR TITLE
XE Trace - Instance Label fix

### DIFF
--- a/DBADashDB/XE/Stored Procedures/XETraceEvents_Get.sql
+++ b/DBADashDB/XE/Stored Procedures/XETraceEvents_Get.sql
@@ -13,6 +13,7 @@ DECLARE @IsAdmin BIT = IS_ROLEMEMBER('db_owner');
 SELECT  E.XETraceEventID,
         E.event_type,
         E.timestamp,
+        S.InstanceID,
         E.Fields
 FROM XE.XETraceEvent E
 JOIN XE.XETraceSession S ON S.XETraceSessionID = E.XETraceSessionID

--- a/DBADashDB/XE/Stored Procedures/XETraceEvents_GetByRunGroup.sql
+++ b/DBADashDB/XE/Stored Procedures/XETraceEvents_GetByRunGroup.sql
@@ -3,8 +3,8 @@ CREATE PROC XE.XETraceEvents_GetByRunGroup(
 )
 AS
 /* All captured events for every per-instance session of a single multi-instance (e.g. AG-wide) trace run, merged in
-   time order.  Each event's source instance is already stored inside its Fields JSON (the "Instance" field written by
-   the GUI for multi-instance runs), so the caller expands Fields exactly as for XETraceEvents_Get - no extra column.
+   time order.  Each event's source instance is the session's own InstanceID (returned here); the caller resolves the
+   display label for it (see XEStoredEvents.Expand) rather than it being stored per-event in the Fields JSON.
 
    Ownership gate (mirrors XETraceSession_Get / XETraceSessionReport_Get so a direct/forged call can't read another
    user's captured query text): db_owner (admin) may read any run; everyone else only runs they started, anchored on
@@ -14,6 +14,7 @@ DECLARE @IsAdmin BIT = IS_ROLEMEMBER('db_owner');
 SELECT  E.XETraceEventID,
         E.event_type,
         E.timestamp,
+        S.InstanceID,
         E.Fields
 FROM XE.XETraceEvent E
 JOIN XE.XETraceSession S ON S.XETraceSessionID = E.XETraceSessionID

--- a/DBADashGUI/XETrace/QuickXETrace.cs
+++ b/DBADashGUI/XETrace/QuickXETrace.cs
@@ -1072,7 +1072,7 @@ namespace DBADashGUI.XETrace
             if (_context is not { InstanceID: > 0 }) return;
             var existing = new HashSet<int>(clbInstances.Items.Cast<TraceInstance>().Select(t => t.InstanceID)) { _context.InstanceID };
             var candidates = CommonData.Instances.Rows.Cast<DataRow>()
-                .Select(ToInstanceCandidate)
+                .Select(XEInstanceLabels.ToCandidate)
                 .Where(c => c != null && !existing.Contains(c.InstanceID))
                 .ToList();
             if (candidates.Count == 0)
@@ -1088,31 +1088,6 @@ namespace DBADashGUI.XETrace
                 if (byId.TryGetValue(id, out var c)) AddInstanceItem(id, c.ListLabel, isAg: false, check: true);
             }
             UpdateInstanceCount();
-        }
-
-        /// <summary>
-        /// Maps a CommonData.Instances row to a pickable candidate.  Each Azure SQL database is its own monitored
-        /// instance (its own InstanceID / ConnectionID) sharing a logical server, so Azure rows are exposed per-database
-        /// under their server; regular instances are a single leaf.  Returns null for rows with nothing to label.
-        /// </summary>
-        private static XEInstanceCandidate ToInstanceCandidate(DataRow r)
-        {
-            var id = Convert.ToInt32(r["InstanceID"]);
-            if (id <= 0) return null;
-            var isAzure = r["IsAzure"] != DBNull.Value && Convert.ToBoolean(r["IsAzure"]);
-            var server = r["Instance"] as string;
-            if (isAzure)
-            {
-                var db = r["AzureDBName"] as string;
-                if (string.IsNullOrEmpty(db) || string.IsNullOrEmpty(server)) return null;
-                // 'master' isn't a useful XE trace target on Azure DB - skip it so the picker only lists user databases.
-                if (string.Equals(db, "master", StringComparison.OrdinalIgnoreCase)) return null;
-                return new XEInstanceCandidate { InstanceID = id, IsAzure = true, ServerName = server, DatabaseName = db };
-            }
-            var name = r["InstanceGroupName"] as string ?? server;
-            return string.IsNullOrEmpty(name)
-                ? null
-                : new XEInstanceCandidate { InstanceID = id, IsAzure = false, DisplayName = name };
         }
 
         /// <summary>Adds an instance to the instances list (deduped by InstanceID) with the given checked state.</summary>
@@ -1163,7 +1138,7 @@ namespace DBADashGUI.XETrace
                 if (clbInstances.Items[i] is TraceInstance { IsCurrent: true }) clbInstances.Items.RemoveAt(i);
             }
             clbInstances.Items.Insert(0, new TraceInstance
-            { InstanceID = _context.InstanceID, Name = _context.InstanceName, IsCurrent = true });
+            { InstanceID = _context.InstanceID, Name = XEInstanceLabels.Resolve(_context.InstanceID, _context.InstanceName), IsCurrent = true });
             clbInstances.SetItemChecked(0, true);
             UpdateInstanceCount();
         }
@@ -1441,10 +1416,14 @@ namespace DBADashGUI.XETrace
             try
             {
                 var capturesXel = !tagInstance; // single-instance run only - a multi-instance .xel would be per-instance
+                // In a multi-instance run, tag each live batch with its source instance (resolved from the trace's own
+                // InstanceID) so the merged grid can tell replicas apart.  History reload derives this from the session
+                // row instead (see XEStoredEvents.Expand), so it isn't persisted into the event JSON.
+                var instanceLabel = tagInstance ? XEInstanceLabels.Resolve(rt.Context.InstanceID, rt.Context.InstanceName) : null;
                 var outcome = await XETraceController.RunTraceAsync(rt.Context, config, rt.MessageGroup, ControllerStatus,
-                    batch => AppendEventsAsync(generation, batch),
+                    batch => AppendEventsAsync(generation, batch, instanceLabel),
                     summary => OnSummary(generation, summary, capturesXel),
-                    runGroupID, tagInstance,
+                    runGroupID,
                     onRunningConfirmed: () => OnTraceConfirmedRunning(generation, instanceCount));
                 rt.SessionID = outcome?.SessionID;
                 return outcome ?? new XETraceController.XETraceOutcome(false, false,
@@ -1547,11 +1526,12 @@ namespace DBADashGUI.XETrace
 
         // ---- Live grid ---------------------------------------------------------------------------
 
-        private Task AppendEventsAsync(int generation, DataTable batch)
+        private Task AppendEventsAsync(int generation, DataTable batch, string instanceLabel = null)
         {
             if (generation != _traceGeneration) return Task.CompletedTask; // stale trace (switched/reset) - drop the batch
-            if (InvokeRequired) return (Task)Invoke(new Func<Task>(() => AppendEventsAsync(generation, batch)));
+            if (InvokeRequired) return (Task)Invoke(new Func<Task>(() => AppendEventsAsync(generation, batch, instanceLabel)));
             if (generation != _traceGeneration) return Task.CompletedTask; // re-check after marshalling to the UI thread
+            if (instanceLabel != null) StampInstance(batch, instanceLabel);
             _results.AppendEvents(batch);
             // While stopping, in-flight batches (e.g. an SQS backlog still arriving) are real captured events, so keep
             // them and their count - but say we're stopping rather than repainting "Trace running..." over the
@@ -1561,6 +1541,20 @@ namespace DBADashGUI.XETrace
                     : $"Trace running.  Collected {_results.RowCount} events.",
                 string.Empty, _cancelling ? DashColors.Warning : DashColors.Information);
             return Task.CompletedTask;
+        }
+
+        /// <summary>Stamps the source-instance column on every row of a live batch (multi-instance run only).</summary>
+        private static void StampInstance(DataTable batch, string instanceLabel)
+        {
+            if (batch == null) return;
+            if (!batch.Columns.Contains(XETraceController.InstanceColumn))
+            {
+                batch.Columns.Add(XETraceController.InstanceColumn, typeof(string));
+            }
+            foreach (DataRow row in batch.Rows)
+            {
+                row[XETraceController.InstanceColumn] = instanceLabel ?? string.Empty;
+            }
         }
 
         private void OnSummary(int generation, DataRow summary, bool capturesXel)

--- a/DBADashGUI/XETrace/XEInstanceLabels.cs
+++ b/DBADashGUI/XETrace/XEInstanceLabels.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Data;
+using System.Linq;
+
+namespace DBADashGUI.XETrace
+{
+    /// <summary>
+    /// Resolves an instance's display label from <see cref="CommonData.Instances"/> - "server / database" for an Azure
+    /// SQL database, the instance group name otherwise.  The source-instance identity for a trace is the session's
+    /// <c>InstanceID</c> (see <c>XE.XETraceSession</c>); the label is resolved here at display time so it is always
+    /// populated, unique per database, and reflects the current alias - shared by the instance picker, the live grid's
+    /// source-instance stamp and the stored-event expander so every view labels instances identically.
+    /// </summary>
+    internal static class XEInstanceLabels
+    {
+        /// <summary>
+        /// The label for an instance, or <paramref name="fallback"/> when the row/label can't be resolved (e.g. the
+        /// instance was removed from monitoring after the trace ran).
+        /// </summary>
+        public static string Resolve(int instanceId, string fallback = null)
+        {
+            var row = CommonData.Instances?.Select($"InstanceID={instanceId}").FirstOrDefault();
+            var label = row == null ? null : ToCandidate(row)?.ListLabel;
+            return string.IsNullOrEmpty(label) ? fallback : label;
+        }
+
+        /// <summary>
+        /// Maps a CommonData.Instances row to a pickable candidate.  Each Azure SQL database is its own monitored
+        /// instance (its own InstanceID / ConnectionID) sharing a logical server, so Azure rows are exposed per-database
+        /// under their server; regular instances are a single leaf.  Returns null for rows with nothing to label.
+        /// </summary>
+        public static XEInstanceCandidate ToCandidate(DataRow r)
+        {
+            var id = Convert.ToInt32(r["InstanceID"]);
+            if (id <= 0) return null;
+            var isAzure = r["IsAzure"] != DBNull.Value && Convert.ToBoolean(r["IsAzure"]);
+            var server = r["Instance"] as string;
+            if (isAzure)
+            {
+                var db = r["AzureDBName"] as string;
+                if (string.IsNullOrEmpty(db) || string.IsNullOrEmpty(server)) return null;
+                // 'master' isn't a useful XE trace target on Azure DB - skip it so the picker only lists user databases.
+                if (string.Equals(db, "master", StringComparison.OrdinalIgnoreCase)) return null;
+                return new XEInstanceCandidate { InstanceID = id, IsAzure = true, ServerName = server, DatabaseName = db };
+            }
+            var name = r["InstanceGroupName"] as string ?? server;
+            return string.IsNullOrEmpty(name)
+                ? null
+                : new XEInstanceCandidate { InstanceID = id, IsAzure = false, DisplayName = name };
+        }
+    }
+}

--- a/DBADashGUI/XETrace/XEStoredEvents.cs
+++ b/DBADashGUI/XETrace/XEStoredEvents.cs
@@ -2,6 +2,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 
 namespace DBADashGUI.XETrace
 {
@@ -17,7 +18,17 @@ namespace DBADashGUI.XETrace
     {
         public static DataTable Expand(DataTable stored)
         {
-            // Pass 1: parse each row's Fields JSON once and infer a column type per field across all rows.
+            // The source instance is carried by the session's InstanceID (returned per event), not stored in the event
+            // JSON.  When a run spans more than one instance, resolve a display label per event and surface it as a
+            // left-most "Instance" column so the merged grid can tell them apart (single-instance runs stay unchanged).
+            var hasInstanceId = stored.Columns.Contains("InstanceID");
+            var multiInstance = hasInstanceId &&
+                stored.Rows.Cast<DataRow>().Select(r => r["InstanceID"]).Where(v => v != DBNull.Value)
+                    .Select(Convert.ToInt32).Distinct().Take(2).Count() > 1;
+            var instanceLabels = new Dictionary<int, string>();
+
+            // Pass 1: parse each row's Fields JSON once and infer a column type per field across all rows.  A legacy
+            // "Instance" key (stamped into the JSON by an older build) is ignored - the InstanceID-derived column wins.
             var parsed = new List<(DataRow Source, JObject Fields)>();
             var fieldTypes = new Dictionary<string, Type>(StringComparer.Ordinal);
             var order = new List<string>();
@@ -30,6 +41,7 @@ namespace DBADashGUI.XETrace
                     fields = JObject.Parse(json);
                     foreach (var p in fields.Properties())
                     {
+                        if (string.Equals(p.Name, XETraceController.InstanceColumn, StringComparison.Ordinal)) continue;
                         if (!fieldTypes.ContainsKey(p.Name)) { fieldTypes[p.Name] = null; order.Add(p.Name); }
                         fieldTypes[p.Name] = MergeJsonType(fieldTypes[p.Name], p.Value);
                     }
@@ -41,6 +53,7 @@ namespace DBADashGUI.XETrace
             var dt = new DataTable();
             dt.Columns.Add("event_type", typeof(string));
             dt.Columns.Add("timestamp", typeof(DateTime));
+            if (multiInstance) dt.Columns.Add(XETraceController.InstanceColumn, typeof(string));
             foreach (var name in order)
             {
                 dt.Columns.Add(name, fieldTypes[name] ?? typeof(string));
@@ -51,10 +64,21 @@ namespace DBADashGUI.XETrace
                 var row = dt.NewRow();
                 row["event_type"] = source["event_type"];
                 if (source["timestamp"] != DBNull.Value) row["timestamp"] = source["timestamp"];
+                if (multiInstance && source["InstanceID"] != DBNull.Value)
+                {
+                    var id = Convert.ToInt32(source["InstanceID"]);
+                    if (!instanceLabels.TryGetValue(id, out var label))
+                    {
+                        label = XEInstanceLabels.Resolve(id, id.ToString());
+                        instanceLabels[id] = label;
+                    }
+                    row[XETraceController.InstanceColumn] = label;
+                }
                 if (fields != null)
                 {
                     foreach (var p in fields.Properties())
                     {
+                        if (string.Equals(p.Name, XETraceController.InstanceColumn, StringComparison.Ordinal)) continue;
                         row[p.Name] = ConvertJsonValue(p.Value, dt.Columns[p.Name].DataType);
                     }
                 }

--- a/DBADashGUI/XETrace/XETraceController.cs
+++ b/DBADashGUI/XETrace/XETraceController.cs
@@ -78,7 +78,12 @@ namespace DBADashGUI.XETrace
         /// be used to cancel the trace (see <see cref="CancelAsync"/>).  Returns the repo session id, or null if the
         /// session couldn't be opened (e.g. one already running for the instance).
         /// </summary>
-        /// <summary>Column added to each event batch to identify its source instance in a multi-instance run.</summary>
+        /// <summary>
+        /// Grid column that identifies an event's source instance in a multi-instance run.  This is not persisted into
+        /// the event JSON - the source instance is the session's own InstanceID (see <c>XE.XETraceSession</c>).  The GUI
+        /// stamps it on live batches (from the trace's InstanceID) and resolves it from the session row on history
+        /// reload (see <c>XEStoredEvents.Expand</c>), so both paths label instances identically.
+        /// </summary>
         public const string InstanceColumn = "Instance";
 
         public static async Task<XETraceOutcome> RunTraceAsync(
@@ -89,7 +94,6 @@ namespace DBADashGUI.XETrace
             Func<DataTable, Task> onBatch,
             Action<DataRow> onSummary,
             Guid? runGroupID = null,
-            bool tagInstance = false,
             Action onRunningConfirmed = null)
         {
             if (context.ImportAgentID == null)
@@ -167,9 +171,6 @@ namespace DBADashGUI.XETrace
 
                 var table = reply.Data?.Tables.Count > 0 ? reply.Data.Tables[0] : null;
                 if (table == null || !table.Columns.Contains("event_type") || table.Rows.Count == 0) return;
-                // In a multi-instance run, stamp the source instance so the merged grid (and persisted history) can
-                // tell which replica each event came from.  Single-instance runs leave the schema untouched.
-                if (tagInstance) StampInstanceColumn(table, context.InstanceName);
                 await XETraceRepo.AddEventsAsync(sessionID, table);
                 await onBatch(table);
             }
@@ -235,19 +236,6 @@ namespace DBADashGUI.XETrace
             }
 
             return new XETraceOutcome(ok, cancelled, outcomeMessage, sessionID);
-        }
-
-        /// <summary>Adds/sets the <see cref="InstanceColumn"/> on every row of a batch to identify its source instance.</summary>
-        private static void StampInstanceColumn(DataTable table, string instanceName)
-        {
-            if (!table.Columns.Contains(InstanceColumn))
-            {
-                table.Columns.Add(InstanceColumn, typeof(string));
-            }
-            foreach (DataRow row in table.Rows)
-            {
-                row[InstanceColumn] = instanceName ?? string.Empty;
-            }
         }
 
         private static async Task SafeCompleteAsync(long sessionID, string errorMessage)

--- a/DBADashGUI/XETrace/XETraceRepo.cs
+++ b/DBADashGUI/XETrace/XETraceRepo.cs
@@ -202,8 +202,9 @@ namespace DBADashGUI.XETrace
             FillAsync("XE.XETraceEvents_Get", cmd => cmd.Parameters.AddWithValue("@XETraceSessionID", sessionID));
 
         /// <summary>
-        /// Returns the merged events of every per-instance session of a multi-instance run (each event's source
-        /// instance is carried inside its Fields JSON), in time order.  Used to reload an AG-wide trace as one grid.
+        /// Returns the merged events of every per-instance session of a multi-instance run (each event carries its
+        /// session's InstanceID; the caller resolves the label - see XEStoredEvents.Expand), in time order.  Used to
+        /// reload an AG-wide trace as one grid.
         /// </summary>
         public static Task<DataTable> GetEventsByRunGroupAsync(Guid runGroupID) =>
             FillAsync("XE.XETraceEvents_GetByRunGroup", cmd => cmd.Parameters.AddWithValue("@RunGroupID", runGroupID));


### PR DESCRIPTION
Remove instance from Json and resolve name from InstanceID instead.  Reduce data stored per-row while ensuring correct instance labels are used.