### PR TITLE
Add Extended Events node at root level

### DIFF
--- a/DBADashGUI/ExtensionMethods.cs
+++ b/DBADashGUI/ExtensionMethods.cs
@@ -291,8 +291,13 @@ namespace DBADashGUI
 
         public static void ApplyVisibility(this DataGridViewColumnCollection columns, List<ISelectable> selectables)
         {
-            var columnDict = columns.Cast<DataGridViewColumn>()
-                .ToDictionary(c => c.HeaderText, c => c);
+            // Columns are keyed by HeaderText, which is not guaranteed unique (e.g. a visible column aliased to the
+            // same header as a hidden backing column).  Keep the first occurrence rather than throwing on duplicates.
+            var columnDict = new Dictionary<string, DataGridViewColumn>();
+            foreach (var c in columns.Cast<DataGridViewColumn>())
+            {
+                columnDict.TryAdd(c.HeaderText, c);
+            }
 
             foreach (var selectable in selectables)
             {

--- a/DBADashGUI/Main.cs
+++ b/DBADashGUI/Main.cs
@@ -65,6 +65,7 @@ namespace DBADashGUI
             var jobs = new SQLTreeItem("Jobs", SQLTreeItem.TreeType.AgentJobs);
 
             root.Nodes.AddRange(new TreeNode[] { changes, checks, hadr, storage, jobs });
+            AddMultiInstanceXENode(root);
 
             root.AddReportsFolder(reports?.RootLevelReports);
 
@@ -98,6 +99,7 @@ namespace DBADashGUI
                         {
                             parentNode.Nodes.Remove(hadrGrp);
                         }
+                        AddMultiInstanceXENode(parentNode);
                         parentNode.AddReportsFolder(reports?.RootLevelReports);
                         root.Nodes.Add(parentNode);
                         currentTagGroup = tagGroup;
@@ -239,7 +241,8 @@ namespace DBADashGUI
             AIAssistant,
             ExtendedEvents,
             AdhocTrace,
-            XETraceSessions
+            XETraceSessions,
+            MultiInstanceXE
         }
 
         private static readonly List<Main.Tabs> InstanceOnlyTabs = new() { Main.Tabs.PerformanceSummary, Tabs.Metrics, Tabs.Waits, Tabs.Memory, Tabs.RunningQueries };
@@ -272,6 +275,7 @@ namespace DBADashGUI
         private TabPage tabExtendedEvents;
         private TabPage tabAdhocTrace;
         private TabPage tabXETraceSessions;
+        private TabPage tabMultiInstanceXE;
 
         public Main(CommandLineOptions opts)
         {
@@ -354,6 +358,9 @@ namespace DBADashGUI
 
             tabXETraceSessions = new TabPage("XE Trace History") { Name = Tabs.XETraceSessions.TabName() };
             tabXETraceSessions.Controls.Add(new XETrace.XETraceSessionsView { Dock = DockStyle.Fill });
+
+            tabMultiInstanceXE = new TabPage("Running Sessions") { Name = Tabs.MultiInstanceXE.TabName() };
+            tabMultiInstanceXE.Controls.Add(new XETrace.MultiInstanceXEView { Dock = DockStyle.Fill });
         }
 
         public TabPage GetCommunityToolsTabPage(ProcedureExecutionMessage.CommunityProcs proc)
@@ -1114,6 +1121,19 @@ namespace DBADashGUI
             }
         }
 
+        /// <summary>
+        /// Adds the higher-level "Extended Events" node to a root / instance-group node.  Unlike the per-instance node
+        /// (added in <see cref="ExpandInstance"/>), this one aggregates across every instance in the node's context: the
+        /// running XE sessions (<see cref="XETrace.MultiInstanceXEView"/>, needs Manage/Watch XE) and the ad-hoc XE trace
+        /// history (<see cref="XETrace.XETraceSessionsView"/>, needs Adhoc XE).  Shown if the user has any of those rights;
+        /// per-instance capability / messaging availability is resolved when the views load.
+        /// </summary>
+        private static void AddMultiInstanceXENode(SQLTreeItem parentNode)
+        {
+            if (!DBADashUser.AllowManageXE && !DBADashUser.AllowWatchXE && !DBADashUser.AllowAdhocXE) return;
+            parentNode.Nodes.Add(new SQLTreeItem("Extended Events", SQLTreeItem.TreeType.ExtendedEvents));
+        }
+
         private void ExpandInstance(SQLTreeItem instanceNode)
         {
             List<TreeNode> nodesToAdd = new();
@@ -1335,12 +1355,31 @@ namespace DBADashGUI
             }
             else if (n.Type == SQLTreeItem.TreeType.ExtendedEvents)
             {
-                // Each tab is gated on the user's repository-DB role: the session viewer for Manage/Watch XE, the ad-hoc
-                // trace tab for Adhoc XE.  A user without the role never sees that tab; whether the capability is enabled
-                // on the service side is surfaced (disabled controls + a message) inside the tab, not hidden here.
-                if (DBADashUser.AllowManageXE || DBADashUser.AllowWatchXE) allowedTabs.Add(tabExtendedEvents);
-                if (DBADashUser.AllowAdhocXE) allowedTabs.Add(tabAdhocTrace);
-                if (DBADashUser.AllowAdhocXE) allowedTabs.Add(tabXETraceSessions);
+                // The same node type serves two levels (mirrors the AgentJobs branch): at root / instance-group level it
+                // shows the multi-instance running-sessions grid; at instance level it shows the per-instance viewer,
+                // ad-hoc trace and trace history.  Each tab is gated on the user's repository-DB role - a user without
+                // the role never sees that tab; whether the capability is enabled on the service side is surfaced
+                // (disabled controls + a message) inside the tab, not hidden here.
+                if (parent.Type is SQLTreeItem.TreeType.DBADashRoot or SQLTreeItem.TreeType.InstanceFolder)
+                {
+                    // The ad-hoc trace tab works at group level too - QuickXETrace lets the user pick which instances in
+                    // the group to trace (see its "Instances to Trace" selector); nothing is pre-selected here.
+                    if (DBADashUser.AllowAdhocXE)
+                    {
+                        allowedTabs.Add(tabAdhocTrace);
+                        allowedTabs.Add(tabXETraceSessions);
+                    }
+                    if (DBADashUser.AllowManageXE || DBADashUser.AllowWatchXE) allowedTabs.Add(tabMultiInstanceXE);
+                }
+                else
+                {
+                    if (DBADashUser.AllowManageXE || DBADashUser.AllowWatchXE) allowedTabs.Add(tabExtendedEvents);
+                    if (DBADashUser.AllowAdhocXE)
+                    {
+                        allowedTabs.Add(tabAdhocTrace);
+                        allowedTabs.Add(tabXETraceSessions);
+                    }
+                }
             }
             else if (n.Type == SQLTreeItem.TreeType.DBAChecks)
             {
@@ -1485,7 +1524,7 @@ namespace DBADashGUI
             }
 
             // AI Assistant tab - show only at root level (no tree context is used)
-            if (n.Type is SQLTreeItem.TreeType.DBADashRoot 
+            if (n.Type is SQLTreeItem.TreeType.DBADashRoot
                 && aiAssistantControl?.IsServiceAvailable == true
                 && (DBADashUser.IsAdmin || DBADashUser.IsInRole("AIUser")))
             {
@@ -3041,6 +3080,7 @@ namespace DBADashGUI
                 }
             }
         }
+
         void IThemedControl.ApplyTheme(BaseTheme theme)
         {
             Controls.ApplyTheme(theme);

--- a/DBADashGUI/XETrace/MultiInstanceXEView.cs
+++ b/DBADashGUI/XETrace/MultiInstanceXEView.cs
@@ -1,0 +1,603 @@
+using DBADash.Messaging;
+using DBADashGUI.CustomReports;
+using DBADashGUI.Theme;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace DBADashGUI.XETrace
+{
+    /// <summary>
+    /// Multi-instance Extended Events view: lists the existing XE sessions across every instance in the selected node's
+    /// context in a single filterable/sortable grid, with the instance name on each row.  Reuses the per-instance list
+    /// message via <see cref="XESessionController.ListSessionsMultiAsync"/> (bounded fan-out), so nothing is persisted -
+    /// it is an on-demand snapshot.  Running sessions only by default (the common question higher up the tree is "what's
+    /// running where"); untick "Running only" to list every defined session.
+    ///
+    /// A refresh updates the grid <b>per instance as replies land</b> and keeps an instance's last-known rows if that
+    /// refresh misses it (slow / offline / no reply within the window) rather than blanking it - so a partial round never
+    /// makes instances silently vanish.  Progress and any non-responders are shown in the status bar.
+    /// </summary>
+    internal class MultiInstanceXEView : UserControl, ISetContext
+    {
+        // How many instances we message at once.  Each instance only ever receives a single lightweight session-list
+        // query, so the per-instance load is negligible regardless of this - the cap is really about not flooding the
+        // service / the repo connection pool with in-flight requests.  Offline instances are short-circuited (never
+        // messaged), so this budget is spent on responsive instances.
+        private const int MaxConcurrency = 25;
+
+        private readonly ToolStrip _toolStrip = new() { GripStyle = ToolStripGripStyle.Hidden };
+        private readonly ToolStripButton _tsRefresh = new("Refresh") { DisplayStyle = ToolStripItemDisplayStyle.ImageAndText, Image = Properties.Resources.ProjectSystemModelRefresh_16x, ToolTipText = "Queries each monitored instance for XE sessions" };
+
+        private readonly ToolStripDropDownButton _tsFilter = new("Filter")
+        {
+            DisplayStyle = ToolStripItemDisplayStyle.Image,
+            ToolTipText = "Filter which sessions are shown.",
+            Image = Properties.Resources.FilterDropdown_16x,
+        };
+
+        private readonly ToolStripMenuItem _tsRunningOnly = new("Running Only")
+        {
+            CheckOnClick = true,
+            Checked = true,
+            ToolTipText = "Show only sessions that are currently running.  Untick to list every defined session."
+        };
+
+        private readonly ToolStripMenuItem _tsExcludeSystemHealth = new("Exclude System Health")
+        {
+            CheckOnClick = true,
+            Checked = true,
+            ToolTipText = "Exclude the system_health session."
+        };
+
+        private readonly ToolStripMenuItem _tsExcludeTelemetry = new("Exclude Telemetry")
+        {
+            CheckOnClick = true,
+            Checked = true,
+            ToolTipText = "Exclude telemetry sessions (telemetry_xevents)."
+        };
+
+        private readonly ToolStripMenuItem _tsExcludeAlwaysOnHealth = new("Exclude Always On Health")
+        {
+            CheckOnClick = true,
+            Checked = true,
+            ToolTipText = "Exclude the AlwaysOn_health session."
+        };
+
+        private readonly ToolStripMenuItem _tsExcludeDBADash = new("Exclude DBA Dash")
+        {
+            CheckOnClick = true,
+            Checked = false,
+            ToolTipText = "Exclude DBA Dash sessions (DBADash_1, DBADash_2, DBADash_AdHoc)."
+        };
+
+        private readonly ToolStripButton _tsClearFilter = new("Clear Filter")
+        {
+            DisplayStyle = ToolStripItemDisplayStyle.Image,
+            Image = Properties.Resources.Eraser_16x,
+            Enabled = false,
+            ToolTipText = "No Filter Applied"
+        };
+
+        private readonly ToolStripButton _tsCopy = new("Copy") { DisplayStyle = ToolStripItemDisplayStyle.Image, Image = Properties.Resources.ASX_Copy_blue_16x };
+        private readonly ToolStripButton _tsExcel = new("Excel") { DisplayStyle = ToolStripItemDisplayStyle.Image, Image = Properties.Resources.excel16x16 };
+
+        private readonly DBADashDataGridView _grid = new()
+        {
+            Dock = DockStyle.Fill,
+            AutoGenerateColumns = false,
+            AllowUserToAddRows = false,
+            ReadOnly = true,
+            AllowUserToOrderColumns = true,
+            SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+            RowHeadersVisible = false
+        };
+
+        private readonly StatusStrip _statusStrip = new();
+        private readonly ToolStripStatusLabel _status = new() { TextAlign = System.Drawing.ContentAlignment.MiddleLeft };
+
+        // _all is the master (every session across every in-scope instance); _sessions is the grid-bound projection of it
+        // (all rows, or only running rows when "Running only" is ticked).  Keeping them separate lets the grid solely own
+        // the DataView's RowFilter / Sort (the user's column filters + sort order), which then survive a refresh - the
+        // "Running only" toggle is applied by row inclusion in the projection, never by touching RowFilter.
+        private readonly DataTable _all = CreateEmptyTable();
+
+        private readonly DataTable _sessions = CreateEmptyTable();
+        private DBADashContext _context;
+        private CancellationTokenSource _cts;
+
+        // Live counters for the current / last refresh, so the status can re-render when the "Running only" toggle flips.
+        private int _total, _collected, _excluded, _offline, _failed;
+
+        private bool _refreshRunning;
+        private DateTime? _lastRefreshTime;
+        private readonly List<string> _problems = new();
+
+        public MultiInstanceXEView()
+        {
+            _tsFilter.DropDownItems.AddRange(new ToolStripItem[]
+            {
+                _tsRunningOnly, _tsExcludeSystemHealth, _tsExcludeTelemetry, _tsExcludeAlwaysOnHealth, _tsExcludeDBADash
+            });
+            _toolStrip.Items.AddRange(new ToolStripItem[]
+            {
+                _tsRefresh, _tsCopy, _tsExcel, _tsFilter, _tsClearFilter, new ToolStripSeparator(),
+            });
+            _statusStrip.Items.Add(_status);
+
+            // Add fill first (lowest z-order) then bottom/top so docking lays out correctly.
+            Controls.Add(_grid);
+            Controls.Add(_statusStrip);
+            Controls.Add(_toolStrip);
+
+            _tsRefresh.Click += (_, _) => RefreshData();
+            _tsRunningOnly.CheckedChanged += (_, _) => { RebuildGrid(); RenderStatus(); };
+            _tsExcludeSystemHealth.CheckedChanged += (_, _) => { RebuildGrid(); RenderStatus(); };
+            _tsExcludeTelemetry.CheckedChanged += (_, _) => { RebuildGrid(); RenderStatus(); };
+            _tsExcludeAlwaysOnHealth.CheckedChanged += (_, _) => { RebuildGrid(); RenderStatus(); };
+            _tsExcludeDBADash.CheckedChanged += (_, _) => { RebuildGrid(); RenderStatus(); };
+            _tsCopy.Click += (_, _) => _grid.CopyGrid();
+            _tsExcel.Click += (_, _) => _grid.ExportToExcel();
+            _grid.DataBindingComplete += Grid_DataBindingComplete;
+            _grid.CellContentClick += Grid_CellContentClick;
+            _grid.RegisterClearFilter(_tsClearFilter);
+
+            BuildColumns();
+            _grid.DataSource = _sessions.DefaultView;
+            _grid.ApplyTheme();
+        }
+
+        /// <summary>The fixed schema of the aggregated grid (matches the per-instance list message + the stamped columns).</summary>
+        private static DataTable CreateEmptyTable()
+        {
+            var dt = new DataTable("Sessions");
+            dt.Columns.Add("Instance", typeof(string));
+            dt.Columns.Add("Name", typeof(string));
+            dt.Columns.Add("IsRunning", typeof(bool));
+            dt.Columns.Add("StartTime", typeof(DateTime));
+            dt.Columns.Add("EventCount", typeof(int));
+            dt.Columns.Add("TargetTypes", typeof(string));
+            dt.Columns.Add("InstanceID", typeof(int));
+            dt.Columns.Add("CanManage", typeof(bool));
+            dt.Columns.Add("CanWatch", typeof(bool));
+            dt.Columns.Add("ActionStartStop", typeof(string));
+            dt.Columns.Add("ActionWatch", typeof(string));
+            dt.Columns.Add("ActionViewData", typeof(string));
+            return dt;
+        }
+
+        /// <summary>
+        /// Defines the grid's columns.  Bound data columns map by <c>DataPropertyName</c>; the Instance name and the
+        /// action columns (start/stop, watch, view data, DDL) are <see cref="DataGridViewLinkColumn"/>s bound to
+        /// precomputed text columns (empty text = a blank, non-clickable cell).  The <c>InstanceID</c> / <c>CanManage</c>
+        /// / <c>CanWatch</c> data columns are carried in the bound table but not shown - they're read via the cell's
+        /// <see cref="DataRowView"/> when an action link is clicked.
+        /// </summary>
+        private void BuildColumns()
+        {
+            _grid.Columns.Clear();
+            _grid.Columns.Add(new DataGridViewLinkColumn
+            {
+                Name = "Instance",
+                HeaderText = "Instance",
+                DataPropertyName = "Instance",
+                Frozen = true,
+                TrackVisitedState = false,
+                SortMode = DataGridViewColumnSortMode.Automatic,
+                ToolTipText = "Go to this instance's Extended Events node."
+            });
+            _grid.Columns.Add(new DataGridViewLinkColumn { Name = "Session", HeaderText = "Session", DataPropertyName = "Name", ToolTipText = "Click to view the CREATE EVENT SESSION script." });
+            _grid.Columns.Add(new DataGridViewCheckBoxColumn { Name = "Running", HeaderText = "Running", DataPropertyName = "IsRunning", SortMode = DataGridViewColumnSortMode.Automatic });
+            _grid.Columns.Add(new DataGridViewTextBoxColumn { Name = "StartTime", HeaderText = "Start Time", DataPropertyName = "StartTime" });
+            _grid.Columns.Add(new DataGridViewTextBoxColumn { Name = "Events", HeaderText = "Events", DataPropertyName = "EventCount" });
+            _grid.Columns.Add(new DataGridViewTextBoxColumn { Name = "Targets", HeaderText = "Targets", DataPropertyName = "TargetTypes" });
+            _grid.Columns.Add(new DataGridViewLinkColumn
+            {
+                Name = "StartStop",
+                HeaderText = "",
+                DataPropertyName = "ActionStartStop",
+                TrackVisitedState = false,
+                SortMode = DataGridViewColumnSortMode.Automatic
+            });
+            _grid.Columns.Add(new DataGridViewLinkColumn
+            {
+                Name = "Watch",
+                HeaderText = "",
+                DataPropertyName = "ActionWatch",
+                TrackVisitedState = false,
+                SortMode = DataGridViewColumnSortMode.Automatic
+            });
+            _grid.Columns.Add(new DataGridViewLinkColumn
+            {
+                Name = "ViewData",
+                HeaderText = "",
+                DataPropertyName = "ActionViewData",
+                TrackVisitedState = false,
+                SortMode = DataGridViewColumnSortMode.Automatic
+            });
+        }
+
+        public void SetContext(DBADashContext context)
+        {
+            if (context == _context) return;
+            _context = context;
+            RefreshData();
+        }
+
+        private async void RefreshData()
+        {
+            if (_context == null) return;
+
+            // Cancel any in-flight fan-out (e.g. a rapid context switch or a second Refresh click).
+            _cts?.Cancel();
+            var cts = _cts = new CancellationTokenSource();
+
+            var ids = _context.InstanceIDs?.Where(id => id > 0).Distinct().ToList() ?? new List<int>();
+
+            // Drop rows for instances no longer in scope (e.g. a different group was selected), but keep in-scope
+            // instances' existing rows - each instance's rows are replaced when its own reply lands, so a slow or missed
+            // instance keeps its last-known sessions rather than disappearing.
+            PruneToScope(new HashSet<int>(ids));
+            RebuildGrid();
+
+            _total = ids.Count;
+            _collected = 0;
+            _excluded = 0;
+            _offline = 0;
+            _failed = 0;
+            _problems.Clear();
+
+            if (ids.Count == 0)
+            {
+                _refreshRunning = false;
+                _status.Text = "No instances in scope.";
+                _status.ToolTipText = null;
+                return;
+            }
+
+            _refreshRunning = true;
+            _tsRefresh.Enabled = false;
+            RenderStatus();
+
+            string error = null;
+            try
+            {
+                await XESessionController.ListSessionsMultiAsync(ids, MaxConcurrency, (result, rows) =>
+                {
+                    if (cts.IsCancellationRequested) return Task.CompletedTask;
+                    if (result.Ok && rows != null)
+                    {
+                        ReplaceInstanceRows(result.InstanceID, rows);
+                        _collected++;
+                        RebuildGrid();
+                    }
+                    else if (result.Offline)
+                    {
+                        _offline++;
+                        _problems.Add($"{result.Label}: {result.Message}");
+                    }
+                    else if (result.Skipped)
+                    {
+                        _excluded++;
+                    }
+                    else
+                    {
+                        _failed++;
+                        _problems.Add($"{result.Label}: {result.Message}");
+                    }
+                    RenderStatus();
+                    return Task.CompletedTask;
+                }, cts.Token);
+
+                if (cts.IsCancellationRequested) return;
+                _lastRefreshTime = DateTime.Now;
+            }
+            catch (OperationCanceledException)
+            {
+                // Superseded by a newer refresh - the newer run owns the grid + status.
+            }
+            catch (Exception ex)
+            {
+                if (!cts.IsCancellationRequested) error = ex.Message;
+            }
+            finally
+            {
+                // Only the owning (non-superseded) run finalises the UI, and it always renders the completed summary here
+                // so the progress info persists after the run ends (rather than depending on the success path alone).
+                if (_cts == cts)
+                {
+                    _refreshRunning = false;
+                    _tsRefresh.Enabled = true;
+                    if (error != null)
+                    {
+                        _status.Text = error;
+                        _status.ToolTipText = null;
+                    }
+                    else
+                    {
+                        RenderStatus();
+                    }
+                    // This run still owns _cts - clear it so the next refresh's _cts?.Cancel() doesn't hit the CTS we're
+                    // about to dispose (which would throw ObjectDisposedException).
+                    _cts = null;
+                }
+                // Each run disposes its own CTS: the await has returned by here so the token is no longer observed.
+                // Everything is UI-thread affine, so a superseded run reaching this point can't race the owning run.
+                cts.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Projects the master table (<see cref="_all"/>) into the grid-bound table, including only running sessions when
+        /// "Running only" is ticked.  Deliberately never touches the bound view's RowFilter / Sort, so the user's column
+        /// filters and sort order (owned by the grid) survive every refresh and toggle.
+        /// </summary>
+        private void RebuildGrid()
+        {
+            var runningOnly = _tsRunningOnly.Checked;
+            _sessions.BeginLoadData();
+            try
+            {
+                _sessions.Rows.Clear();
+                foreach (DataRow r in _all.Rows)
+                {
+                    if (runningOnly && !(r["IsRunning"] != DBNull.Value && Convert.ToBoolean(r["IsRunning"]))) continue;
+                    if (IsExcludedByName(r["Name"] as string)) continue;
+                    _sessions.ImportRow(r);
+                }
+            }
+            finally
+            {
+                _sessions.EndLoadData();
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a session should be excluded from the grid based on the "Exclude ..." filter toggles.
+        /// The name comparison is case-insensitive.
+        /// </summary>
+        private bool IsExcludedByName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return false;
+
+            if (_tsExcludeSystemHealth.Checked &&
+                string.Equals(name, "system_health", StringComparison.OrdinalIgnoreCase)) return true;
+
+            if (_tsExcludeTelemetry.Checked &&
+                string.Equals(name, "telemetry_xevents", StringComparison.OrdinalIgnoreCase)) return true;
+
+            if (_tsExcludeAlwaysOnHealth.Checked &&
+                string.Equals(name, "AlwaysOn_health", StringComparison.OrdinalIgnoreCase)) return true;
+
+            if (_tsExcludeDBADash.Checked &&
+                (string.Equals(name, "DBADash_1", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(name, "DBADash_2", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(name, "DBADash_AdHoc", StringComparison.OrdinalIgnoreCase))) return true;
+
+            return false;
+        }
+
+        /// <summary>Removes master rows for instances that are no longer in the current context.</summary>
+        private void PruneToScope(HashSet<int> inScope)
+        {
+            for (var i = _all.Rows.Count - 1; i >= 0; i--)
+            {
+                var row = _all.Rows[i];
+                if (row["InstanceID"] == DBNull.Value || !inScope.Contains(Convert.ToInt32(row["InstanceID"])))
+                {
+                    row.Delete();
+                }
+            }
+            _all.AcceptChanges();
+        }
+
+        /// <summary>Swaps in a fresh set of master rows for one instance (removes its old rows, adds the new).</summary>
+        private void ReplaceInstanceRows(int instanceID, DataTable rows)
+        {
+            for (var i = _all.Rows.Count - 1; i >= 0; i--)
+            {
+                var row = _all.Rows[i];
+                if (row["InstanceID"] != DBNull.Value && Convert.ToInt32(row["InstanceID"]) == instanceID)
+                {
+                    row.Delete();
+                }
+            }
+            _all.AcceptChanges();
+            _all.Merge(rows, false, MissingSchemaAction.Ignore);
+        }
+
+        private void RenderStatus()
+        {
+            var shown = _sessions.DefaultView.Count; // after the running-only projection + the user's column filters
+            var totalAll = _all.Rows.Count;
+            var sessionText = shown == totalAll
+                ? $"{shown} session{Plural(shown)}"
+                : $"{shown} of {totalAll} session{Plural(totalAll)}";
+
+            var verb = _refreshRunning ? "Collecting" : "Collected";
+            var sb = new StringBuilder($"{verb} {_collected} of {_total} instance{Plural(_total)}");
+            var notes = new List<string>();
+            if (_excluded > 0) notes.Add($"{_excluded} excluded");
+            if (_offline > 0) notes.Add($"{_offline} offline");
+            if (notes.Count > 0) sb.Append($" ({string.Join(", ", notes)})");
+            if (_failed > 0) sb.Append($" · {_failed} not responding");
+            sb.Append($" — {sessionText}");
+            if (!_refreshRunning && _lastRefreshTime.HasValue) sb.Append($" · updated {_lastRefreshTime:HH:mm:ss}");
+            _status.Text = sb.ToString();
+
+            // Detail of the instances that didn't return anything, so the user can see what's missing from the grid.
+            _status.ToolTipText = _problems.Count == 0 ? null : string.Join(Environment.NewLine, _problems);
+        }
+
+        private void Grid_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
+        {
+            _grid.AutoResizeColumnsWithMaxColumnWidth(DataGridViewAutoSizeColumnsMode.DisplayedCells);
+        }
+
+        /// <summary>The target must carry an event stream to view/watch - only event_file and ring_buffer qualify.</summary>
+        private static bool HasReadableTarget(string targetTypes) =>
+            !string.IsNullOrEmpty(targetTypes) &&
+            (targetTypes.IndexOf("event_file", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             targetTypes.IndexOf("ring_buffer", StringComparison.OrdinalIgnoreCase) >= 0);
+
+        private async void Grid_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0 || e.ColumnIndex < 0 || e.RowIndex >= _grid.Rows.Count) return;
+            if (_grid.Rows[e.RowIndex].DataBoundItem is not DataRowView drv) return;
+
+            var row = drv.Row;
+            var instanceId = row["InstanceID"] != DBNull.Value ? Convert.ToInt32(row["InstanceID"]) : 0;
+            var session = row["Name"] as string;
+            var running = row["IsRunning"] != DBNull.Value && Convert.ToBoolean(row["IsRunning"]);
+            var canManage = row["CanManage"] != DBNull.Value && Convert.ToBoolean(row["CanManage"]);
+            var canWatch = row["CanWatch"] != DBNull.Value && Convert.ToBoolean(row["CanWatch"]);
+            var readable = HasReadableTarget(row["TargetTypes"] as string);
+            if (instanceId <= 0) return;
+
+            switch (_grid.Columns[e.ColumnIndex].Name)
+            {
+                case "Instance":
+                    NavigateToInstance(instanceId);
+                    break;
+
+                case "StartStop" when canManage && !string.IsNullOrEmpty(session):
+                    await StartStopAsync(instanceId, session, running);
+                    break;
+
+                case "Watch" when running && canWatch && !string.IsNullOrEmpty(session):
+                    XETraceLauncher.LaunchWatch(this, BuildContext(instanceId), session);
+                    break;
+
+                case "ViewData" when running && canWatch && readable && !string.IsNullOrEmpty(session):
+                    XETraceLauncher.LaunchViewData(this, BuildContext(instanceId), session);
+                    break;
+
+                case "Session" when !string.IsNullOrEmpty(session):
+                    await ScriptDdlAsync(instanceId, session);
+                    break;
+            }
+        }
+
+        /// <summary>Scripts the session's CREATE EVENT SESSION DDL and opens it in the shared code viewer.</summary>
+        private async Task ScriptDdlAsync(int instanceId, string session)
+        {
+            _status.Text = $"Scripting {session}...";
+            try
+            {
+                var ddl = await XESessionController.ScriptSessionAsync(BuildContext(instanceId), session, (_, _, _) => { });
+                if (string.IsNullOrEmpty(ddl))
+                {
+                    _status.Text = $"Couldn't script {session}.";
+                    return;
+                }
+                Common.ShowCodeViewer(ddl, $"Extended Events - {session}");
+                _status.Text = $"Scripted {session}.";
+            }
+            catch (Exception ex)
+            {
+                _status.Text = ex.Message;
+                MessageBox.Show(this, ex.Message, "Extended Events", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        /// <summary>Selects the instance's Extended Events node in the tree (drills from the current context's instance).</summary>
+        private void NavigateToInstance(int instanceId)
+        {
+            Main.MainFormInstance?.Instance_Selected(this, new Main.InstanceSelectedEventArgs
+            {
+                InstanceID = instanceId,
+                Tab = Main.Tabs.ExtendedEvents,
+                SearchFromRoot = true
+            });
+        }
+
+        /// <summary>A minimal, fully messaging-capable context for one instance (agents/connection resolve from CommonData).</summary>
+        private static DBADashContext BuildContext(int instanceId) =>
+            new() { InstanceID = instanceId, InstanceName = XEInstanceLabels.Resolve(instanceId, instanceId.ToString()) };
+
+        /// <summary>
+        /// Starts / stops the session on the given instance, then refreshes so the grid reflects the real state.  Uses the
+        /// same outcome checks as the per-instance viewer so a rejected or ineffective operation is surfaced, never a
+        /// phantom success.
+        /// </summary>
+        private async Task StartStopAsync(int instanceId, string session, bool running)
+        {
+            var label = XEInstanceLabels.Resolve(instanceId, instanceId.ToString());
+
+            // Confirm both directions: stopping interrupts an active capture, and starting begins a capture on the
+            // instance - so ask before either.
+            var action = running ? "Stop" : "Start";
+            if (MessageBox.Show(this,
+                    $"{action} the Extended Events session '{session}' on {label}?",
+                    $"{action} Session", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+            {
+                return;
+            }
+
+            var op = running ? XESessionOperation.Stop : XESessionOperation.Start;
+            var verb = running ? "stopped" : "started";
+            _status.Text = $"{op} {session} on {label}...";
+            try
+            {
+                var outcome = await XESessionController.ControlSessionAsync(BuildContext(instanceId), session, op,
+                    (_, _, _) => { });
+                if (!outcome.Ok)
+                {
+                    var msg = string.IsNullOrWhiteSpace(outcome.Message) ? $"{session} could not be {verb}." : outcome.Message;
+                    _status.Text = msg;
+                    MessageBox.Show(this, msg, "Extended Events", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                if (outcome.Running.HasValue && outcome.Running.Value == running)
+                {
+                    var msg = $"{session} was not {verb} - it is still {(outcome.Running.Value ? "running" : "stopped")}.";
+                    _status.Text = msg;
+                    MessageBox.Show(this, msg, "Extended Events", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                _status.Text = $"{session} {verb} on {label}.";
+            }
+            catch (Exception ex)
+            {
+                _status.Text = ex.Message;
+                MessageBox.Show(this, ex.Message, "Extended Events", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+            finally
+            {
+                // Refresh just this instance's rows to reflect the real state - re-fanning out to every instance would
+                // be excessive for a single start/stop.
+                await RefreshInstanceAsync(instanceId);
+            }
+        }
+
+        /// <summary>Re-lists a single instance and swaps in its rows, without disturbing the aggregate status / counters.</summary>
+        private async Task RefreshInstanceAsync(int instanceId)
+        {
+            try
+            {
+                await XESessionController.ListSessionsMultiAsync(new[] { instanceId }, 1, (result, rows) =>
+                {
+                    if (result.Ok && rows != null)
+                    {
+                        ReplaceInstanceRows(result.InstanceID, rows);
+                        RebuildGrid();
+                    }
+                    return Task.CompletedTask;
+                });
+            }
+            catch (Exception ex)
+            {
+                // Best-effort single-instance refresh - the session was already started/stopped; the grid just keeps its
+                // last-known rows for this instance if the re-list fails.
+                Serilog.Log.Debug(ex, "Multi-instance XE: single-instance refresh failed for instance {instanceID}.", instanceId);
+            }
+        }
+
+        private static string Plural(int n) => n == 1 ? string.Empty : "s";
+    }
+}

--- a/DBADashGUI/XETrace/MultiInstanceXEView.resx
+++ b/DBADashGUI/XETrace/MultiInstanceXEView.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/DBADashGUI/XETrace/QuickXETrace.cs
+++ b/DBADashGUI/XETrace/QuickXETrace.cs
@@ -92,6 +92,13 @@ namespace DBADashGUI.XETrace
         // Guards the AG checkbox handler while we set it programmatically (context switch / template load).
         private bool _loadingInstances;
 
+        // At a root / instance-group node the tab has no single "current instance": the instance selector is populated
+        // from the group's instances (all unchecked - the user picks which to trace).  Group nodes all report InstanceID
+        // 0, so we track the group's instance set here to know when to re-sync the selector (switching between two groups).
+        private HashSet<int> _lastGroupScope;
+
+        private bool IsGroupMode => _context is { InstanceID: <= 0 };
+
         // Bumped on every trace start and whenever a running trace is stopped to switch instances.  Batch and summary
         // callbacks capture the generation they were started with and drop themselves if it no longer matches, so a
         // cancelled trace's in-flight events can't leak into a freshly cleared grid.
@@ -386,7 +393,13 @@ namespace DBADashGUI.XETrace
             // As a context-following tab this is re-invoked whenever the tree selection changes.  A stopped/history
             // grid holds nothing that needs protecting (the events live in the DB), so only a *running* trace prompts.
             // We remember which history snapshot each instance was showing so switching back can re-load it.
-            var switchingInstance = _context is { InstanceID: > 0 } && context?.InstanceID != _context.InstanceID;
+            // A switch is any change of node identity - or leaving a running (possibly group) trace.  Group nodes all
+            // report InstanceID 0, so also treat a change of the group's instance set as a switch (handled below).
+            // Dropping from a group (InstanceID 0) down to an instance is also a switch, so the group-level picks are
+            // cleared and the instance seeds only its own current instance (otherwise the root selection leaks down).
+            var leavingGroupForInstance = _context is { InstanceID: <= 0 } && context is { InstanceID: > 0 };
+            var switchingInstance = _context != null && context?.InstanceID != _context.InstanceID &&
+                                    (_context.InstanceID > 0 || _isRunning || leavingGroupForInstance);
             if (switchingInstance)
             {
                 if (_isRunning)
@@ -433,7 +446,9 @@ namespace DBADashGUI.XETrace
             // The service may have ad-hoc XE tracing disabled for this instance.  Keep the tab (the user holds the
             // AdhocXE role) but disable the config + start controls and explain, instead of loading the catalog and
             // letting a trace be built that would only be rejected on start.
-            _adhocServiceAvailable = context is { InstanceID: > 0 } && context.CanRunAdhocXE;
+            // At group level availability is per-instance (checked when the trace fans out / rejected per instance), so
+            // the tab is available; at instance level it follows the collect agent's advertised capability.
+            _adhocServiceAvailable = IsGroupMode || (context is { InstanceID: > 0 } && context.CanRunAdhocXE);
             if (!_adhocServiceAvailable)
             {
                 if (switchingInstance) ResetInstances();
@@ -446,10 +461,17 @@ namespace DBADashGUI.XETrace
             }
             tsStartTrace.ToolTipText = null;
 
-            // Reset the instance list on a switch (the AG/added instances belonged to the previous instance); otherwise
-            // just make sure the current instance is seeded (first load, or re-selecting the same instance).
+            // Instance selector: at instance level seed the mandatory current instance; at group level sync the list to
+            // the group's instances (all unchecked - the user picks which to trace).  A switch resets first.
             if (switchingInstance) ResetInstances();
+            if (IsGroupMode) ResetGroupInstancesOnScopeChange();
             else EnsureCurrentInstanceSeeded();
+
+            // AG-replica resolution and the inline history dropdown both need a single current instance, so they're only
+            // meaningful at instance level; at group level use the "XE Trace History" tab for history.
+            chkIncludeAg.Enabled = !IsGroupMode;
+            tsHistory.Enabled = !IsGroupMode;
+
             SetRunningState(_isRunning); // re-enable config controls when returning from a disabled instance
             UpdateXelCaptureState(); // engine edition is now known (in-memory), so Auto+Azure DB can disable xel capture
             _ = LoadCatalogAsync();
@@ -484,11 +506,15 @@ namespace DBADashGUI.XETrace
 
         private async Task LoadCatalogAsync()
         {
-            if (_context is not { InstanceID: > 0 }) return;
+            // At instance level use the current instance; at group level use a representative instance from the group so
+            // the event/field pickers are populated (the trace definition is validated per instance on the service, so an
+            // event a specific instance's version doesn't support is rejected there).
+            var catalogContext = _context is { InstanceID: > 0 } ? _context : RepresentativeInstanceContext();
+            if (catalogContext == null) return;
             SetStatus("Loading extended events catalog...", string.Empty, DashColors.Information);
             try
             {
-                _catalog = await XETraceController.GetCatalogAsync(_context, ControllerStatus);
+                _catalog = await XETraceController.GetCatalogAsync(catalogContext, ControllerStatus);
                 // An event name can exist in several packages (e.g. error_reported in sqlserver and xesvlpkg); show
                 // one entry per name, preferring the sqlserver package (the one the trace built-ins/pickers mean).
                 _allEvents = _catalog.Events
@@ -1069,11 +1095,21 @@ namespace DBADashGUI.XETrace
 
         private void AddInstancesViaPicker()
         {
-            if (_context is not { InstanceID: > 0 }) return;
-            var existing = new HashSet<int>(clbInstances.Items.Cast<TraceInstance>().Select(t => t.InstanceID)) { _context.InstanceID };
+            if (_context == null) return;
+            var existing = new HashSet<int>(clbInstances.Items.Cast<TraceInstance>().Select(t => t.InstanceID));
+            if (_context is { InstanceID: > 0 }) existing.Add(_context.InstanceID);
+            // At group level, offer only the instances in this node's scope (the tag group / all at root); at instance
+            // level offer every monitored instance (so AG replicas / any cross-instance can be added).  Only offer
+            // instances that actually support Extended Events - an older-version instance can't be traced and would also
+            // fail the catalog load if it happened to be the first (representative) one added.
+            var scope = IsGroupMode ? _context.InstanceIDs : null;
             var candidates = CommonData.Instances.Rows.Cast<DataRow>()
                 .Select(XEInstanceLabels.ToCandidate)
-                .Where(c => c != null && !existing.Contains(c.InstanceID))
+                .Where(c => c != null && !existing.Contains(c.InstanceID) && (scope == null || scope.Contains(c.InstanceID))
+                            && BuildContextForInstance(c.InstanceID, c.ListLabel).IsXESupported)
+                // When grouping by tag, an instance in more than one tag group appears once per group in
+                // CommonData.Instances, so collapse to one candidate per instance to avoid duplicate picker entries.
+                .DistinctBy(c => c.InstanceID)
                 .ToList();
             if (candidates.Count == 0)
             {
@@ -1088,6 +1124,10 @@ namespace DBADashGUI.XETrace
                 if (byId.TryGetValue(id, out var c)) AddInstanceItem(id, c.ListLabel, isAg: false, check: true);
             }
             UpdateInstanceCount();
+
+            // Group level has no "current instance" to load the events catalog from, so load it from the first added
+            // instance once we have one (the config pickers need it, and Start refuses until it's available).
+            if (IsGroupMode && _catalog.Events.Count == 0) _ = LoadCatalogAsync();
         }
 
         /// <summary>Adds an instance to the instances list (deduped by InstanceID) with the given checked state.</summary>
@@ -1101,8 +1141,27 @@ namespace DBADashGUI.XETrace
 
         private void UpdateInstanceCount()
         {
-            var n = Math.Max(1, clbInstances.CheckedItems.Count); // the current instance is always checked
-            lblInstanceCount.Text = $"Tracing {n} instance{(n == 1 ? string.Empty : "s")}";
+            // Instance level always has the (mandatory) current instance checked; group level can have none selected.
+            var n = clbInstances.CheckedItems.Count;
+            lblInstanceCount.Text = n == 0
+                ? "No instances selected"
+                : $"Tracing {n} instance{(n == 1 ? string.Empty : "s")}";
+        }
+
+        /// <summary>
+        /// Group level only: the instance selector starts empty and the user adds instances through the "Add instance"
+        /// picker (better than scrolling a listbox pre-filled with a whole group / the entire estate).  We only clear it
+        /// when the group's instance set actually changes (switching between two groups); re-selecting the same group
+        /// node keeps the user's picks, so the frequent context-following SetContext calls don't wipe the selection.
+        /// </summary>
+        private void ResetGroupInstancesOnScopeChange()
+        {
+            var scope = _context?.InstanceIDs ?? new HashSet<int>();
+            if (_lastGroupScope != null && _lastGroupScope.SetEquals(scope)) return; // same group - keep current selection
+            _lastGroupScope = new HashSet<int>(scope);
+            _loadingInstances = true;
+            try { clbInstances.Items.Clear(); } finally { _loadingInstances = false; }
+            UpdateInstanceCount();
         }
 
         /// <summary>The current instance is mandatory - block any attempt to uncheck its (IsCurrent) list item.</summary>
@@ -1116,13 +1175,15 @@ namespace DBADashGUI.XETrace
             BeginInvoke(new Action(UpdateInstanceCount));
         }
 
-        /// <summary>Resets the instance selection to just the (mandatory) current instance - used when it changes.</summary>
+        /// <summary>Resets the instance selection when the node changes - to the current instance, or (group level) empty
+        /// so the group's instances re-sync from scratch on the incoming node.</summary>
         private void ResetInstances()
         {
             _loadingInstances = true;
             try { chkIncludeAg.Checked = false; } finally { _loadingInstances = false; }
             clbInstances.Items.Clear();
-            EnsureCurrentInstanceSeeded();
+            _lastGroupScope = null; // force a fresh group sync (or none) for the incoming node
+            if (!IsGroupMode) EnsureCurrentInstanceSeeded();
             UpdateInstanceCount();
         }
 
@@ -1156,7 +1217,9 @@ namespace DBADashGUI.XETrace
                     ? _context
                     : BuildContextForInstance(item.InstanceID, item.Name));
             }
-            if (list.Count == 0) list.Add(_context); // safety - the current instance is always seeded + checked
+            // Instance level always has the current instance checked; group level can legitimately have none selected
+            // (Start is gated on there being at least one - see StartAsync).
+            if (list.Count == 0 && _context is { InstanceID: > 0 }) list.Add(_context);
             return list.GroupBy(c => c.InstanceID).Select(g => g.First()).ToList();
         }
 
@@ -1166,6 +1229,14 @@ namespace DBADashGUI.XETrace
             InstanceName = name,
             RegularInstanceIDsWithHidden = new HashSet<int> { instanceId }
         };
+
+        /// <summary>Group level: an instance to load the catalog from - the first checked, else the first listed.</summary>
+        private DBADashContext RepresentativeInstanceContext()
+        {
+            var item = clbInstances.CheckedItems.Cast<TraceInstance>().FirstOrDefault()
+                       ?? clbInstances.Items.Cast<TraceInstance>().FirstOrDefault();
+            return item == null ? null : BuildContextForInstance(item.InstanceID, item.Name);
+        }
 
         // ---- Run / stop --------------------------------------------------------------------------
 
@@ -1258,17 +1329,29 @@ namespace DBADashGUI.XETrace
                 return;
             }
 
-            // Every event carries its data columns from the catalog (the service applies data-column filters and the
-            // severity floor per the columns each event exposes).  If the catalog hasn't loaded the events would be
-            // sent with no columns, so refuse to start until it's available rather than run a mis-filtered trace.
-            if (_catalog.Events.Count == 0)
+            var instances = EffectiveInstanceContexts();
+            if (instances.Count == 0)
             {
-                SetStatus("Extended events catalog is still loading.  Wait for it to finish, then start the trace.",
-                    string.Empty, DashColors.Warning);
+                // Group level with nothing ticked - there's no instance to trace.
+                SetStatus("Select at least one instance to trace.", string.Empty, DashColors.Warning);
                 return;
             }
 
-            var instances = EffectiveInstanceContexts();
+            // Every event carries its data columns from the catalog (the service applies data-column filters and the
+            // severity floor per the columns each event exposes).  If the catalog hasn't loaded the events would be
+            // sent with no columns, so refuse to start until it's available.  At group level there's no current instance
+            // to load it from until instances are added, so load it now (from a selected instance) rather than getting
+            // stuck telling the user to wait for a load that was never started.
+            if (_catalog.Events.Count == 0)
+            {
+                await LoadCatalogAsync();
+                if (_catalog.Events.Count == 0)
+                {
+                    SetStatus("Couldn't load the Extended Events catalog.  Check the selected instance(s) support " +
+                              "Extended Events, then try again.", string.Empty, DashColors.Warning);
+                    return;
+                }
+            }
 
             // First-run cost warning.  XE traces add overhead to the monitored instance; make sure the user understands
             // that once, before they build the habit.  Suppressible ("Don't show this again") via a user setting.

--- a/DBADashGUI/XETrace/XESessionController.cs
+++ b/DBADashGUI/XETrace/XESessionController.cs
@@ -1,7 +1,13 @@
 using DBADash.Messaging;
 using DBADashGUI.Messaging;
+using Microsoft.Data.SqlClient;
+using Serilog;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Data;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DBADashGUI.XETrace
@@ -90,6 +96,187 @@ namespace DBADashGUI.XETrace
             }
             return new XEListOutcome(ok, result, outcomeMessage);
         }
+
+        /// <summary>
+        /// Per-instance outcome of a multi-instance session list (see <see cref="ListSessionsMultiAsync"/>), so the view
+        /// can show a footer of what did / didn't respond.  We never message an instance that is <paramref name="Offline"/>
+        /// (currently flagged offline in the repo - it would just make the fan-out wait on a connection timeout) or
+        /// <paramref name="Skipped"/> (unsupported SQL version / messaging unavailable); anything else that returned no
+        /// sessions was messaged but failed or timed out.
+        /// </summary>
+        public sealed record XEInstanceListResult(int InstanceID, string Label, bool Ok, bool Skipped, bool Offline,
+            string Message, int SessionCount);
+
+        /// <summary>
+        /// Lists the existing XE sessions across many instances at once by fanning <see cref="ListSessionsAsync"/> out to
+        /// each, with bounded concurrency so a large estate doesn't message every agent simultaneously.  As each instance
+        /// completes - whether it returned sessions, failed / timed out, or was skipped (unsupported / no messaging) -
+        /// <paramref name="onInstanceResult"/> is invoked with its outcome and (for a success) its rows, stamped with the
+        /// <c>Instance</c> label + <c>InstanceID</c>.  Reporting every instance (not just successes) lets the caller show
+        /// live progress and keep an instance's last-known rows when a single refresh misses it, rather than blanking it -
+        /// offline / no-permission / older / slow-to-respond instances are the normal case at scale.
+        ///
+        /// Everything is UI-thread affine via the WinForms synchronization context - the per-instance requests run their
+        /// I/O off-thread but their continuations (and therefore <paramref name="onInstanceResult"/>) resume on the
+        /// caller's thread, so the callback can safely touch the grid without marshalling.  The returned list is the full
+        /// set of per-instance outcomes.
+        /// </summary>
+        public static async Task<IReadOnlyList<XEInstanceListResult>> ListSessionsMultiAsync(
+            IEnumerable<int> instanceIDs, int maxConcurrency, Func<XEInstanceListResult, DataTable, Task> onInstanceResult,
+            CancellationToken cancellationToken = default)
+        {
+            if (onInstanceResult == null) throw new ArgumentNullException(nameof(onInstanceResult));
+            var ids = (instanceIDs ?? Enumerable.Empty<int>()).Where(id => id > 0).Distinct().ToList();
+            var results = new ConcurrentBag<XEInstanceListResult>();
+            using var throttle = new SemaphoreSlim(Math.Max(1, maxConcurrency));
+            // ListSessionsAsync manages its own status; the multi-view owns the aggregate status, so swallow per-instance.
+            void NoStatus(string message, string details, System.Drawing.Color color) { }
+
+            // Instances the collector currently can't reach: messaging one just makes the fan-out wait on a source
+            // connection timeout before failing, so short-circuit them (best-effort - on lookup failure we message all).
+            var offline = await GetOfflineInstanceIDsAsync();
+
+            async Task RunOne(int id)
+            {
+                var label = XEInstanceLabels.Resolve(id, id.ToString());
+                XEInstanceListResult result;
+                DataTable rows = null;
+                try
+                {
+                    if (offline.Contains(id))
+                    {
+                        result = new XEInstanceListResult(id, label, false, false, true,
+                            "Instance is currently offline - not contacted.", 0);
+                    }
+                    else
+                    {
+                        var context = new DBADashContext { InstanceID = id, InstanceName = label };
+                        if (!context.IsXESupported)
+                        {
+                            result = new XEInstanceListResult(id, label, false, true, false,
+                                "Extended events aren't supported on this SQL Server version.", 0);
+                        }
+                        else if (!context.CanMessage)
+                        {
+                            result = new XEInstanceListResult(id, label, false, true, false,
+                                "Messaging isn't available for this instance.", 0);
+                        }
+                        else
+                        {
+                            await throttle.WaitAsync(cancellationToken);
+                            try
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                var outcome = await ListSessionsAsync(context, NoStatus);
+                                if (outcome.Ok && outcome.Sessions != null)
+                                {
+                                    StampInstance(outcome.Sessions, id, label, context);
+                                    rows = outcome.Sessions;
+                                    result = new XEInstanceListResult(id, label, true, false, false, null, rows.Rows.Count);
+                                }
+                                else
+                                {
+                                    result = new XEInstanceListResult(id, label, false, false, false,
+                                        outcome.Message ?? "No response from the service.", 0);
+                                }
+                            }
+                            finally
+                            {
+                                throttle.Release();
+                            }
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw; // superseded by a newer refresh - drop this instance's result silently
+                }
+                catch (Exception ex)
+                {
+                    result = new XEInstanceListResult(id, label, false, false, false, ex.Message, 0);
+                }
+
+                results.Add(result);
+                if (!cancellationToken.IsCancellationRequested) await onInstanceResult(result, rows);
+            }
+
+            await Task.WhenAll(ids.Select(RunOne));
+            return results.OrderBy(r => r.Label, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        /// <summary>
+        /// The InstanceIDs currently flagged offline in the repo (<c>dbo.OfflineInstances</c> where <c>IsCurrent = 1</c> -
+        /// set by the collector when it can't reach an instance).  Best-effort: any failure returns an empty set so the
+        /// fan-out simply messages every instance (its previous behaviour) rather than hiding instances on a lookup error.
+        /// </summary>
+        private static async Task<HashSet<int>> GetOfflineInstanceIDsAsync()
+        {
+            var offline = new HashSet<int>();
+            try
+            {
+                await using var cn = new SqlConnection(Common.ConnectionString);
+                await using var cmd = new SqlCommand(
+                    "SELECT InstanceID FROM dbo.OfflineInstances WHERE IsCurrent = 1", cn);
+                await cn.OpenAsync();
+                await using var rdr = await cmd.ExecuteReaderAsync();
+                while (await rdr.ReadAsync()) offline.Add(rdr.GetInt32(0));
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Multi-instance XE: couldn't read the offline instance list; messaging all instances.");
+            }
+            return offline;
+        }
+
+        /// <summary>
+        /// Adds the left-most <c>Instance</c> label column (+ hidden <c>InstanceID</c>) to a per-instance session table so
+        /// the aggregated grid can tell rows from different instances apart, plus per-row <c>CanManage</c> / <c>CanWatch</c>
+        /// policy flags (resolved from the instance's collect-agent policy + the caller's role for each session name) so
+        /// the grid can gate the start/stop, watch and view-data action links exactly like the per-instance viewer does.
+        /// </summary>
+        private static void StampInstance(DataTable dt, int instanceID, string label, DBADashContext context)
+        {
+            if (!dt.Columns.Contains("Instance")) dt.Columns.Add("Instance", typeof(string)).SetOrdinal(0);
+            if (!dt.Columns.Contains("InstanceID")) dt.Columns.Add("InstanceID", typeof(int));
+            if (!dt.Columns.Contains("CanManage")) dt.Columns.Add("CanManage", typeof(bool));
+            if (!dt.Columns.Contains("CanWatch")) dt.Columns.Add("CanWatch", typeof(bool));
+            // The action-link text is precomputed here (rather than in the grid's CellFormatting) so the link columns can
+            // bind to real columns - reading sibling-row data during formatting is unsafe while the bound view is being
+            // merged/pruned and can throw from DataGridViewRow.DataBoundItem.  Empty text = a blank, non-clickable cell.
+            if (!dt.Columns.Contains("ActionStartStop")) dt.Columns.Add("ActionStartStop", typeof(string));
+            if (!dt.Columns.Contains("ActionWatch")) dt.Columns.Add("ActionWatch", typeof(string));
+            if (!dt.Columns.Contains("ActionViewData")) dt.Columns.Add("ActionViewData", typeof(string));
+            var hasStartTime = dt.Columns.Contains("StartTime");
+            foreach (DataRow r in dt.Rows)
+            {
+                var name = dt.Columns.Contains("Name") ? r["Name"] as string : null;
+                var running = dt.Columns.Contains("IsRunning") && r["IsRunning"] != DBNull.Value &&
+                              Convert.ToBoolean(r["IsRunning"]);
+                var canManage = !string.IsNullOrEmpty(name) && context.CanManageXESession(name);
+                var canWatch = !string.IsNullOrEmpty(name) && context.CanWatchXESession(name);
+                var readable = HasReadableTarget(dt.Columns.Contains("TargetTypes") ? r["TargetTypes"] as string : null);
+
+                r["Instance"] = label;
+                r["InstanceID"] = instanceID;
+                r["CanManage"] = canManage;
+                r["CanWatch"] = canWatch;
+                r["ActionStartStop"] = canManage ? (running ? "Stop" : "Start") : string.Empty;
+                r["ActionWatch"] = running && canWatch ? "Watch" : string.Empty;
+                r["ActionViewData"] = running && canWatch && readable ? "View Data" : string.Empty;
+                // dm_xe_sessions.create_time is server-LOCAL;
+                // so the aggregated grid shows every instance's start time in one consistent (the app's) time zone.
+                if (hasStartTime && r["StartTime"] != DBNull.Value)
+                {
+                    r["StartTime"] = Convert.ToDateTime(r["StartTime"]).AddMinutes(context.UTCOffset).ToAppTimeZone();
+                }
+            }
+        }
+
+        /// <summary>The target must carry an event stream to view/watch - only event_file and ring_buffer qualify.</summary>
+        private static bool HasReadableTarget(string targetTypes) =>
+            !string.IsNullOrEmpty(targetTypes) &&
+            (targetTypes.IndexOf("event_file", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             targetTypes.IndexOf("ring_buffer", StringComparison.OrdinalIgnoreCase) >= 0);
 
         /// <summary>
         /// Starts or stops an existing session.  Returns an <see cref="XEControlOutcome"/> carrying whether the service

--- a/DBADashGUI/XETrace/XETraceSessionLinks.cs
+++ b/DBADashGUI/XETrace/XETraceSessionLinks.cs
@@ -5,24 +5,53 @@ using System.Windows.Forms;
 namespace DBADashGUI.XETrace
 {
     /// <summary>
+    /// Base for the Trace History report's link columns: resolves the row's trace session id and provides the shared
+    /// "captured data was deleted" guard (deleted rows are only visible via the admin "Show deleted" toggle).
+    /// </summary>
+    internal abstract class XETraceSessionLinkColumnInfo : LinkColumnInfo
+    {
+        public string SessionIdColumn { get; set; } = "XETraceSessionID";
+        public string DeletedDateColumn { get; set; } = "DeletedDate";
+
+        /// <summary>Resolves the row's trace session id; false (with <paramref name="sessionId"/> = 0) if the cell is null.</summary>
+        protected bool TryGetSessionId(DataGridViewRow row, out long sessionId)
+        {
+            sessionId = 0;
+            var sessionVal = row.Cells[SessionIdColumn].Value.DBNullToNull();
+            if (sessionVal == null) return false;
+            sessionId = Convert.ToInt64(sessionVal);
+            return true;
+        }
+
+        /// <summary>True if the row's trace has been soft-deleted (its captured events and .xel were removed).</summary>
+        protected bool RowDataDeleted(DataGridViewRow row) =>
+            row.DataGridView.Columns.Contains(DeletedDateColumn) &&
+            row.Cells[DeletedDateColumn].Value.DBNullToNull() != null;
+
+        /// <summary>Standard "nothing to view" message for the viewer links when the captured data has been deleted.</summary>
+        protected static void ShowDataDeletedMessage(ContainerControl sender) =>
+            MessageBox.Show(sender,
+                "The captured data for this trace has been deleted, so there is nothing to view.\r\n\r\n" +
+                "The record is retained for audit only.",
+                "Trace Data", MessageBoxButtons.OK, MessageBoxIcon.Information);
+    }
+
+    /// <summary>
     /// Editable "Notes" link for the Trace History report: prompts for the row's free-text note (e.g. "Capture for
     /// issue #1234"), saves it, and refreshes the report.  The cell shows <c>NotesDisplay</c> (the note, or a prompt
     /// to add one) while the raw value being edited comes from the hidden <c>Notes</c> column.  Ownership is enforced
     /// server-side (<c>XE.XETraceSession_Notes_Upd</c> rejects editing another user's trace unless the caller is
     /// db_owner); the client also only ever shows non-admins their own sessions, so a visible row is safe here.
     /// </summary>
-    internal class XETraceEditNotesLinkColumnInfo : LinkColumnInfo
+    internal class XETraceEditNotesLinkColumnInfo : XETraceSessionLinkColumnInfo
     {
         private const int MaxNotesLength = 1000; // matches XE.XETraceSession.Notes NVARCHAR(1000)
 
-        public string SessionIdColumn { get; set; } = "XETraceSessionID";
         public string NotesColumn { get; set; } = "Notes";
 
         public override void Navigate(DBADashContext context, DataGridViewRow row, int selectedTableIndex, ContainerControl sender)
         {
-            var sessionVal = row.Cells[SessionIdColumn].Value.DBNullToNull();
-            if (sessionVal == null) return;
-            var sessionId = Convert.ToInt64(sessionVal);
+            if (!TryGetSessionId(row, out var sessionId)) return;
 
             var current = row.DataGridView.Columns.Contains(NotesColumn)
                 ? row.Cells[NotesColumn].Value.DBNullToNull() as string ?? string.Empty
@@ -55,30 +84,47 @@ namespace DBADashGUI.XETrace
     }
 
     /// <summary>
-    /// "View Data" link for the Trace History report: opens a read-only viewer over the events already captured for
-    /// the row's trace session (or the whole merged run when the row carries a RunGroupID).
+    /// Opens a read-only viewer over the events captured for the row's trace, for both viewer links on the Trace
+    /// History report:
+    /// <list type="bullet">
+    /// <item><b>"View Data"</b> (<see cref="ScopeToSession"/> = false): opens the whole merged run when the row is part
+    /// of a multi-instance trace (shared RunGroupID), else just the single session.</item>
+    /// <item><b>"Events Captured"</b> (<see cref="ScopeToSession"/> = true): always scopes to this row's own session
+    /// (forces runGroupID = null) and titles the viewer with the instance name, so the count shown in the cell (that
+    /// instance's events) matches what opens.</item>
+    /// </list>
+    /// For a single-instance trace the two are equivalent.
     /// </summary>
-    internal class XETraceViewDataLinkColumnInfo : LinkColumnInfo
+    internal class XETraceStoredDataLinkColumnInfo : XETraceSessionLinkColumnInfo
     {
-        public string SessionIdColumn { get; set; } = "XETraceSessionID";
+        /// <summary>When true, scope strictly to this row's own session ("Events Captured"); when false, open the whole
+        /// merged run for a multi-instance trace ("View Data").</summary>
+        public bool ScopeToSession { get; set; }
+
         public string RunGroupColumn { get; set; } = "RunGroupID";
-        public string DeletedDateColumn { get; set; } = "DeletedDate";
+        public string InstanceColumn { get; set; } = "InstanceGroupName";
 
         public override void Navigate(DBADashContext context, DataGridViewRow row, int selectedTableIndex, ContainerControl sender)
         {
-            var sessionVal = row.Cells[SessionIdColumn].Value.DBNullToNull();
-            if (sessionVal == null) return;
-            var sessionId = Convert.ToInt64(sessionVal);
+            if (!TryGetSessionId(row, out var sessionId)) return;
 
             // A deleted trace has had its captured data removed - there's nothing to view, so say so rather than
-            // opening an empty grid.  (Deleted rows are only visible via the admin "Show deleted" toggle.)
-            if (row.DataGridView.Columns.Contains(DeletedDateColumn) &&
-                row.Cells[DeletedDateColumn].Value.DBNullToNull() != null)
+            // opening an empty grid.
+            if (RowDataDeleted(row))
             {
-                MessageBox.Show(sender,
-                    "The captured data for this trace has been deleted, so there is nothing to view.\r\n\r\n" +
-                    "The record is retained for audit only.",
-                    "Trace Data", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                ShowDataDeletedMessage(sender);
+                return;
+            }
+
+            if (ScopeToSession)
+            {
+                var instance = row.DataGridView.Columns.Contains(InstanceColumn)
+                    ? row.Cells[InstanceColumn].Value.DBNullToNull() as string
+                    : null;
+                var title = string.IsNullOrEmpty(instance) ? $"Session {sessionId}" : $"{instance} - Session {sessionId}";
+
+                // runGroupID: null forces the single-session view even for a multi-instance run.
+                XETraceLauncher.LaunchStoredData(sender, sessionId, null, title);
                 return;
             }
 
@@ -98,15 +144,11 @@ namespace DBADashGUI.XETrace
     /// a chosen path.  The proc only emits link text for rows that actually captured a file, so this only fires where a
     /// download is available.
     /// </summary>
-    internal class XETraceXelLinkColumnInfo : LinkColumnInfo
+    internal class XETraceXelLinkColumnInfo : XETraceSessionLinkColumnInfo
     {
-        public string SessionIdColumn { get; set; } = "XETraceSessionID";
-
         public override void Navigate(DBADashContext context, DataGridViewRow row, int selectedTableIndex, ContainerControl sender)
         {
-            var sessionVal = row.Cells[SessionIdColumn].Value.DBNullToNull();
-            if (sessionVal == null) return;
-            var sessionId = Convert.ToInt64(sessionVal);
+            if (!TryGetSessionId(row, out var sessionId)) return;
             _ = SaveXelAsync(sessionId, sender);
         }
 
@@ -142,21 +184,15 @@ namespace DBADashGUI.XETrace
     /// is enforced server-side (<c>XE.XETraceSession_Del</c> rejects deleting another user's trace unless the caller is
     /// db_owner); the client also only ever shows non-admins their own sessions, so a visible row is always safe here.
     /// </summary>
-    internal class XETraceDeleteLinkColumnInfo : LinkColumnInfo
+    internal class XETraceDeleteLinkColumnInfo : XETraceSessionLinkColumnInfo
     {
-        public string SessionIdColumn { get; set; } = "XETraceSessionID";
-        public string DeletedDateColumn { get; set; } = "DeletedDate";
-
         public override void Navigate(DBADashContext context, DataGridViewRow row, int selectedTableIndex, ContainerControl sender)
         {
-            var sessionVal = row.Cells[SessionIdColumn].Value.DBNullToNull();
-            if (sessionVal == null) return;
-            var sessionId = Convert.ToInt64(sessionVal);
+            if (!TryGetSessionId(row, out var sessionId)) return;
 
             // Already deleted (only visible via the admin "Show deleted" toggle) - its data is gone, so there's nothing
             // to delete.  Say so rather than running a no-op delete.
-            if (row.DataGridView.Columns.Contains(DeletedDateColumn) &&
-                row.Cells[DeletedDateColumn].Value.DBNullToNull() != null)
+            if (RowDataDeleted(row))
             {
                 MessageBox.Show(sender, "This trace has already been deleted - its captured data has been removed.",
                     "Delete Trace", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/DBADashGUI/XETrace/XETraceSessionsView.cs
+++ b/DBADashGUI/XETrace/XETraceSessionsView.cs
@@ -265,7 +265,16 @@ namespace DBADashGUI.XETrace
                         ["StartTime"] = new() { Alias = "Start Time", Description = "Time the trace started (local time)" },
                         ["EndTime"] = new() { Alias = "End Time", Description = "Time the trace ended (local time)" },
                         ["MaxDurationSeconds"] = new() { Alias = "Max Duration (s)", FormatString = "N0" },
-                        ["TotalEvents"] = new() { Alias = "Events Captured", FormatString = "N0" },
+                        ["TotalEvents"] = new()
+                        {
+                            Alias = "Events Captured",
+                            FormatString = "N0",
+                            // For a multi-instance trace this is the count for this instance only (each replica is a
+                            // separate row); "View Data" opens the whole merged run.  Click to view just this instance's
+                            // captured events.
+                            Description = "Number of events captured.  For a multi-instance trace this is the count for this instance only (each instance is a separate row) - click to view just this instance's captured events.  \"View Data\" opens the whole merged run.",
+                            Link = new XETraceStoredDataLinkColumnInfo { ScopeToSession = true }
+                        },
                         ["TargetTypeDescription"] = new() { Alias = "Target", Description = "Resolved trace target" },
                         ["Xel"] = new()
                         {
@@ -291,7 +300,7 @@ namespace DBADashGUI.XETrace
                         {
                             Alias = "View Data",
                             Description = "View the events captured by this trace",
-                            Link = new XETraceViewDataLinkColumnInfo()
+                            Link = new XETraceStoredDataLinkColumnInfo()
                         },
                         ["Delete"] = new()
                         {


### PR DESCRIPTION
Add node at root and group level.  Provide option to view running sessions across all instances.  Provide history report across multiple instances.  Provide option to run ad-hoc XE sessions - leaving the user the choice to select which instances to include.