### PR TITLE
XE Trace - Flush live batch tail on interval, not just on event arrival

### DIFF
--- a/DBADash/XE/XELiveTraceReader.cs
+++ b/DBADash/XE/XELiveTraceReader.cs
@@ -1,8 +1,10 @@
 using Microsoft.SqlServer.XEvent.XELite;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace DBADash.XE
@@ -15,8 +17,11 @@ namespace DBADash.XE
     /// cancelled.  A single live session has one clock, so none of the per-file metadata handling the captured-file
     /// reader needs applies here - XELite parses the stream into <see cref="IXEvent"/>s for us.
     ///
-    /// <para>The streamer invokes its handler once per event; we accumulate and flush a shredded batch on whichever
-    /// comes first - a count threshold or a time interval - so the GUI gets batches, not a message per event.</para>
+    /// <para>The streamer invokes its handler once per event; we hand each event to a single-consumer channel and
+    /// accumulate on the consumer side, flushing a shredded batch on whichever comes first - a count threshold or a
+    /// time interval - so the GUI gets batches, not a message per event.  The interval is driven by the consumer's own
+    /// wait, so the tail of a bursty-then-idle workload still flushes on time even though no further events arrive to
+    /// trigger it (the streamer's handler only runs when an event is delivered).</para>
     /// </summary>
     public sealed class XELiveTraceReader
     {
@@ -40,45 +45,131 @@ namespace DBADash.XE
         public async Task StreamAsync(Func<DataTable, Task> onBatch, CancellationToken ct)
         {
             var streamer = new XELiveEventStreamer(_connectionString, _sessionName);
-            var buffer = new List<IXEvent>(_batchSize);
-            var lastFlush = DateTime.UtcNow;
 
-            async Task FlushAsync()
-            {
-                if (buffer.Count == 0) return;
-                var batch = XELiteShredder.Build(buffer);
-                buffer.Clear();
-                lastFlush = DateTime.UtcNow;
-                await onBatch(batch).ConfigureAwait(false);
-            }
-
-            HandleXEvent onEvent = async ev =>
-            {
-                buffer.Add(ev);
-                if (buffer.Count >= _batchSize || DateTime.UtcNow - lastFlush >= _batchInterval)
+            // The streamer's handler must return quickly and is called serially, so it just posts each event to the
+            // channel.  A single consumer owns the buffer, so no locking is needed - the buffer has exactly one writer.
+            //
+            // The channel is bounded so a slow consumer (or a slow GUI push inside onBatch) can't grow memory without
+            // limit.  When it fills we DROP the incoming event rather than block the handler: blocking it would stall
+            // ReadEventStream, and the server session runs ALLOW_SINGLE_EVENT_LOSS, so it would shed events on its own
+            // anyway - we keep the live tap draining and drop on our side instead.  The ItemDropped callback counts
+            // what we shed so the consumer can log it.
+            long dropped = 0;
+            var channel = Channel.CreateBounded<IXEvent>(
+                new BoundedChannelOptions(Math.Max(_batchSize * 16, 8192))
                 {
-                    await FlushAsync().ConfigureAwait(false);
-                }
+                    SingleReader = true,
+                    SingleWriter = true,
+                    FullMode = BoundedChannelFullMode.DropWrite
+                },
+                _ => Interlocked.Increment(ref dropped));
+
+            HandleXEvent onEvent = ev =>
+            {
+                channel.Writer.TryWrite(ev);
+                return Task.CompletedTask;
             };
 
+            // A flush failure (the GUI report throwing) should tear the stream down, not be swallowed, so link a CTS the
+            // consumer can trip to cancel ReadEventStream.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+            async Task ConsumeAsync()
+            {
+                var reader = channel.Reader;
+                var buffer = new List<IXEvent>(_batchSize);
+
+                // Flush against a fixed deadline rather than a delay that restarts each loop.  A restarting delay only
+                // fires after a full interval of *silence*, so a steady trickle that never reaches _batchSize would keep
+                // resetting it and never flush on time; the deadline guarantees "count threshold OR time interval".
+                var nextFlush = DateTime.UtcNow + _batchInterval;
+                long reportedDrops = 0;
+
+                async Task FlushAsync()
+                {
+                    nextFlush = DateTime.UtcNow + _batchInterval;
+                    if (buffer.Count == 0) return;
+                    var batch = XELiteShredder.Build(buffer);
+                    buffer.Clear();
+                    await onBatch(batch).ConfigureAwait(false);
+                }
+
+                void ReportDrops()
+                {
+                    var total = Interlocked.Read(ref dropped);
+                    if (total <= reportedDrops) return;
+                    Log.Warning(
+                        "XE live trace on session {session}: dropped {count} event(s) - consumer could not keep up ({total} total this stream)",
+                        _sessionName, total - reportedDrops, total);
+                    reportedDrops = total;
+                }
+
+                try
+                {
+                    while (true)
+                    {
+                        // Wait for the next event or the flush deadline, whichever comes first.  The deadline branch is
+                        // what flushes a partial tail when the workload has gone quiet - it does not depend on a further
+                        // event arriving.
+                        var waitTask = reader.WaitToReadAsync().AsTask();
+                        var remaining = nextFlush - DateTime.UtcNow;
+                        if (remaining < TimeSpan.Zero) remaining = TimeSpan.Zero;
+                        var signalled = await Task.WhenAny(waitTask, Task.Delay(remaining)).ConfigureAwait(false);
+                        if (signalled != waitTask)
+                        {
+                            await FlushAsync().ConfigureAwait(false); // flush deadline reached
+                            ReportDrops();
+                            continue;
+                        }
+
+                        if (!await waitTask.ConfigureAwait(false))
+                        {
+                            break; // writer completed and the channel is drained
+                        }
+
+                        while (reader.TryRead(out var ev))
+                        {
+                            buffer.Add(ev);
+                            if (buffer.Count >= _batchSize)
+                            {
+                                await FlushAsync().ConfigureAwait(false);
+                            }
+                        }
+                        ReportDrops();
+                    }
+
+                    // Flush the final partial batch once the writer has completed.
+                    await FlushAsync().ConfigureAwait(false);
+                    ReportDrops();
+                }
+                catch
+                {
+                    cts.Cancel(); // abort ReadEventStream so the request ends instead of hanging
+                    throw;
+                }
+            }
+
+            var consumer = ConsumeAsync();
             try
             {
                 // ReadEventStream runs until the connection is cancelled; a live session never ends on its own, so it
                 // ultimately throws (cancellation, or its own "reader aborted") - both mean "we're done streaming".
-                await streamer.ReadEventStream(onEvent, ct).ConfigureAwait(false);
+                await streamer.ReadEventStream(onEvent, cts.Token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
                 // Expected on stop / duration cap / heartbeat loss.
             }
-            catch (Exception) when (ct.IsCancellationRequested)
+            catch (Exception) when (cts.IsCancellationRequested)
             {
                 // The cancelled streaming query can surface as a SqlException rather than OCE - treat as a clean stop.
             }
             finally
             {
-                // Flush any events buffered since the last batch (best-effort - the request is over).
-                try { await FlushAsync().ConfigureAwait(false); } catch { /* ignore on teardown */ }
+                // Signal the consumer to drain whatever is queued, emit the final batch, and finish.  Its exceptions
+                // (a failed flush) propagate here rather than being swallowed on teardown.
+                channel.Writer.Complete();
+                await consumer.ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
The live reader's time-based flush was only evaluated inside the XELite event handler, so it never fired unless a further event arrived. After a bursty-then-idle workload (e.g. SELECT 1 GO 5000) the final partial batch sat in the buffer until the trace was stopped - potentially minutes.

Replace the inline buffering with a single-consumer channel: the streamer handler just posts events (fast, no shared state), and a dedicated consumer owns the buffer and flushes on whichever comes first - the count threshold or the batch interval. The interval is now driven by the consumer's own wait, so the tail flushes on time regardless of whether more events arrive. Single ownership removes the need for locking. A failed flush trips a linked CTS to tear down the stream rather than being swallowed on teardown.