### PR TITLE
XE Session Cleanup

### DIFF
--- a/DBADash/DBCollector.cs
+++ b/DBADash/DBCollector.cs
@@ -567,6 +567,31 @@ namespace DBADash
         }
 
         /// <summary>
+        /// Drops any leftover ad-hoc XE session (<see cref="Messaging.XETraceMessage.SessionName"/>) on the instance.
+        /// An ad-hoc trace normally drops itself in a finally block (or self-terminates on heartbeat loss), but a hard
+        /// service crash - or the instance being unreachable at cleanup - can leave the session running with no
+        /// consumer.  Unlike the slow-query sessions, nothing reconciles it periodically, so this is swept on service
+        /// startup.  Always a DROP (never STOP-and-keep): ad-hoc traces are transient and, after a restart, there is no
+        /// heartbeat or in-memory tracking, so a surviving session is by definition orphaned.  Covers both server-scoped
+        /// (on-prem / MI) and database-scoped (Azure SQL DB) sessions.  The session name is a fixed, validated constant,
+        /// so it is safe to inline.  Returns true only when a session actually existed and was dropped, so the caller
+        /// can log the (rare) real cleanup without a misleading message on every startup.
+        /// </summary>
+        public async Task<bool> RemoveAdhocXESessionAsync(CancellationToken cancellationToken = default)
+        {
+            if (!IsXESupported) return false;
+            var scope = IsAzureDB ? "ON DATABASE" : "ON SERVER";
+            var catalog = IsAzureDB ? "sys.database_event_sessions" : "sys.server_event_sessions";
+            var sql = $"IF EXISTS(SELECT 1 FROM {catalog} WHERE name = N'{Messaging.XETraceMessage.SessionName}') " +
+                      $"BEGIN DROP EVENT SESSION [{Messaging.XETraceMessage.SessionName}] {scope}; SELECT CAST(1 AS bit); END " +
+                      $"ELSE SELECT CAST(0 AS bit);";
+            await using var cn = new SqlConnection(ConnectionString);
+            await using var cmd = new SqlCommand(sql, cn);
+            await cn.OpenAsync(cancellationToken);
+            return Convert.ToBoolean(await cmd.ExecuteScalarAsync(cancellationToken));
+        }
+
+        /// <summary>
         /// Add Metadata relating to the DBA Dash service used for collection.
         /// </summary>
         public static void AddDBADashServiceMetadata(ref DataTable dt)

--- a/DBADashService/SchedulerService.cs
+++ b/DBADashService/SchedulerService.cs
@@ -235,6 +235,10 @@ namespace DBADashService
                     Log.Information("All source connections are online");
                 }
                 backgroundTasks.Add(Task.Run(() => OfflineInstances.ManageOfflineInstances(config, backgroundTasksCts.Token), backgroundTasksCts.Token));
+
+                // Sweep any ad-hoc XE session orphaned by a prior hard crash.  Run in the background so it doesn't delay
+                // scheduling; it needs the offline check above to have completed so offline instances are skipped.
+                backgroundTasks.Add(Task.Run(() => RemoveAdhocXESessionsAsync(backgroundTasksCts.Token), backgroundTasksCts.Token));
             }
             catch (Exception ex)
             {
@@ -1011,6 +1015,54 @@ namespace DBADashService
                 catch (Exception ex)
                 {
                     Log.Logger.Error(ex, "Error Stop/Remove DBADash event sessions for {connection}", src.SourceConnection.ConnectionForPrint);
+                }
+            }
+        }
+
+        /// <summary>
+        /// On service startup, drops any leftover ad-hoc XE session left behind by a hard crash (or an instance that was
+        /// unreachable at cleanup).  A running ad-hoc trace normally drops itself, so this only clears true orphans - the
+        /// slow-query sessions have no equivalent because their collection cycle reconciles them each run.  Only runs when
+        /// the ad-hoc XE feature is enabled; errors are logged and never block startup.
+        /// </summary>
+        private async Task RemoveAdhocXESessionsAsync(CancellationToken cancellationToken)
+        {
+            if (!config.AllowAdhocXE) return;
+            Log.Information("Remove ad-hoc XE sessions started");
+            var options = new ParallelOptions()
+            {
+                MaxDegreeOfParallelism = 30,
+                CancellationToken = cancellationToken
+            };
+            await Parallel.ForEachAsync(config.SourceConnections, options, async (src, ct) =>
+            {
+                await RemoveAdhocXESessionAsync(src, ct);
+            });
+            Log.Information("Remove ad-hoc XE sessions completed");
+        }
+
+        private async Task RemoveAdhocXESessionAsync(DBADashSource src, CancellationToken cancellationToken)
+        {
+            if (src.SourceConnection.Type == ConnectionType.SQL && !OfflineInstances.IsOffline(src))
+            {
+                try
+                {
+                    if (src.SourceConnection.ConnectionInfo.IsXESupported)
+                    {
+                        var collector = await DBCollector.CreateAsync(src, config.ServiceName);
+                        if (await collector.RemoveAdhocXESessionAsync(cancellationToken))
+                        {
+                            Log.Logger.Information("Removed leftover ad-hoc XE session for {connection}", src.SourceConnection.ConnectionForPrint);
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    // Service is shutting down - stop cleanly without logging as an error.
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Error(ex, "Error removing leftover ad-hoc XE session for {connection}", src.SourceConnection.ConnectionForPrint);
                 }
             }
         }


### PR DESCRIPTION
Remove any existing Ad-hoc XE sessions on startup.  This might occur if the service wasn't shutdown correctly while a trace was running or if there was an issue connecting to the instance.