### PR TITLE
Directory destination improvements

### DIFF
--- a/DBADash.Test/FolderDestinationTests.cs
+++ b/DBADash.Test/FolderDestinationTests.cs
@@ -1,0 +1,108 @@
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DBADash.Test
+{
+    /// <summary>
+    /// Tests for writing to and reading from a folder destination.  A service importing from the folder
+    /// processes files for an instance in order and can't skip a file it fails to read, so a file must never
+    /// be visible to it until it's complete.
+    /// </summary>
+    [TestClass]
+    public class FolderDestinationTests
+    {
+        private string _folder = string.Empty;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _folder = Path.Combine(Path.GetTempPath(), "DBADashTest_" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_folder);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            try
+            {
+                Directory.Delete(_folder, true);
+            }
+            catch (IOException)
+            {
+                // Leave it to the temp folder cleanup
+            }
+        }
+
+        private static DataSet GetTestDataSet(int rowCount)
+        {
+            var ds = new DataSet("Test");
+            var dt = new DataTable("TestTable");
+            dt.Columns.Add("Value", typeof(string));
+            for (var i = 0; i < rowCount; i++)
+            {
+                dt.Rows.Add("Row " + i);
+            }
+            ds.Tables.Add(dt);
+            return ds;
+        }
+
+        [TestMethod]
+        public async Task WriteFolderAsync_WritesFileThatCanBeReadBack()
+        {
+            var fileName = DestinationHandling.FileNamePrefix + "Test" + DestinationHandling.FileExtension;
+            await DestinationHandling.WriteFolderAsync(GetTestDataSet(3), _folder, fileName, new CollectionConfig());
+
+            var ds = DataSetSerialization.DeserializeFromFile(Path.Combine(_folder, fileName));
+            Assert.AreEqual(3, ds.Tables["TestTable"]!.Rows.Count);
+        }
+
+        [TestMethod]
+        public async Task WriteFolderAsync_DoesNotLeaveTempFileBehind()
+        {
+            var fileName = DestinationHandling.FileNamePrefix + "Test" + DestinationHandling.FileExtension;
+            await DestinationHandling.WriteFolderAsync(GetTestDataSet(3), _folder, fileName, new CollectionConfig());
+
+            CollectionAssert.AreEqual(new[] { fileName },
+                Directory.GetFiles(_folder).Select(Path.GetFileName).ToArray());
+        }
+
+        [TestMethod]
+        public async Task WriteFolderAsync_OverwritingExistingFileDoesNotLeaveTrailingContent()
+        {
+            // The file is written under a temp name and renamed, so an existing file is always replaced
+            // rather than partially overwritten.  A file left with the tail of a longer document can never
+            // be imported and would block the files behind it.
+            var fileName = DestinationHandling.FileNamePrefix + "Test" + DestinationHandling.FileExtension;
+            await DestinationHandling.WriteFolderAsync(GetTestDataSet(100), _folder, fileName, new CollectionConfig());
+            await DestinationHandling.WriteFolderAsync(GetTestDataSet(1), _folder, fileName, new CollectionConfig());
+
+            var ds = DataSetSerialization.DeserializeFromFile(Path.Combine(_folder, fileName));
+            Assert.AreEqual(1, ds.Tables["TestTable"]!.Rows.Count);
+        }
+
+        [TestMethod]
+        public void TempFileName_IsNotPickedUpAsACompletedFile()
+        {
+            // The importer lists DestinationHandling.FileSearchPattern and imports what ends with
+            // FileExtension - the temp file has to be excluded by that filter.
+            var tempFileName = DestinationHandling.FileNamePrefix + "Test" + DestinationHandling.FileExtension +
+                               DestinationHandling.TempFileExtension;
+
+            Assert.IsFalse(tempFileName.EndsWith(DestinationHandling.FileExtension));
+        }
+
+        [TestMethod]
+        public void DeserializeFromFile_MissingFile_ThrowsAndDoesNotCreateTheFile()
+        {
+            // A file that was deleted between being listed and read (e.g. by another service importing from
+            // the same folder) must throw rather than create an empty file that can never be imported.
+            var path = Path.Combine(_folder, DestinationHandling.FileNamePrefix + "Missing" + DestinationHandling.FileExtension);
+
+            Assert.ThrowsExactly<FileNotFoundException>(() => DataSetSerialization.DeserializeFromFile(path));
+            Assert.IsFalse(File.Exists(path));
+        }
+    }
+}

--- a/DBADash.Test/OfflineInstancesReportingTests.cs
+++ b/DBADash.Test/OfflineInstancesReportingTests.cs
@@ -1,0 +1,60 @@
+using System;
+using DBADashService;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DBADash.Test
+{
+    /// <summary>
+    /// The repository opens and closes offline incidents from these reports, so a change to the set of
+    /// offline instances has to be reported as soon as it happens.  An unchanged state is repeated on an
+    /// interval to recover from a lost report rather than on every check - see #2042, where the every 10
+    /// seconds repeat filled a folder destination with files.
+    /// </summary>
+    [TestClass]
+    public class OfflineInstancesReportingTests
+    {
+        private const string NoneOffline = "";
+        private const string OneOffline = "SERVER1@1000";
+        private static readonly DateTime Now = new(2026, 09, 11, 12, 00, 00, DateTimeKind.Utc);
+
+        [TestMethod]
+        public void FirstReport_IsAlwaysRequired()
+        {
+            // Nothing reported yet.  Reporting on startup is what closes incidents left open by a restart.
+            Assert.IsTrue(OfflineInstances.IsReportRequired(NoneOffline, null, DateTime.MinValue, Now, 60));
+        }
+
+        [TestMethod]
+        public void InstanceGoingOffline_IsReportedImmediately()
+        {
+            Assert.IsTrue(OfflineInstances.IsReportRequired(OneOffline, NoneOffline, Now, Now, 60));
+        }
+
+        [TestMethod]
+        public void InstanceComingBackOnline_IsReportedImmediately()
+        {
+            Assert.IsTrue(OfflineInstances.IsReportRequired(NoneOffline, OneOffline, Now, Now, 60));
+        }
+
+        [TestMethod]
+        public void UnchangedState_IsNotReportedBeforeTheInterval()
+        {
+            Assert.IsFalse(OfflineInstances.IsReportRequired(NoneOffline, NoneOffline, Now, Now.AddSeconds(59), 60));
+            Assert.IsFalse(OfflineInstances.IsReportRequired(OneOffline, OneOffline, Now, Now.AddSeconds(59), 60));
+        }
+
+        [TestMethod]
+        public void UnchangedState_IsReportedOnTheInterval()
+        {
+            Assert.IsTrue(OfflineInstances.IsReportRequired(NoneOffline, NoneOffline, Now, Now.AddSeconds(60), 60));
+            Assert.IsTrue(OfflineInstances.IsReportRequired(OneOffline, OneOffline, Now, Now.AddSeconds(60), 60));
+        }
+
+        [TestMethod]
+        public void ZeroInterval_ReportsChangesOnly()
+        {
+            Assert.IsFalse(OfflineInstances.IsReportRequired(NoneOffline, NoneOffline, Now, Now.AddDays(1), 0));
+            Assert.IsTrue(OfflineInstances.IsReportRequired(OneOffline, NoneOffline, Now, Now, 0));
+        }
+    }
+}

--- a/DBADash/CollectionConfig.cs
+++ b/DBADash/CollectionConfig.cs
@@ -46,6 +46,18 @@ namespace DBADash
         /// </summary>
         private const int ReadReplicaScanParallelism = 8;
 
+        /// <summary>
+        /// How often (seconds) the set of offline instances is reported when nothing has changed.  A change -
+        /// an instance going offline, coming back, or failing again after it recovered - is always reported
+        /// immediately, so this only controls the repeat.  The repeat is what recovers the state if a report
+        /// is lost, and what keeps LastFail/FailCount current for an instance that's still offline, so those
+        /// values lag by up to this interval.  Every destination is reported to: a SQL destination runs
+        /// OfflineInstances_Add, a folder or S3 destination gets a file for the importing service to process.
+        /// 0 = report changes only (not recommended - a lost report would leave an instance marked offline
+        /// until it's reported again).
+        /// </summary>
+        public int OfflineInstancesReportInterval { get; set; } = 60;
+
         public string ServiceName { get; set; } = "DBADashService";
 
         public bool AutoUpdateDatabase { get; set; } = true;

--- a/DBADash/DataSetSerialization.cs
+++ b/DBADash/DataSetSerialization.cs
@@ -22,7 +22,10 @@ namespace DBADash
         
         public static DataSet DeserializeFromXmlFile(string filePath)
         {
-            using FileStream fs = new(filePath, FileMode.OpenOrCreate, FileAccess.Read);
+            // FileMode.Open (not OpenOrCreate).  A file that was deleted between being listed and read here
+            // must throw FileNotFoundException so the caller can skip it.  Creating the file instead leaves a
+            // zero byte file behind that can never be imported ("Root element is missing").
+            using FileStream fs = new(filePath, FileMode.Open, FileAccess.Read);
             var ds = new DataSet();
             ds.ReadXml(fs);
             return ds;

--- a/DBADash/DestinationHandling.cs
+++ b/DBADash/DestinationHandling.cs
@@ -17,6 +17,10 @@ namespace DBADash
     {
         public const string FileNamePrefix = "DBADash_";
         public const string FileExtension = ".xml";
+
+        /// <summary>Extension used while a file is being written to a folder destination.  Renamed to <see cref="FileExtension"/> once the write completes.</summary>
+        public const string TempFileExtension = ".tmp";
+
         public const string FileSearchPattern = FileNamePrefix + "*";
 
         private static readonly ResiliencePipeline pipeline = new ResiliencePipelineBuilder()
@@ -157,11 +161,27 @@ namespace DBADash
             {
                 var filePath = Path.Combine(destination, fileName);
                 var extension = Path.GetExtension(fileName);
-                if (extension == ".xml")
+                if (extension == FileExtension)
                 {
-                    await using FileStream fs = new(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+                    // Write to a temp file and rename it once the write is complete.  The service importing
+                    // from this folder ignores anything that doesn't have the .xml extension, so it can't read
+                    // a partially written file, and a service killed mid-write leaves an inert temp file behind
+                    // instead of a truncated .xml file that could never be imported.
+                    var tempPath = filePath + TempFileExtension;
                     DataSetSerialization.SetDateTimeKind(ds); // Required to prevent timezone conversion
-                    await Task.Run(() => ds.WriteXml(fs, XmlWriteMode.WriteSchema));
+                    try
+                    {
+                        await using (FileStream fs = new(tempPath, FileMode.Create, FileAccess.Write))
+                        {
+                            await Task.Run(() => ds.WriteXml(fs, XmlWriteMode.WriteSchema));
+                        }
+                        File.Move(tempPath, filePath, true);
+                    }
+                    catch
+                    {
+                        TryDeleteTempFile(tempPath);
+                        throw;
+                    }
                 }
                 else
                 {
@@ -171,6 +191,22 @@ namespace DBADash
             else
             {
                 Log.Error("Destination Folder doesn't exist {folder}", destination);
+            }
+        }
+
+        /// <summary>
+        /// Remove a temp file left behind by a failed write.  Failure to delete it isn't an error worth
+        /// propagating - the service importing from the folder cleans up any temp file that gets left behind.
+        /// </summary>
+        private static void TryDeleteTempFile(string tempPath)
+        {
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Error deleting temp file {tempPath}", tempPath);
             }
         }
 

--- a/DBADash/OfflineInstances.cs
+++ b/DBADash/OfflineInstances.cs
@@ -83,6 +83,16 @@ namespace DBADashService
 
         private const int DelayBetweenChecks = 10;
 
+        /// <summary>
+        /// How long before a report that didn't reach every destination is repeated, in seconds.  Used in
+        /// place of the configured interval, which can be 0 for no repeat at all.
+        /// </summary>
+        private const int FailedReportRetryInterval = 60;
+
+        private static string lastReportedState;
+        private static DateTime lastReportDate = DateTime.MinValue;
+        private static bool lastReportFailed;
+
         public static async Task ManageOfflineInstances(CollectionConfig config, CancellationToken stoppingToken)
         {
             var lastCheck = DateTime.MinValue;
@@ -103,7 +113,7 @@ namespace DBADashService
                 }
                 try
                 {
-                    await LogOfflineInstances(config, lastCheck);
+                    await LogOfflineInstancesIfRequired(config);
                 }
                 catch (Exception ex)
                 {
@@ -172,6 +182,63 @@ namespace DBADashService
             var fileName = DBADashSource.GenerateFileName("OfflineInstances");
             await DestinationHandling.WriteAllDestinationsAsync(offlineInstances, fileName, config);
         }
+
+        /// <summary>
+        /// Identifies the current set of offline instances by the ConnectionID and FirstFail of each open
+        /// incident.  LastFail and FailCount are deliberately excluded as they change on every check, which
+        /// would make every state look like a new one.  Instances without a ConnectionID are excluded to
+        /// match what's actually reported - see <see cref="GetOfflineDataSet"/>.
+        /// </summary>
+        private static string GetCurrentState() =>
+            string.Join('|', Instances.Values
+                .Where(instance => !string.IsNullOrEmpty(instance.Source.ConnectionID))
+                .Select(instance => instance.Source.ConnectionID + "@" + instance.FirstFail.Ticks)
+                .OrderBy(key => key, StringComparer.Ordinal));
+
+        /// <summary>
+        /// Report the offline instances if the set of them has changed since the last report, or if the
+        /// report interval has elapsed.  The repository opens and closes offline incidents based on these
+        /// reports, so a change is always reported immediately - the repeat exists to recover the state if a
+        /// report is lost and to keep LastFail/FailCount current.  Repeating an unchanged state on a short
+        /// interval gains nothing at any destination, and on a folder/S3 destination it leaves a file behind
+        /// each time, which piles up if the service importing them falls behind (#2042).
+        /// </summary>
+        private static async Task LogOfflineInstancesIfRequired(CollectionConfig config)
+        {
+            var state = GetCurrentState();
+            // Note: SnapshotDateUTC, so UtcNow rather than the local time used to schedule the checks.
+            var now = DateTime.UtcNow;
+            // A report that threw is repeated on its own interval rather than on the next check.  A write to
+            // several destinations can succeed on some and fail on one, so repeating it every 10 seconds would
+            // leave a file behind at every healthy folder/S3 destination each time, which is the backlog this
+            // is meant to avoid (#2042).
+            var interval = lastReportFailed ? FailedReportRetryInterval : config.OfflineInstancesReportInterval;
+            if (!IsReportRequired(state, lastReportedState, lastReportDate, now, interval)) return;
+
+            var reported = false;
+            try
+            {
+                await LogOfflineInstances(config, now);
+                reported = true;
+            }
+            finally
+            {
+                // Recorded even when the report threw, so that the retry is driven by the interval above
+                // rather than by the state looking new on every check.  A further change to the set of
+                // offline instances is still reported straight away.
+                lastReportedState = state;
+                lastReportDate = now;
+                lastReportFailed = !reported;
+            }
+        }
+
+        /// <summary>
+        /// A change to the set of offline instances is always reported.  An unchanged state is reported again
+        /// once <paramref name="reportInterval"/> seconds have elapsed, or not at all if it's 0.
+        /// </summary>
+        internal static bool IsReportRequired(string currentState, string previousState, DateTime previousReportDate, DateTime now, int reportInterval) =>
+            currentState != previousState ||
+            (reportInterval > 0 && now >= previousReportDate.AddSeconds(reportInterval));
 
         private static async Task CheckConnectionsAsync(CancellationToken stoppingToken)
         {

--- a/DBADashService/DirectoryWorkItem.cs
+++ b/DBADashService/DirectoryWorkItem.cs
@@ -15,6 +15,7 @@ namespace DBADashService
     {
         private static readonly AsyncKeyedLocker<string> _folderLocker = new();
         private const uint ERROR_SHARING_VIOLATION = 0x80070020;
+        private static readonly TimeSpan StaleTempFileAge = TimeSpan.FromHours(1);
 
         public DBADashSource Source { get; set; }
 
@@ -39,18 +40,19 @@ namespace DBADashService
             // One job per folder at a time
             using (await _folderLocker.LockAsync(Source.ConnectionString).ConfigureAwait(false))
             {
-                List<string> files;
+                List<string> allFiles;
                 try
                 {
-                    files = Directory.EnumerateFiles(folder, DestinationHandling.FileSearchPattern, SearchOption.TopDirectoryOnly)
-                                     .Where(f => f.EndsWith(DestinationHandling.FileExtension))
-                                     .ToList();
+                    allFiles = Directory.EnumerateFiles(folder, DestinationHandling.FileSearchPattern, SearchOption.TopDirectoryOnly)
+                                        .ToList();
                 }
                 catch (Exception ex)
                 {
                     Log.Error(ex, "Enumerate files {folder}", folder);
                     return;
                 }
+                DeleteStaleTempFiles(allFiles);
+                var files = allFiles.Where(f => f.EndsWith(DestinationHandling.FileExtension)).ToList();
 
                 var filesByInstance = GetFilesToProcessByInstance(files);
                 var tasks = filesByInstance.Select(kv => ProcessInstanceFilesAsync(kv.Value, Source, config, cancellationToken)).ToList();
@@ -67,12 +69,21 @@ namespace DBADashService
             foreach (var f in files)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await ProcessFileAsync(f, source, config);
-                TryDeleteFile(f);
+                if (await ProcessFileAsync(f, source, config))
+                {
+                    TryDeleteFile(f);
+                }
             }
         }
 
-        private static async Task ProcessFileAsync(string f, DBADashSource source, CollectionConfig config, int tryCount = 1)
+        /// <summary>
+        /// Import a single file.  Returns true if the file has been dealt with and can be removed from the
+        /// source folder, or false if it should be left in place and retried on the next iteration.
+        /// A file that can't be imported is moved to the failed message folder rather than being left in
+        /// place - files are processed in order, so leaving it would block every file behind it for this
+        /// instance indefinitely.
+        /// </summary>
+        private static async Task<bool> ProcessFileAsync(string f, DBADashSource source, CollectionConfig config, int tryCount = 1)
         {
             const int MaxTryCount = 5;
             const int RetryDelay = 10;
@@ -86,22 +97,28 @@ namespace DBADashService
                 {
                     await DestinationHandling.WriteAllDestinationsAsync(ds, source, fileName, config);
                 }
+                return true;
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) // Deleted after the folder was listed.  e.g. Another service importing from the same folder.
+            {
+                Log.Information("File {FileName} no longer exists.  Skipping", fileName);
+                return false;
             }
             catch (IOException ex) when ((uint)ex.HResult == ERROR_SHARING_VIOLATION) // Another process has a lock on the file.  It might still be being written to.
             {
                 if (tryCount > MaxTryCount)
                 {
                     Log.Warning("File {FileName} is in use.  Exceeded max wait/retry.  File will be processed on the next iteration", fileName);
-                    return;
+                    return false; // Leave the file in place.  It hasn't been imported.
                 }
                 Log.Information("File {FileName} is in use.  Waiting for lock to release. Attempt {TryCount}/{MaxRetryCount}", fileName, tryCount, MaxTryCount);
                 await Task.Delay(RetryDelay);
-                await ProcessFileAsync(f, source, config, tryCount + 1);
+                return await ProcessFileAsync(f, source, config, tryCount + 1);
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error importing from {filename}.  File will be copied to {failedMessageFolder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
-                File.Copy(f, Path.Combine(SchedulerServiceConfig.FailedMessageFolder, f));
+                Log.Error(ex, "Error importing from {filename}.  File will be moved to {failedMessageFolder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
+                return TryMoveToFailedMessageFolder(f);
             }
         }
 
@@ -154,6 +171,55 @@ namespace DBADashService
                 }
             }
             return filesToProcessByInstance;
+        }
+
+        /// <summary>
+        /// Move a file that couldn't be imported to the failed message folder so it doesn't block the files
+        /// queued behind it.  Files are removed from that folder after 7 days (SchedulerService.FolderCleanup).
+        /// Returns true if the file has been dealt with, false if it has to be left where it is.
+        /// </summary>
+        private static bool TryMoveToFailedMessageFolder(string filePath)
+        {
+            var fileName = Path.GetFileName(filePath);
+            try
+            {
+                if (string.IsNullOrEmpty(SchedulerServiceConfig.FailedMessageFolder))
+                {
+                    throw new Exception("Failed message folder is not available");
+                }
+                // Note: Path.GetFileName is required here.  filePath is rooted and Path.Combine returns a rooted
+                // second argument unchanged, which would make this a move of the file over itself.
+                File.Move(filePath, Path.Combine(SchedulerServiceConfig.FailedMessageFolder, fileName), true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error moving {FileName} to failed message folder {failedMessageFolder}.  The file will be left in place", fileName, SchedulerServiceConfig.FailedMessageFolder);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Temp files are renamed to .xml once the write completes (see DestinationHandling.WriteFolderAsync).
+        /// A service killed mid-write leaves one behind that will never be renamed, so remove it once it's old
+        /// enough that it can't still be in the process of being written.
+        /// </summary>
+        private static void DeleteStaleTempFiles(IEnumerable<string> files)
+        {
+            try
+            {
+                var cutOff = DateTime.UtcNow.Subtract(StaleTempFileAge);
+                foreach (var f in files.Where(f => f.EndsWith(DestinationHandling.TempFileExtension)
+                                                   && File.GetLastWriteTimeUtc(f) < cutOff))
+                {
+                    Log.Warning("Deleting incomplete file {FileName}", Path.GetFileName(f));
+                    TryDeleteFile(f);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error deleting incomplete files");
+            }
         }
 
         private static void TryDeleteFile(string filePath)

--- a/DBADashService/DirectoryWorkItem.cs
+++ b/DBADashService/DirectoryWorkItem.cs
@@ -2,6 +2,7 @@ using AsyncKeyedLock;
 using DBADash;
 using Serilog;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -16,6 +17,25 @@ namespace DBADashService
         private static readonly AsyncKeyedLocker<string> _folderLocker = new();
         private const uint ERROR_SHARING_VIOLATION = 0x80070020;
         private static readonly TimeSpan StaleTempFileAge = TimeSpan.FromHours(1);
+
+        /// <summary>
+        /// How long a file that's in use is waited for before the files behind it are processed without it.
+        /// A file still being written is only locked for as long as the write takes, so a lock held for
+        /// longer is something else - another service importing from the same folder, or a stuck handle -
+        /// and waiting on it indefinitely would stall every file behind it.
+        /// </summary>
+        private static readonly TimeSpan LockedFileWaitLimit = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// When a file that's in use was first seen locked, keyed on source folder and then on file path.  The
+        /// wait is bounded from that point rather than from the file's last write time: a file can sit in the
+        /// folder long before it's imported - a backlog built up while the service was down, for example - so
+        /// its age says nothing about how long the lock has been held, and bounding on it would skip a whole
+        /// backlog on the first momentary lock.
+        /// Tracking is held per folder so a pass over one folder only ever prunes its own entries.  Each
+        /// folder's entries are only read and written while the lock for that folder is held.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, DateTime>> LockedFilesFirstSeenByFolder = new(StringComparer.OrdinalIgnoreCase);
 
         public DBADashSource Source { get; set; }
 
@@ -52,10 +72,12 @@ namespace DBADashService
                     return;
                 }
                 DeleteStaleTempFiles(allFiles);
+                var lockedFilesFirstSeen = LockedFilesFirstSeenByFolder.GetOrAdd(folder, _ => new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase));
+                PruneLockTracking(lockedFilesFirstSeen, allFiles);
                 var files = allFiles.Where(f => f.EndsWith(DestinationHandling.FileExtension)).ToList();
 
                 var filesByInstance = GetFilesToProcessByInstance(files);
-                var tasks = filesByInstance.Select(kv => ProcessInstanceFilesAsync(kv.Value, Source, config, cancellationToken)).ToList();
+                var tasks = filesByInstance.Select(kv => ProcessInstanceFilesAsync(kv.Value, Source, config, lockedFilesFirstSeen, cancellationToken)).ToList();
                 await Task.WhenAll(tasks).ConfigureAwait(false);
             }
         }
@@ -63,27 +85,49 @@ namespace DBADashService
         /// <summary>
         /// Process a given list of files in order for a specific instance, writing collected data to the DBADash repository database
         /// </summary>
-        private static async Task ProcessInstanceFilesAsync(List<string> files, DBADashSource source, CollectionConfig config, CancellationToken cancellationToken)
+        private static async Task ProcessInstanceFilesAsync(List<string> files, DBADashSource source, CollectionConfig config, ConcurrentDictionary<string, DateTime> lockedFilesFirstSeen, CancellationToken cancellationToken)
         {
             files.Sort(); // Ensure we process files in order
             foreach (var f in files)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (await ProcessFileAsync(f, source, config))
+                var result = await ProcessFileAsync(f, source, config, lockedFilesFirstSeen);
+                if (result == FileResult.Imported)
                 {
                     TryDeleteFile(f);
+                }
+                else if (result == FileResult.Retry)
+                {
+                    // The file still holds data to import.  Some collections discard a snapshot older than
+                    // the one they last imported, so the files behind it wait for the next iteration rather
+                    // than overtaking it.
+                    Log.Information("Stopping at {FileName}.  The files behind it are processed on the next iteration", Path.GetFileName(f));
+                    break;
                 }
             }
         }
 
         /// <summary>
-        /// Import a single file.  Returns true if the file has been dealt with and can be removed from the
-        /// source folder, or false if it should be left in place and retried on the next iteration.
-        /// A file that can't be imported is moved to the failed message folder rather than being left in
-        /// place - files are processed in order, so leaving it would block every file behind it for this
-        /// instance indefinitely.
+        /// What the caller does with a file after an import attempt.
         /// </summary>
-        private static async Task<bool> ProcessFileAsync(string f, DBADashSource source, CollectionConfig config, int tryCount = 1)
+        private enum FileResult
+        {
+            /// <summary>Imported.  The file can be deleted.</summary>
+            Imported,
+
+            /// <summary>Nothing more to do with it in this pass.  The file was quarantined, no longer exists, or is locked by something that isn't writing it.</summary>
+            Skip,
+
+            /// <summary>Not imported and still holding data to import.  Leave it and stop, so it keeps its place in the order.</summary>
+            Retry
+        }
+
+        /// <summary>
+        /// Import a single file.  A file that can't be imported is quarantined in the failed message folder
+        /// rather than left in place - files are imported in order, so leaving it would block every file
+        /// behind it for this instance indefinitely.
+        /// </summary>
+        private static async Task<FileResult> ProcessFileAsync(string f, DBADashSource source, CollectionConfig config, ConcurrentDictionary<string, DateTime> lockedFilesFirstSeen, int tryCount = 1)
         {
             const int MaxTryCount = 5;
             const int RetryDelay = 10;
@@ -97,28 +141,43 @@ namespace DBADashService
                 {
                     await DestinationHandling.WriteAllDestinationsAsync(ds, source, fileName, config);
                 }
-                return true;
+                lockedFilesFirstSeen.TryRemove(f, out _);
+                return FileResult.Imported;
             }
             catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) // Deleted after the folder was listed.  e.g. Another service importing from the same folder.
             {
                 Log.Information("File {FileName} no longer exists.  Skipping", fileName);
-                return false;
+                lockedFilesFirstSeen.TryRemove(f, out _);
+                return FileResult.Skip;
             }
             catch (IOException ex) when ((uint)ex.HResult == ERROR_SHARING_VIOLATION) // Another process has a lock on the file.  It might still be being written to.
             {
                 if (tryCount > MaxTryCount)
                 {
-                    Log.Warning("File {FileName} is in use.  Exceeded max wait/retry.  File will be processed on the next iteration", fileName);
-                    return false; // Leave the file in place.  It hasn't been imported.
+                    // Leave the file in place either way - it hasn't been imported.  While the lock is young
+                    // enough that the file is plausibly still being written, the files behind it wait for it
+                    // to keep them in order.  Past that the lock is something else and they're processed
+                    // without it.
+                    var firstSeenLocked = lockedFilesFirstSeen.GetOrAdd(f, _ => DateTime.UtcNow);
+                    if (firstSeenLocked > DateTime.UtcNow.Subtract(LockedFileWaitLimit))
+                    {
+                        Log.Warning("File {FileName} is in use.  Exceeded max wait/retry.  File will be processed on the next iteration", fileName);
+                        return FileResult.Retry;
+                    }
+                    Log.Warning("File {FileName} has been in use since {FirstSeenLocked} UTC.  Continuing with the files behind it", fileName, firstSeenLocked);
+                    return FileResult.Skip;
                 }
                 Log.Information("File {FileName} is in use.  Waiting for lock to release. Attempt {TryCount}/{MaxRetryCount}", fileName, tryCount, MaxTryCount);
                 await Task.Delay(RetryDelay);
-                return await ProcessFileAsync(f, source, config, tryCount + 1);
+                return await ProcessFileAsync(f, source, config, lockedFilesFirstSeen, tryCount + 1);
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error importing from {filename}.  File will be moved to {failedMessageFolder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
-                return TryMoveToFailedMessageFolder(f);
+                Log.Error(ex, "Error importing from {filename}.  File will be copied to {failedMessageFolder}", fileName, SchedulerServiceConfig.FailedMessageFolder);
+                // A quarantined file can never be imported, so the files behind it aren't overtaking anything
+                // by continuing.  One that's still in the source folder is imported again on the next
+                // iteration, so they wait for it instead.
+                return QuarantineFile(f, lockedFilesFirstSeen) ? FileResult.Skip : FileResult.Retry;
             }
         }
 
@@ -174,11 +233,12 @@ namespace DBADashService
         }
 
         /// <summary>
-        /// Move a file that couldn't be imported to the failed message folder so it doesn't block the files
-        /// queued behind it.  Files are removed from that folder after 7 days (SchedulerService.FolderCleanup).
-        /// Returns true if the file has been dealt with, false if it has to be left where it is.
+        /// Take a file that couldn't be imported out of the source folder so it doesn't block the files queued
+        /// behind it, keeping a copy in the failed message folder for 7 days (SchedulerService.FolderCleanup).
+        /// Returns false if the file is still in the source folder afterwards, as it's then imported again on
+        /// the next iteration and the files behind it can't be allowed to overtake it.
         /// </summary>
-        private static bool TryMoveToFailedMessageFolder(string filePath)
+        private static bool QuarantineFile(string filePath, ConcurrentDictionary<string, DateTime> lockedFilesFirstSeen)
         {
             var fileName = Path.GetFileName(filePath);
             try
@@ -188,13 +248,21 @@ namespace DBADashService
                     throw new Exception("Failed message folder is not available");
                 }
                 // Note: Path.GetFileName is required here.  filePath is rooted and Path.Combine returns a rooted
-                // second argument unchanged, which would make this a move of the file over itself.
-                File.Move(filePath, Path.Combine(SchedulerServiceConfig.FailedMessageFolder, fileName), true);
+                // second argument unchanged, which would make this a copy of the file over itself.
+                // Copy rather than move: the source folder is often a file share and the failed message folder
+                // is always local to the service, and File.Move has volume restrictions that a copy doesn't.
+                File.Copy(filePath, Path.Combine(SchedulerServiceConfig.FailedMessageFolder, fileName), true);
+                if (!TryDeleteFile(filePath))
+                {
+                    Log.Warning("{FileName} has been copied to the failed message folder but couldn't be removed from the source folder.  The import will be attempted again on the next iteration", fileName);
+                    return false;
+                }
+                lockedFilesFirstSeen.TryRemove(filePath, out _);
                 return true;
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error moving {FileName} to failed message folder {failedMessageFolder}.  The file will be left in place", fileName, SchedulerServiceConfig.FailedMessageFolder);
+                Log.Error(ex, "Error copying {FileName} to failed message folder {failedMessageFolder}.  The file will be left in place and retried", fileName, SchedulerServiceConfig.FailedMessageFolder);
                 return false;
             }
         }
@@ -210,7 +278,7 @@ namespace DBADashService
             {
                 var cutOff = DateTime.UtcNow.Subtract(StaleTempFileAge);
                 foreach (var f in files.Where(f => f.EndsWith(DestinationHandling.TempFileExtension)
-                                                   && File.GetLastWriteTimeUtc(f) < cutOff))
+                                                   && IsLastWrittenBefore(f, cutOff)))
                 {
                     Log.Warning("Deleting incomplete file {FileName}", Path.GetFileName(f));
                     TryDeleteFile(f);
@@ -222,16 +290,58 @@ namespace DBADashService
             }
         }
 
-        private static void TryDeleteFile(string filePath)
+        /// <summary>
+        /// Whether the file was last written before the cut off.  A file whose last write time can't be read
+        /// isn't treated as old - the caller deletes what's old, and deleting a file we know nothing about is
+        /// worse than leaving it.  Reading the timestamp doesn't throw, so one unreadable file doesn't stop
+        /// the rest from being cleaned up.
+        /// </summary>
+        private static bool IsLastWrittenBefore(string filePath, DateTime cutOffUtc)
         {
-            if (!File.Exists(filePath)) return;
             try
             {
-                File.Delete(filePath);
+                return File.GetLastWriteTimeUtc(filePath) < cutOffUtc;
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error deleting file");
+                Log.Warning(ex, "Error reading the last write time of {FileName}.  It won't be deleted", Path.GetFileName(filePath));
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Drop lock tracking for files that have left the source folder - imported by another service, or
+        /// removed by hand.  Tracking has to survive the passes that skip a locked file, so it can't be
+        /// cleared on the way past.
+        /// Pruned against the folder listing this pass is working from rather than by testing each tracked
+        /// path.  A folder that can't be listed doesn't get a pass at all, so a file that's only unreachable
+        /// isn't mistaken for one that's gone and given a fresh wait every time the folder drops out.
+        /// </summary>
+        private static void PruneLockTracking(ConcurrentDictionary<string, DateTime> lockedFilesFirstSeen, List<string> folderFiles)
+        {
+            if (lockedFilesFirstSeen.IsEmpty) return;
+            var present = folderFiles.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var f in lockedFilesFirstSeen.Keys.Where(f => !present.Contains(f)))
+            {
+                lockedFilesFirstSeen.TryRemove(f, out _);
+            }
+        }
+
+        /// <summary>
+        /// Delete a file.  Returns false if it's still there afterwards.
+        /// </summary>
+        private static bool TryDeleteFile(string filePath)
+        {
+            if (!File.Exists(filePath)) return true;
+            try
+            {
+                File.Delete(filePath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error deleting file {FileName}", Path.GetFileName(filePath));
+                return false;
             }
         }
     }

--- a/DBADashService/SchedulerService.cs
+++ b/DBADashService/SchedulerService.cs
@@ -1122,6 +1122,14 @@ namespace DBADashService
             }
         }
 
+        /// <summary>
+        /// Extensions removed from the failed message folder.  The temp extension is included because a
+        /// service killed part way through writing one of these files leaves a temp file behind that nothing
+        /// else removes - DirectoryWorkItem only sweeps folders that are configured as an import source, and
+        /// this folder never is.
+        /// </summary>
+        private static readonly string[] FailedMessageExtensions = { ".xml", ".json", ".bin", DestinationHandling.TempFileExtension };
+
         private static void FolderCleanup(object sender, ElapsedEventArgs e)
         {
             FolderCleanup();
@@ -1136,7 +1144,7 @@ namespace DBADashService
                     Log.Information("Maintenance: Failed Message Folder cleanup");
                     (from f in new DirectoryInfo(SchedulerServiceConfig.FailedMessageFolder).GetFiles()
                      where f.LastWriteTime < DateTime.Now.Subtract(TimeSpan.FromDays(7))
-                     && (f.Extension.Equals(".xml", StringComparison.CurrentCultureIgnoreCase) || f.Extension.Equals(".json", StringComparison.CurrentCultureIgnoreCase) || f.Extension.Equals(".bin", StringComparison.CurrentCultureIgnoreCase))
+                     && FailedMessageExtensions.Contains(f.Extension, StringComparer.CurrentCultureIgnoreCase)
                      && f.Name.StartsWith("dbadash", StringComparison.CurrentCultureIgnoreCase)
                      select f
                     ).ToList()


### PR DESCRIPTION
## Fix 1

Fix folder import stalling on a file that fails to import
A file that couldn't be imported was copied to the failed message folder using its own rooted path as the destination, so the copy threw instead of quarantining it. The throw happened inside the error handler, escaping it and aborting the loop for that instance before the file was deleted, so every later run stopped at the same file and nothing behind it was ever imported. Files are grouped by the instance parsed from the name and every agent's offline report shares one group, so a single bad file blocked offline reporting for every agent writing to the folder while other instances kept importing normally - the 400,000 file backlog in https://github.com/trimble-oss/dba-dash/issues/2042.

Writes to a folder destination now land under a temp extension and are renamed once complete, so a service killed mid-write leaves an inert temp file rather than truncated XML that could never be imported and would stall the folder the same way.

Details:
- Quarantine with the file name rather than the full path, and move rather than copy so the file leaves the folder even if the delete behind it fails.
- Importing a file reports whether it has been dealt with, and only then is it deleted. A file still locked after the retries is left for the next iteration instead of being deleted unprocessed, which lost the collection it held.
- Open files for read with FileMode.Open. OpenOrCreate turned a file deleted between listing and reading into an empty file that could never be parsed, which then stalled the folder. That case is now skipped.
- Delete temp files older than an hour when listing the folder, so an interrupted write can't accumulate either.
- Tests cover the write/rename, the overwrite, the temp name being excluded from the import filter, and the missing file behaviour.

## Fix 2

Report offline instances on change rather than every 10 seconds
Checks still run every 10 seconds, but a report is now written only when the set of open incidents changes, or when OfflineInstancesReportInterval seconds have elapsed since the last one. The interval defaults to 60 seconds. The repeat is what restores the state if a report is lost, so 0 (changes only) isn't recommended.

Alerting is unaffected - it keys off the incident being open, and both transitions are reported as they happen. LastFail and FailCount for an instance that's still offline now lag by up to the interval.

For S3/File destinations, this reduces the number of files written and potential backlog after an outage.  For SQL destinations this reduces the frequency of execution for a small reduction in overhead.  https://github.com/trimble-oss/dba-dash/issues/2042