### PR TITLE
Harden ad-hoc XE trace stop/teardown against SQS races and stuck live streams

### DIFF
--- a/DBADash/Messaging/CancellationTokenManager.cs
+++ b/DBADash/Messaging/CancellationTokenManager.cs
@@ -9,10 +9,28 @@ namespace DBADash.Messaging
     {
         private static readonly ConcurrentDictionary<Guid, CancellationTokenSource> Tokens = new();
 
+        // Cancellations that arrived before the operation registered its token - e.g. over the SQS relay a Stop can
+        // overtake the slower Start (or be processed while the Start is still queued), so TryCancel runs before Add.
+        // Recording the request here lets a late Add honour it immediately, instead of the trace starting and running
+        // orphaned on the server after the client has already given up.  Timestamped so stale entries can be pruned.
+        private static readonly ConcurrentDictionary<Guid, DateTime> PreCancelled = new();
+
+        // How long a pre-emptive cancellation is retained for a not-yet-registered operation.  Comfortably longer than
+        // any realistic Start/Stop reordering window, while still bounding memory if a matching Add never arrives.
+        private static readonly TimeSpan PreCancelRetention = TimeSpan.FromMinutes(10);
+
         // Adds a CancellationTokenSource associated with a Guid (Id of the message)
         public static void Add(Guid Id, CancellationTokenSource cts)
         {
             Tokens.TryAdd(Id, cts);
+            // Honour a cancellation that raced ahead of this registration (Stop processed before Start) so the
+            // operation is cancelled the moment it starts rather than running orphaned.
+            if (PreCancelled.TryRemove(Id, out _))
+            {
+                Log.Information("Applying pre-emptive cancellation for message {id} registered after its cancel request", Id);
+                cts.Cancel();
+            }
+            PrunePreCancelled();
         }
 
         // Attempts to cancel the operation associated with the message Id
@@ -20,7 +38,12 @@ namespace DBADash.Messaging
         {
             if (!Tokens.TryRemove(Id, out var cts))
             {
-                Log.Warning("Cancellation requested for message {id}, but no token found", Id);
+                // The operation hasn't registered its token yet (e.g. its Start message is still in-flight/queued over
+                // the SQS relay).  Record the request so a subsequent Add cancels immediately rather than the trace
+                // starting and running orphaned.
+                PreCancelled[Id] = DateTime.UtcNow;
+                PrunePreCancelled();
+                Log.Warning("Cancellation requested for message {id}, but no token found - recorded as a pre-emptive cancellation", Id);
                 return false;
             }
             Log.Information("Cancellation trigger for message {id}", Id);
@@ -33,6 +56,20 @@ namespace DBADash.Messaging
         public static void Remove(Guid Id)
         {
             Tokens.TryRemove(Id, out _);
+        }
+
+        // Drops pre-emptive cancellations whose matching operation never registered within the retention window.
+        private static void PrunePreCancelled()
+        {
+            if (PreCancelled.IsEmpty) return;
+            var cutoff = DateTime.UtcNow - PreCancelRetention;
+            foreach (var kvp in PreCancelled)
+            {
+                if (kvp.Value < cutoff)
+                {
+                    PreCancelled.TryRemove(kvp.Key, out _);
+                }
+            }
         }
     }
 }

--- a/DBADash/Messaging/XETraceMessage.cs
+++ b/DBADash/Messaging/XETraceMessage.cs
@@ -88,6 +88,11 @@ namespace DBADash.Messaging
         private const int MinBatchIntervalSeconds = 1;
         private const int MaxXelBytes = 100 * 1024 * 1024; // don't ship an oversized .xel back through the reply
 
+        // How long to wait for XELite's ReadEventStream to unwind after cancellation before forcing teardown.  The read
+        // observes its token only cooperatively, so a parked read can overrun; past this window we stop waiting and let
+        // the session DROP abort it rather than hold the trace open indefinitely.
+        private const int StreamStopGraceSeconds = 15;
+
         private byte[] _capturedXel;
 
         // Server UTC captured just before START; events older than this are leftover data and are dropped.
@@ -372,23 +377,40 @@ namespace DBADash.Messaging
                 // the stream (the live streamer otherwise runs until its connection is cancelled).
                 var monitorTask = MonitorLiveAsync(connectionString, databaseScoped, heartbeatTimeout, streamCts, monitor);
 
+                // Whatever trips streamCts - duration cap, an external cancellation, heartbeat loss or the session being
+                // dropped - a live ReadEventStream parked waiting for the *next* event won't observe the cancelled
+                // token: sys.fn_MSxe_read_event_stream just sits there when the workload is idle, so the streamer never
+                // returns and teardown (the DROP below) never runs, leaving the session alive until the 1-hour cap.
+                // Force the streamer to return by issuing a server-side STOP on a separate connection as soon as the
+                // token trips; STOP ends the live read so ReadEventStream unwinds and teardown proceeds immediately.
+                using var stopRegistration = streamCts.Token.Register(() =>
+                    _ = StopSessionForStreamUnblockAsync(connectionString, scope));
+
                 var reader = new XELiveTraceReader(connectionString, SessionName, 500,
                     TimeSpan.FromSeconds(batchInterval));
+                var streamTask = reader.StreamAsync(async batch =>
+                {
+                    if (batch == null || batch.Rows.Count == 0) return;
+                    totalEvents += batch.Rows.Count;
+                    var ds = new DataSet();
+                    ds.Tables.Add(batch);
+                    await ReportProgressAsync(new ResponseMessage
+                    {
+                        Type = ResponseMessage.ResponseTypes.Progress,
+                        Message = $"Captured {totalEvents} events",
+                        Data = ds
+                    });
+                }, streamCts.Token);
                 try
                 {
-                    await reader.StreamAsync(async batch =>
-                    {
-                        if (batch == null || batch.Rows.Count == 0) return;
-                        totalEvents += batch.Rows.Count;
-                        var ds = new DataSet();
-                        ds.Tables.Add(batch);
-                        await ReportProgressAsync(new ResponseMessage
-                        {
-                            Type = ResponseMessage.ResponseTypes.Progress,
-                            Message = $"Captured {totalEvents} events",
-                            Data = ds
-                        });
-                    }, streamCts.Token);
+                    // Don't await the streamer unconditionally: XELite's ReadEventStream only observes its cancellation
+                    // token cooperatively, and a live read parked in sys.fn_MSxe_read_event_stream can fail to return
+                    // when the token trips - so awaiting it directly can hang forever (past even the duration cap),
+                    // leaving the session running.  Once streamCts trips, give the streamer a bounded grace period to
+                    // unwind on its own (helped by the server-side STOP registered above); if it overruns, stop waiting
+                    // and fall through to forced teardown.  The DROP in the finally aborts the read, so the abandoned
+                    // streamTask unwinds in the background instead of holding this trace open indefinitely.
+                    await AwaitStreamWithWatchdogAsync(streamTask, streamCts.Token);
                 }
                 catch (Exception ex)
                 {
@@ -659,6 +681,64 @@ namespace DBADash.Messaging
         {
             try { return await IsSessionRunningAsync(connectionString, databaseScoped, CancellationToken.None); }
             catch { return true; }
+        }
+
+        /// <summary>
+        /// Awaits the live streamer but refuses to hang on it.  XELite's <c>ReadEventStream</c> observes its
+        /// cancellation token only cooperatively, so a read parked in <c>sys.fn_MSxe_read_event_stream</c> can fail to
+        /// return when the token trips.  Once <paramref name="stopToken"/> is cancelled we wait only a bounded grace
+        /// period for the streamer to unwind; if it overruns we return anyway so the caller can force teardown (the DROP
+        /// aborts the read, unwinding the abandoned task in the background) instead of holding the trace open forever.
+        /// </summary>
+        private async Task AwaitStreamWithWatchdogAsync(Task streamTask, CancellationToken stopToken)
+        {
+            // Fast path: the stream ends on its own (or promptly on cancellation) before the token even trips.
+            var stopSignalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using (stopToken.Register(() => stopSignalled.TrySetResult(true)))
+            {
+                if (await Task.WhenAny(streamTask, stopSignalled.Task).ConfigureAwait(false) == streamTask)
+                {
+                    await streamTask.ConfigureAwait(false); // completed - surface its outcome/exception
+                    return;
+                }
+            }
+
+            // The stop token has tripped.  Give the streamer a bounded window to unwind cooperatively (helped by the
+            // server-side STOP), then stop waiting so forced teardown can run.
+            var grace = TimeSpan.FromSeconds(StreamStopGraceSeconds);
+            if (await Task.WhenAny(streamTask, Task.Delay(grace)).ConfigureAwait(false) == streamTask)
+            {
+                await streamTask.ConfigureAwait(false);
+                return;
+            }
+
+            Log.Warning(
+                "Live ad-hoc XE stream on {instance} did not stop within {grace}s of cancellation; forcing teardown (the session DROP will abort the stuck read)",
+                ConnectionID, StreamStopGraceSeconds);
+            // Abandon the stuck streamTask - it unwinds once the finally DROP aborts the underlying read.  Observe its
+            // eventual exception so it doesn't surface as an unobserved TaskException.
+            _ = streamTask.ContinueWith(t => _ = t.Exception, TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        /// <summary>
+        /// Issues a server-side STOP on a dedicated connection to unblock a live <c>ReadEventStream</c> that is parked
+        /// waiting for the next event (an idle workload never returns from the read, so a cancelled token alone won't
+        /// end it).  Stopping the session ends the live read so the streamer unwinds and teardown/DROP can run.  Best
+        /// effort - the streamer ending is what matters, and normal teardown STOP/DROP still follows.
+        /// </summary>
+        private async Task StopSessionForStreamUnblockAsync(string connectionString, XESessionScope scope)
+        {
+            try
+            {
+                Log.Information(
+                    "Live ad-hoc XE trace on {instance} cancelled - issuing server-side STOP to end the live stream",
+                    ConnectionID);
+                await ExecAsync(connectionString, StateSql("STOP", scope), CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Error issuing STOP to unblock live ad-hoc XE stream on {instance}", ConnectionID);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Two robustness fixes for ad-hoc XE tracing, both addressing ways a trace could keep running on the server after it should have stopped. Discovered while investigating a live trace that was still running >1 hour after a 15-second trace was requested.
Background
A live ad-hoc XE trace was observed still running on the server long after its configured duration (e.g. a 15s trace still alive after an hour). Investigating the trace lifecycle surfaced two independent gaps, both verifiable by code inspection.

## Changes

1. Honour a Stop that arrives before Start registers its token (SQS race) — CancellationTokenManager
Over the SQS relay, messages are dispatched fire-and-forget (_ = ProcessMessageAsync(...)), so a Stop can be processed before the corresponding Start has registered its cancellation token. Previously TryCancel silently dropped the cancel when no token was found, leaving the operation running unstoppably.
CancellationTokenManager now records a pre-emptive cancellation when no token exists yet and applies it when the token is later registered (Add), with a 10-minute prune so stale pre-cancels can't accumulate.
2. Guarantee live traces tear down within a bounded time of cancellation — XETraceMessage
Every stop path for a live trace — duration cap, explicit cancel, heartbeat loss, external session drop — funnels through a single CancellationToken, and the only consumer of that token is XELite's ReadEventStream, which cancels only cooperatively. A native read parked in sys.fn_MSxe_read_event_stream can fail to return when the token trips, so StreamAsync never returns, teardown (STOP/DROP) never runs, no completion reply is sent, and the client keeps heartbeating — which also defeats the heartbeat-loss and session-gone safety nets. There was no independent backstop.
Added two defenses in ProcessLiveAsync:
•	On token trip, issue a server-side ALTER EVENT SESSION ... STATE = STOP on a separate connection to prod the streamer into returning.
•	Wrap the await in a watchdog (AwaitStreamWithWatchdogAsync): after cancellation, wait at most StreamStopGraceSeconds (15s) for the streamer to unwind, then stop waiting and force teardown. The session DROP aborts the stuck read, so the abandoned task unwinds in the background.
Also improved stop-path logging: log when the unblock STOP is issued (Information) and warn if it fails, so the rare case is traceable in production.
## Testing
•	Solution builds clean.
•	The original rare hang could not be reproduced, so these are hardening changes based on code inspection rather than a confirmed-fixed repro. The added Information/Warning logging is deliberately included so that, if the rare path recurs in production, it is provable that the backstop engaged.
•    Tested manually

## Risk
Low. Change (1) only retains a cancellation that would otherwise be lost. Change (2) adds a bounded wait plus a best-effort STOP; normal teardown is unchanged on the healthy path.